### PR TITLE
Allow configurable path and URL for swagger-ui

### DIFF
--- a/connexion/__init__.py
+++ b/connexion/__init__.py
@@ -15,8 +15,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 
 from flask import abort, request, send_file, send_from_directory, render_template, render_template_string, url_for  # noqa
-from connexion.app import App  # noqa
-from connexion.api import Api  # noqa
-from connexion.problem import problem  # noqa
-from connexion.decorators.produces import NoContent  # noqa
+from .app import App  # noqa
+from .api import Api  # noqa
+from .problem import problem  # noqa
+from .decorators.produces import NoContent  # noqa
 import werkzeug.exceptions as exceptions  # noqa

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -18,8 +18,8 @@ import flask
 import jinja2
 import yaml
 
-from connexion.operation import Operation
-import connexion.utils as utils
+from .operation import Operation
+from . import utils as utils
 
 MODULE_PATH = pathlib.Path(__file__).absolute().parent
 SWAGGER_UI_PATH = MODULE_PATH / 'swagger-ui'

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -17,8 +17,8 @@ import pathlib
 import flask
 import werkzeug.exceptions
 
-from connexion.problem import problem
-import connexion.api
+from .problem import problem
+from .api import Api
 
 logger = logging.getLogger('connexion.app')
 
@@ -92,7 +92,7 @@ class App:
         arguments = arguments or dict()
         arguments = dict(self.arguments, **arguments)  # copy global arguments and update with api specfic
         yaml_path = self.specification_dir / swagger_file
-        api = connexion.api.Api(yaml_path, base_path, arguments, swagger_ui)
+        api = Api(yaml_path, base_path, arguments, swagger_ui)
         self.app.register_blueprint(api.blueprint)
 
     def add_error_handler(self, error_code, function):

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -25,7 +25,7 @@ logger = logging.getLogger('connexion.app')
 
 class App:
     def __init__(self, import_name, port=5000, specification_dir='', server=None, arguments=None, debug=False,
-                 swagger_ui=True):
+                 swagger_ui=True, swagger_path=None, swagger_url=None):
         """
         :param import_name: the name of the application package
         :type import_name: str
@@ -41,6 +41,10 @@ class App:
         :type debug: bool
         :param swagger_ui: whether to include swagger ui or not
         :type swagger_ui: bool
+        :param swagger_path: path to swagger-ui directory
+        :type swagger_path: string | None
+        :param swagger_url: URL to access swagger-ui documentation
+        :type swagger_url: string | None
         """
         self.app = flask.Flask(import_name)
 
@@ -65,6 +69,8 @@ class App:
         self.debug = debug
         self.arguments = arguments or {}
         self.swagger_ui = swagger_ui
+        self.swagger_path = swagger_path
+        self.swagger_url = swagger_url
 
     @staticmethod
     def common_error_handler(e):
@@ -75,7 +81,7 @@ class App:
             e = werkzeug.exceptions.InternalServerError()
         return problem(title=e.name, detail=e.description, status=e.code)
 
-    def add_api(self, swagger_file, base_path=None, arguments=None, swagger_ui=None):
+    def add_api(self, swagger_file, base_path=None, arguments=None, swagger_ui=None, swagger_path=None, swagger_url=None):
         """
         :param swagger_file: swagger file with the specification
         :type swagger_file: pathlib.Path
@@ -85,14 +91,21 @@ class App:
         :type arguments: dict | None
         :param swagger_ui: whether to include swagger ui or not
         :type swagger_ui: bool
+        :param swagger_path: path to swagger-ui directory
+        :type swagger_path: string | None
+        :param swagger_url: URL to access swagger-ui documentation
+        :type swagger_url: string | None
         """
         swagger_ui = swagger_ui if swagger_ui is not None else self.swagger_ui
