### PR TITLE
Options Parameter for Werkzeug

### DIFF
--- a/connexion/app.py
+++ b/connexion/app.py
@@ -25,7 +25,7 @@ logger = logging.getLogger('connexion.app')
 
 class App:
     def __init__(self, import_name, port=5000, specification_dir='', server=None, arguments=None, debug=False,
-                 swagger_ui=True, swagger_path=None, swagger_url=None, **options):
+                 swagger_ui=True, swagger_path=None, swagger_url=None):
         """
         :param import_name: the name of the application package
         :type import_name: str
@@ -45,8 +45,6 @@ class App:
         :type swagger_path: string | None
         :param swagger_url: URL to access swagger-ui documentation
         :type swagger_url: string | None
-        :param options: options to be forwarded to the underlying Werkzeug server
-        :type options: dict
         """
         self.app = flask.Flask(import_name)
 
@@ -73,7 +71,6 @@ class App:
         self.swagger_ui = swagger_ui
         self.swagger_path = swagger_path
         self.swagger_url = swagger_url
-        self.options = options
 
     @staticmethod
     def common_error_handler(e):
@@ -184,11 +181,34 @@ class App:
         logger.debug('Adding %s with decorator', rule, extra=options)
         return self.app.route(rule, **options)
 
-    def run(self):  # pragma: no cover
+    def run(self, port=None, server=None, debug=None, **options):  # pragma: no cover
+        """
+        Runs the application on a local development server.
+
+        :param port: port to listen to
+        :type port: int
+        :param server: which wsgi server to use
+        :type server: str | None
+        :param debug: include debugging information
+        :type debug: bool
+        :param options: options to be forwarded to the underlying Werkzeug server
+        :type options: dict
+        """
         # this functions is not covered in unit tests because we would effectively testing the mocks
+
+        # overwrite constructor parameter
+        if port is not None:
+            self.port = port
+
+        if server is not None:
+            self.server = server
+
+        if debug is not None:
+            self.debug = debug
+
         logger.debug('Starting {} HTTP server..'.format(self.server), extra=vars(self))
         if self.server == 'flask':
-            self.app.run('0.0.0.0', port=self.port, debug=self.debug, **self.options)
+            self.app.run('0.0.0.0', port=self.port, debug=self.debug, **options)
         elif self.server == 'tornado':
             try:
                 import tornado.wsgi

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -25,7 +25,7 @@ logger = logging.getLogger('connexion.app')
 
 class App:
     def __init__(self, import_name, port=5000, specification_dir='', server=None, arguments=None, debug=False,
-                 swagger_ui=True, swagger_path=None, swagger_url=None):
+                 swagger_ui=True, swagger_path=None, swagger_url=None, **options):
         """
         :param import_name: the name of the application package
         :type import_name: str
@@ -45,6 +45,8 @@ class App:
         :type swagger_path: string | None
         :param swagger_url: URL to access swagger-ui documentation
         :type swagger_url: string | None
+        :param options: options to be forwarded to the underlying Werkzeug server
+        :type options: dict
         """
         self.app = flask.Flask(import_name)
 
@@ -71,6 +73,7 @@ class App:
         self.swagger_ui = swagger_ui
         self.swagger_path = swagger_path
         self.swagger_url = swagger_url
+        self.options = options
 
     @staticmethod
     def common_error_handler(e):
@@ -185,7 +188,7 @@ class App:
         # this functions is not covered in unit tests because we would effectively testing the mocks
         logger.debug('Starting {} HTTP server..'.format(self.server), extra=vars(self))
         if self.server == 'flask':
-            self.app.run('0.0.0.0', port=self.port, debug=self.debug)
+            self.app.run('0.0.0.0', port=self.port, debug=self.debug, **self.options)
         elif self.server == 'tornado':
             try:
                 import tornado.wsgi


### PR DESCRIPTION
### What?
The Flask app provides a `kwargs` argument called `options` to forwarded them to the underlying **Werkzeug** server. Currently **connexion** does not provide a way to forward parameter to Werkzeug, so I've implemented the parameter passing into the **connexion app**.

### Why?
We need this to disable the **reloader** in debug mode.

### Example

```python
app = connexion.App(
    __name__,
    port=8000,
    specification_dir='/swagger/',
    debug=True,
    # options kwargs
    use_reloader=False
)
```