### PR TITLE
Add validation for array types in query or path

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -111,7 +111,7 @@ def validate_array(schema, data):
                'pipes': '|',
                'multi': '&'}
     col_fmt = schema.get('collectionFormat', 'csv')
-    delimiter = col_map.get(col_fmt, 'csv')
+    delimiter = col_map.get(col_fmt)
     if not delimiter:
         logger.error("Unrecognized collectionFormat, cannot validate: %s", col_fmt)
         return

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -26,7 +26,6 @@ def test_validate_maximum():
 
 
 def test_parameter_validator(monkeypatch):
-
     request = MagicMock(name='request')
     request.headers = {}
     app = MagicMock(name='app')
@@ -38,7 +37,8 @@ def test_parameter_validator(monkeypatch):
         return 'OK'
 
     params = [{'name': 'p1', 'in': 'path', 'type': 'integer', 'required': True},
-              {'name': 'h1', 'in': 'header', 'type': 'string', 'enum': ['a', 'b']}]
+              {'name': 'h1', 'in': 'header', 'type': 'string', 'enum': ['a', 'b']},
+              {'name': 'a1', 'in': 'query', 'type': 'array', 'items': {'type': 'integer'}}]
     validator = ParameterValidator(params)
     handler = validator(orig_handler)
 
@@ -47,6 +47,12 @@ def test_parameter_validator(monkeypatch):
     assert handler(p1='') == "Wrong type, expected 'integer' for path parameter 'p1'"
     assert handler(p1='foo') == "Wrong type, expected 'integer' for path parameter 'p1'"
     assert handler(p1='1.2') == "Wrong type, expected 'integer' for path parameter 'p1'"
+
+    request.args = {'a1': '1,2'}
+    assert handler(p1=1) == "OK"
+    request.args = {'a1': '1,a'}
+    assert handler(p1=1) == "Wrong type, expected 'integer' for query parameter 'a1'"
+    del request.args['a1']
 
     request.headers = {'h1': 'a'}
     assert handler(p1='123') == 'OK'


### PR DESCRIPTION
This PR adds support for validating arrays that are present within the 'query' or 'path' inputs. Prior to this, arrays were only validated if they were present in the 'body' of a request.

A corresponding unit test was also added.