+        swagger_path = swagger_path if swagger_path is not None else self.swagger_path
+        swagger_url = swagger_url if swagger_url is not None else self.swagger_url
         logger.debug('Adding API: %s', swagger_file)
         # TODO test if base_url starts with an / (if not none)
         arguments = arguments or dict()
         arguments = dict(self.arguments, **arguments)  # copy global arguments and update with api specfic
         yaml_path = self.specification_dir / swagger_file
-        api = Api(yaml_path, base_path, arguments, swagger_ui)
+        api = Api(yaml_path, base_path, arguments,
+                  swagger_ui, swagger_path, swagger_url)
         self.app.register_blueprint(api.blueprint)
 
     def add_error_handler(self, error_code, function):

--- a/connexion/decorators/security.py
+++ b/connexion/decorators/security.py
@@ -18,7 +18,7 @@ import functools
 import logging
 import requests
 
-from connexion.problem import problem
+from ..problem import problem
 
 logger = logging.getLogger('connexion.api.security')
 

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -20,8 +20,8 @@ import re
 import six
 import strict_rfc3339
 
-from connexion.problem import problem
-from connexion.utils import validate_date, boolean
+from ..problem import problem
+from ..utils import validate_date, boolean
 
 logger = logging.getLogger('connexion.decorators.validation')
 

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -14,11 +14,11 @@ Unless required by applicable law or agreed to in writing, software distributed 
 import functools
 import logging
 
-from connexion.decorators.produces import BaseSerializer, Produces, Jsonifier
-from connexion.decorators.security import security_passthrough, verify_oauth
-from connexion.decorators.validation import RequestBodyValidator, ParameterValidator
-from connexion.exceptions import InvalidSpecification
-from connexion.utils import flaskify_endpoint, get_function_from_name, produces_json
+from .decorators.produces import BaseSerializer, Produces, Jsonifier
+from .decorators.security import security_passthrough, verify_oauth
+from .decorators.validation import RequestBodyValidator, ParameterValidator
+from .exceptions import InvalidSpecification
+from .utils import flaskify_endpoint, get_function_from_name, produces_json
 
 logger = logging.getLogger('connexion.operation')
 
@@ -216,7 +216,7 @@ class Operation:
         logger.debug('... Security: %s', self.security, extra=vars(self))
         if self.security:
             if len(self.security) > 1:
-                logger.warning("... More than security requirement defined. **IGNORING SECURITY REQUIREMENTS**",
+                logger.warning("... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**",
                                extra=vars(self))
                 return security_passthrough
 
@@ -234,6 +234,9 @@ class Operation:
                 else:
                     logger.warning("... OAuth2 token info URL missing. **IGNORING SECURITY REQUIREMENTS**",
                                    extra=vars(self))
+            elif security_definition['type'] in ('apiKey','basic'):
+                logger.debug("... Security type '%s' not natively supported by Connexion; you should handle it yourself",
+                             security_definition['type'], extra=vars(self))
             else:
                 logger.warning("... Security type '%s' unknown. **IGNORING SECURITY REQUIREMENTS**",
                                security_definition['type'], extra=vars(self))

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -106,6 +106,15 @@ You can also disable it at api level:
     app = connexion.App(__name__, port = 8080, specification_dir='swagger/')
     app.add_api('my_api.yaml', swagger_ui=False)
 
+Likewise, you can configure the filesystem and URL paths to the Swagger UI
+documentation:
+
+.. code-block:: python
+
+    app = connexion.App(__name__, port = 8080, specification_dir='swagger/')
+    app.add_api('my_api.yaml', swagger_path='/path/to/swagger-ui', swagger_url='doc')
+
+
 
 Server Backend
 --------------


### PR DESCRIPTION
This PR modifies the App and API classes to allow the caller to specify a different directory for the swagger-ui files and/or a different URL path to access the API documentation.

Additionally, it does not emit a loud warning if the API spec specifies a security method other than oauth2. Instead, it warns the user (via a lower logging level) that she should handle the security herself (eg, through a custom decorator).
