### PR TITLE
Serialization: Don't append 'Z' to datetime objects if they already have a timezone

### DIFF
--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -28,8 +28,13 @@ NoContent = object()
 class JSONEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, datetime.datetime):
-            # only supports UTC timestamps
-            return o.isoformat('T') + 'Z'
+            if o.tzinfo:
+                # eg: '2015-09-25T23:14:42.588601+00:00'
+                return o.isoformat('T')
+            else:
+                # No timezone present - assume UTC.
+                # eg: '2015-09-25T23:14:42.588601Z'
+                return o.isoformat('T') + 'Z'
 
         if isinstance(o, datetime.date):
             return o.isoformat()


### PR DESCRIPTION
When serializing responses to JSON, don't append 'Z' to datetime objects if they already have an associated timezone; otherwise, datetime strings can violate RFC 3339 (eg: '2015-09-25T23:14:42+00:00Z'). Note the extraneous 'Z' in the example.