### PR TITLE
Validating the developer's returned response against the specification

### DIFF
--- a/connexion/api.py
+++ b/connexion/api.py
@@ -32,7 +32,7 @@ class Api:
     """
 
     def __init__(self, swagger_yaml_path, base_url=None, arguments=None, swagger_ui=None, swagger_path=None,
-                 swagger_url=None):
+                 swagger_url=None, validate_responses=False):
         """
         :type swagger_yaml_path: pathlib.Path
         :type base_url: str | None
@@ -79,6 +79,9 @@ class Api:
         self.swagger_path = swagger_path or SWAGGER_UI_PATH
         self.swagger_url = swagger_url or SWAGGER_UI_URL
 
+        logger.debug('Validate Responses: %s', str(validate_responses))
+        self.validate_responses = validate_responses
+
         # Create blueprint and endpoints
         self.blueprint = self.create_blueprint()
 
@@ -107,7 +110,8 @@ class Api:
         operation = Operation(method=method, path=path, operation=swagger_operation,
                               app_produces=self.produces, app_security=self.security,
                               security_definitions=self.security_definitions, definitions=self.definitions,
-                              parameter_definitions=self.parameter_definitions)
+                              parameter_definitions=self.parameter_definitions,
+                              validate_responses=self.validate_responses)
         operation_id = operation.operation_id
         logger.debug('... Adding %s -> %s', method.upper(), operation_id, extra=vars(operation))
 

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -82,7 +82,7 @@ class App:
         return problem(title=exception.name, detail=exception.description, status=exception.code)
 
     def add_api(self, swagger_file, base_path=None, arguments=None, swagger_ui=None, swagger_path=None,
-                swagger_url=None):
+                swagger_url=None, validate_responses=False):
         """
         Adds an API to the application based on a swagger file
 
@@ -98,6 +98,8 @@ class App:
         :type swagger_path: string | None
         :param swagger_url: URL to access swagger-ui documentation
         :type swagger_url: string | None
+        :param validate_responses: True enables validation. Validation errors generate HTTP 500 responses.
+        :type validate_responses: bool
         :rtype: Api
         """
         swagger_ui = swagger_ui if swagger_ui is not None else self.swagger_ui
@@ -109,7 +111,7 @@ class App:
         arguments = dict(self.arguments, **arguments)  # copy global arguments and update with api specfic
         yaml_path = self.specification_dir / swagger_file
         api = Api(yaml_path, base_path, arguments,
-                  swagger_ui, swagger_path, swagger_url)
+                  swagger_ui, swagger_path, swagger_url, validate_responses)
         self.app.register_blueprint(api.blueprint)
         return api
 

--- a/connexion/decorators/decorator.py
+++ b/connexion/decorators/decorator.py
@@ -19,9 +19,7 @@ logger = logging.getLogger('connexion.decorators.decorator')
 class BaseDecorator:
 
     @staticmethod
-    def get_full_response(classname, data):
-        import datetime
-        logger.debug(classname + " get_full_response:" + str(datetime.datetime.now()))
+    def get_full_response(data):
         """
         Gets Data. Status Code and Headers for response.
         If only body data is returned by the endpoint function, then the status code will be set to 200 and no headers

--- a/connexion/decorators/decorator.py
+++ b/connexion/decorators/decorator.py
@@ -1,0 +1,61 @@
+"""
+Copyright 2015 Zalando SE
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ language governing permissions and limitations under the License.
+"""
+import logging
+import flask
+
+logger = logging.getLogger('connexion.decorators.decorator')
+
+
+class BaseDecorator:
+
+    @staticmethod
+    def get_full_response(classname, data):
+        import datetime
+        logger.debug(classname + " get_full_response:" + str(datetime.datetime.now()))
+        """
+        Gets Data. Status Code and Headers for response.
+        If only body data is returned by the endpoint function, then the status code will be set to 200 and no headers
+        will be added.
+        If the returned object is a flask.Response then it will just pass the information needed to recreate it.
+
+        :type data: flask.Response | (object, int) | (object, int, dict) | object
+        :rtype: (object, int, dict)
+        """
+        url = flask.request.url
+        logger.debug('Getting data and status code', extra={'data': data, 'data_type': type(data), 'url': url})
+        status_code, headers = 200, {}
+        if isinstance(data, flask.Response):
+            data = data
+            status_code = data.status_code
+            headers = data.headers
+        elif isinstance(data, tuple) and len(data) == 3:
+            data, status_code, headers = data
+        elif isinstance(data, tuple) and len(data) == 2:
+            data, status_code = data
+        logger.debug('Got data and status code (%d)', status_code, extra={'data': data,
+                                                                          'data_type': type(data),
+                                                                          'url': url})
+        return data, status_code, headers
+
+    def __call__(self, function):
+        """
+        :type function: types.FunctionType
+        :rtype: types.FunctionType
+        """
+        return function
+
+    def __repr__(self):
+        """
+        :rtype: str
+        """
+        return '<BaseDecorator: {}>'

--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -146,7 +146,7 @@ class BaseSerializer:
 
         if response_definition and response_definition.get("schema"):
             schema = self.operation.resolve_reference(response_definition.get("schema"))
-            data = self.get_as_type(response.get_data(), schema.get("type"), mimetype)
+            data = self.get_as_type(response.get_data(as_text=True), schema.get("type"), mimetype)
             v = RequestBodyValidator(schema)
             error = v.validate_schema(data, schema)
             if error:

--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -82,7 +82,7 @@ class Produces(BaseSerializer):
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
             url = flask.request.url
-            data, status_code, headers = self.get_full_response("Produces", function(*args, **kwargs))
+            data, status_code, headers = self.get_full_response(function(*args, **kwargs))
             logger.debug('Returning %s', url, extra={'url': url, 'mimetype': self.mimetype})
             if isinstance(data, flask.Response):  # if the function returns a Response object don't change it
                 logger.debug('Endpoint returned a Flask Response', extra={'url': url, 'mimetype': data.mimetype})
@@ -114,7 +114,7 @@ class Jsonifier(BaseSerializer):
         def wrapper(*args, **kwargs):
             url = flask.request.url
             logger.debug('Jsonifing %s', url, extra={'url': url, 'mimetype': self.mimetype})
-            data, status_code, headers = self.get_full_response("Jsonifier", function(*args, **kwargs))
+            data, status_code, headers = self.get_full_response(function(*args, **kwargs))
             if isinstance(data, flask.Response):  # if the function returns a Response object don't change it
                 logger.debug('Endpoint returned a Flask Response', extra={'url': url, 'mimetype': data.mimetype})
                 return data

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -1,0 +1,86 @@
+"""
+Copyright 2015 Zalando SE
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ language governing permissions and limitations under the License.
+"""
+
+# Decorators to change the return type of endpoints
+import datetime
+import flask
+import functools
+import json
+import ast
+import logging
+from ..exceptions import NonConformingResponse
+from ..problem import problem
+from .validation import RequestBodyValidator
+from .decorator import BaseDecorator
+
+
+logger = logging.getLogger('connexion.decorators.response')
+
+class ResponseValidator(BaseDecorator):
+    def __init__(self, operation={},  mimetype='text/plain'):
+        """
+        :type operation: Operation
+        :type mimetype: str
+        """
+        self.operation = operation
+        self.mimetype = mimetype
+
+    def validate_response(self, data, status_code, headers, mimetype):
+        """
+        Validates the Response object based on what has been declared in the specification.
+        Ensures the response body matches the declated schema.
+        :type data: dict
+        :type status_code: int
+        :type mimetype: str
+        :rtype bool | None
+        """
+        response_definitions = self.operation.operation.get("responses", {})
+        if not response_definitions:
+            return True
+        response_definition = response_definitions.get(status_code, {})
+        # TODO handle default response definitions
+
+        if response_definition and response_definition.get("schema"):
+            schema = self.operation.resolve_reference(response_definition.get("schema"))
+            v = RequestBodyValidator(schema)
+            error = v.validate_schema(data, schema)
+            if error:
+                raise NonConformingResponse("Response body does not conform to specification")
+
+        if response_definition and response_definition.get("headers"):
+            if not all(item in headers.keys() for item in response_definition.get("headers").keys()):
+                raise NonConformingResponse("Response headers do not conform to specification")
+        return True
+
+    def __call__(self, function):
+        """
+        :type function: types.FunctionType
+        :rtype: types.FunctionType
+        """
+        @functools.wraps(function)
+        def wrapper(*args, **kwargs):
+            result = function(*args, **kwargs)
+            try:
+                data, status_code, headers = self.get_full_response("Response", result)
+                self.validate_response(data, status_code, headers, self.mimetype)
+            except NonConformingResponse as e:
+                return problem(500, 'Internal Server Error', e.reason)
+            return result
+
+        return wrapper
+
+    def __repr__(self):
+        """
+        :rtype: str
+        """
+        return '<ResponseValidator>'

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -68,7 +68,7 @@ class ResponseValidator(BaseDecorator):
         def wrapper(*args, **kwargs):
             result = function(*args, **kwargs)
             try:
-                data, status_code, headers = self.get_full_response("Response", result)
+                data, status_code, headers = self.get_full_response(result)
                 self.validate_response(data, status_code, headers, self.mimetype)
             except NonConformingResponse as e:
                 return problem(500, 'Internal Server Error', e.reason)

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -12,11 +12,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 """
 
 # Decorators to change the return type of endpoints
-import datetime
-import flask
 import functools
-import json
-import ast
 import logging
 from ..exceptions import NonConformingResponse
 from ..problem import problem
@@ -25,6 +21,7 @@ from .decorator import BaseDecorator
 
 
 logger = logging.getLogger('connexion.decorators.response')
+
 
 class ResponseValidator(BaseDecorator):
     def __init__(self, operation={},  mimetype='text/plain'):

--- a/connexion/exceptions.py
+++ b/connexion/exceptions.py
@@ -29,3 +29,18 @@ class InvalidSpecification(ConnexionException):
 
     def __repr__(self):
         return '<InvalidSpecification: {}>'.format(self.reason)
+
+
+class NonConformingResponse(ConnexionException):
+    def __init__(self, reason='Unknown Reason'):
+        """
+        :param reason: Reason why the response did not conform to the specification
+        :type reason: str
+        """
+        self.reason = reason
+
+    def __str__(self):
+        return '<NonConformingResponse: {}>'.format(self.reason)
+
+    def __repr__(self):
+        return '<NonConformingResponse: {}>'.format(self.reason)

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -196,12 +196,12 @@ class Operation:
                 # if the endpoint as no 'produces' then the default is 'application/json'
                 mimetype = 'application/json'
             logger.debug('... Produces json', extra=vars(self))
-            jsonify = Jsonifier(mimetype)
+            jsonify = Jsonifier(mimetype, self)
             return jsonify
         elif len(self.produces) == 1:
             mimetype = self.produces[0]
             logger.debug('... Produces %s', mimetype, extra=vars(self))
-            decorator = Produces(mimetype)
+            decorator = Produces(mimetype, self)
             return decorator
         else:
             return BaseSerializer()

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -19,6 +19,7 @@ from .decorators.produces import BaseSerializer, Produces, Jsonifier
 from .decorators.security import security_passthrough, verify_oauth
 from .decorators.validation import RequestBodyValidator, ParameterValidator
 from .decorators.metrics import UWSGIMetricsCollector
+from.decorators.response import ResponseValidator
 from .exceptions import InvalidSpecification
 from .utils import flaskify_endpoint, get_function_from_name, produces_json
 
@@ -31,7 +32,7 @@ class Operation:
     """
 
     def __init__(self, method, path, operation, app_produces, app_security,
-                 security_definitions, definitions, parameter_definitions):
+                 security_definitions, definitions, parameter_definitions, validate_responses=False):
         """
         This class uses the OperationID identify the module and function that will handle the operation
 
@@ -58,6 +59,8 @@ class Operation:
         :param definitions: `Definitions Object
             <https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#definitionsObject>`_
         :type definitions: dict
+        :param validate_responses: True enables validation. Validation errors generate HTTP 500 responses.
+        :type validate_responses: bool
         """
 
         self.method = method
@@ -69,6 +72,7 @@ class Operation:
             'definitions': self.definitions,
             'parameters': self.parameter_definitions
         }
+        self.validate_responses = validate_responses
 
         self.operation = operation
         self.operation_id = operation['operationId']
@@ -102,6 +106,18 @@ class Operation:
                     definition_name=definition_name, method=self.method, path=self.path))
             del schema['$ref']
         return schema
+
+    def get_mimetype(self):
+        if produces_json(self.produces):  # endpoint will return json
+            try:
+                return self.produces[0]
+            except IndexError:
+                # if the endpoint as no 'produces' then the default is 'application/json'
+                return 'application/json'
+        elif len(self.produces) == 1:
+            return self.produces[0]
+        else:
+            return None
 
     def resolve_parameters(self, parameters):
         for param in parameters:
@@ -152,6 +168,12 @@ class Operation:
             parameters.append(param)
         function = parameter_to_arg(parameters, self.__undecorated_function)
 
+        if self.validate_responses:
+            logger.debug('... Response validation enabled.')
+            response_decorator = self.__response_validation_decorator
+            logger.debug('... Adding response decorator (%r)', response_decorator)
+            function = response_decorator(function)
+
         produces_decorator = self.__content_type_decorator
         logger.debug('... Adding produces decorator (%r)', produces_decorator, extra=vars(self))
         function = produces_decorator(function)
@@ -189,19 +211,14 @@ class Operation:
 
         logger.debug('... Produces: %s', self.produces, extra=vars(self))
 
+        mimetype = self.get_mimetype()
         if produces_json(self.produces):  # endpoint will return json
-            try:
-                mimetype = self.produces[0]
-            except IndexError:
-                # if the endpoint as no 'produces' then the default is 'application/json'
-                mimetype = 'application/json'
             logger.debug('... Produces json', extra=vars(self))
-            jsonify = Jsonifier(mimetype, self)
+            jsonify = Jsonifier(mimetype)
             return jsonify
         elif len(self.produces) == 1:
-            mimetype = self.produces[0]
             logger.debug('... Produces %s', mimetype, extra=vars(self))
-            decorator = Produces(mimetype, self)
+            decorator = Produces(mimetype)
             return decorator
         else:
             return BaseSerializer()
@@ -271,3 +288,11 @@ class Operation:
             yield ParameterValidator(self.parameters)
         if self.body_schema:
             yield RequestBodyValidator(self.body_schema)
+
+    @property
+    def __response_validation_decorator(self):
+        """
+        Get a decorator for validating the generated Response.
+        :rtype: types.FunctionType
+        """
+        return ResponseValidator(self, self.get_mimetype())

--- a/tests/fakeapi/api.yaml
+++ b/tests/fakeapi/api.yaml
@@ -194,7 +194,7 @@ paths:
         200:
           description: goodbye response
           schema:
-            type: string
+            $ref: '#/definitions/new_stack'
   /test_schema/response/object/{valid}:
     get:
       summary: Returns an image_version as an object
@@ -326,7 +326,8 @@ paths:
         200:
           description: goodbye response
           schema:
-            type: string
+            $ref: '#/definitions/new_stack'
+
   /test_schema_list:
     post:
       summary: Returns empty response
@@ -459,7 +460,7 @@ paths:
               type: string
               description: The URI of the created resource
           schema:
-            type: string
+            type: object
       parameters:
         - name: name
           in: path
@@ -479,7 +480,7 @@ paths:
               type: string
               description: The URI of the created resource
           schema:
-            type: string
+            type: object
   /goodevening/{name}:
     post:
       summary: Generate good evening

--- a/tests/fakeapi/api.yaml
+++ b/tests/fakeapi/api.yaml
@@ -27,7 +27,7 @@ paths:
         200:
           description: greeting response
           schema:
-            type: string
+            type: object
       parameters:
         - name: name
           in: path
@@ -45,7 +45,7 @@ paths:
         200:
           description: greeting response
           schema:
-            type: string
+            type: object
       parameters:
         - name: name
           in: path
@@ -112,7 +112,9 @@ paths:
         200:
           description: a greeting in a list
           schema:
-            type: string
+            type: array
+            items:
+              type: string
       parameters:
         - name: name
           in: path
@@ -193,6 +195,117 @@ paths:
           description: goodbye response
           schema:
             type: string
+  /test_schema/response/object/{valid}:
+    get:
+      summary: Returns an image_version as an object
+      description: Returns image_version
+      operationId: fakeapi.hello.schema_response_object
+      produces:
+        - application/json
+      parameters:
+        - name: valid
+          in: path
+          description: Whether to return a valid or invalid schema in the response body
+          required: true
+          type: string
+      responses:
+        200:
+          description: Requested new_stack data model
+          schema:
+            $ref: '#/definitions/new_stack'
+  /test_schema/response/string/{valid}:
+    get:
+      summary: Returns an image_version as a string
+      description: Returns image_version
+      operationId: fakeapi.hello.schema_response_string
+      produces:
+        - text/plain
+      parameters:
+        - name: valid
+          in: path
+          description: Whether to return a valid or invalid schema in the response body
+          required: true
+          type: string
+      responses:
+        200:
+          description: Requested new_stack data model
+          schema:
+            type: string
+  /test_schema/response/integer/{valid}:
+    get:
+      summary: Returns an image_version as an integer
+      description: Returns image_version
+      operationId: fakeapi.hello.schema_response_integer
+      produces:
+        - text/plain
+      parameters:
+        - name: valid
+          in: path
+          description: Whether to return a valid or invalid schema in the response body
+          required: true
+          type: string
+      responses:
+        200:
+          description: Requested new_stack data model
+          schema:
+            type: integer
+  /test_schema/response/number/{valid}:
+    get:
+      summary: Returns an image_version as a number(float)
+      description: Returns image_version
+      operationId: fakeapi.hello.schema_response_number
+      produces:
+        - text/plain
+      parameters:
+        - name: valid
+          in: path
+          description: Whether to return a valid or invalid schema in the response body
+          required: true
+          type: string
+      responses:
+        200:
+          description: Requested new_stack data model
+          schema:
+            type: number
+  /test_schema/response/boolean/{valid}:
+    get:
+      summary: Returns an image_version as a boolean
+      description: Returns image_version
+      operationId: fakeapi.hello.schema_response_boolean
+      produces:
+        - text/plain
+      parameters:
+        - name: valid
+          in: path
+          description: Whether to return a valid or invalid schema in the response body
+          required: true
+          type: string
+      responses:
+        200:
+          description: Requested new_stack data model
+          schema:
+            type: boolean
+  /test_schema/response/array/{valid}:
+    get:
+      summary: Returns an image_version as a boolean
+      description: Returns image_version
+      operationId: fakeapi.hello.schema_response_array
+      produces:
+        - application/json
+      parameters:
+        - name: valid
+          in: path
+          description: Whether to return a valid or invalid schema in the response body
+          required: true
+          type: string
+      responses:
+        200:
+          description: Requested new_stack data model          
+          schema:
+            type: array
+            items:
+              schema: 
+                $ref: '#/definitions/new_stack'
   /test_schema_in_query:
     post:
       summary: Returns the image_version
@@ -333,10 +446,18 @@ paths:
     post:
       summary: Generate good day greeting
       description: Generates a good day message.
+      headers:
+        Location:
+          type: string
+          description: The URI of the created resource
       operationId: fakeapi.hello.post_goodday
       responses:
         201:
           description: gooday response
+          headers:
+            Location:
+              type: string
+              description: The URI of the created resource
           schema:
             type: string
       parameters:
@@ -345,16 +466,38 @@ paths:
           description: Name of the person to greet.
           required: true
           type: string
+  /goodday/noheader:
+    post:
+      summary: Generate good day greeting
+      description: Generates a good day message.
+      operationId: fakeapi.hello.post_goodday_no_header
+      responses:
+        201:
+          description: gooday response
+          headers:
+            Location:
+              type: string
+              description: The URI of the created resource
+          schema:
+            type: string
   /goodevening/{name}:
     post:
       summary: Generate good evening
       description: Generates a good evening message.
+      headers:
+        Location:
+          type: string
+          description: The URI of the created resource
       operationId: fakeapi.hello.post_goodevening
       produces:
         - text/plain
       responses:
         201:
           description: goodevening response
+          headers:
+            Location:
+              type: string
+              description: The URI of the created resource
           schema:
             type: string
       parameters:

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -12,6 +12,9 @@ def post_goodday(name):
     headers = {"Location": "/my/uri"}
     return data, 201, headers
 
+def post_goodday_no_header():
+    return {'greeting': 'Hello.'}, 201
+
 def post_goodevening(name):
     data = 'Good evening {name}'.format(name=name)
     headers = {"Location": "/my/uri"}
@@ -67,6 +70,58 @@ def empty():
 
 def schema(new_stack):
     return new_stack
+
+
+def schema_response_object(valid):
+    if valid == "invalid_requirements":
+        return {"docker_version": 1.0}
+    elif valid == "invalid_type":
+        return {"image_version": 1.0}
+    else:
+        return {"image_version": "1.0"}  # valid
+
+
+def schema_response_string(valid):
+    if valid == "valid":
+        return "Image version 2.0"
+    else:
+        return 2.0
+
+
+def schema_response_integer(valid):
+    if valid == "valid":
+        return 3
+    else:
+        return 3.0
+
+
+def schema_response_number(valid):
+    if valid == "valid":
+        return 4.0
+    else:
+        return "Four"
+
+
+def schema_response_boolean(valid):
+    if valid == "valid":
+        return True
+    else:
+        return "yes"
+
+
+def schema_response_array(valid):
+    if valid == "invalid_dict":
+        return {
+            {"image_version": "1.0"}:
+            {"image_version": "2.0"}
+        }
+    elif valid == "invalid_string":
+        return "Not an array."
+    else:
+        return [
+            {"image_version": "1.0"},
+            {"image_version": "2.0"}
+        ]
 
 
 def schema_query(image_version=None):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -52,7 +52,7 @@ def oauth_requests(monkeypatch):
 @pytest.fixture
 def app():
     app = App(__name__, 5001, SPEC_FOLDER, debug=True)
-    app.add_api('api.yaml')
+    app.add_api('api.yaml', validate_responses=True)
     return app
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -193,6 +193,7 @@ def test_jsonifier(app):
     assert len(greetings_reponse) == 1
     assert greetings_reponse['greetings'] == 'Hello jsantos'
 
+
 def test_headers_jsonifier(app):
     app_client = app.app.test_client()
 
@@ -200,12 +201,27 @@ def test_headers_jsonifier(app):
     assert response.status_code == 201
     assert response.headers["Location"] == "http://localhost/my/uri"
 
+
 def test_headers_produces(app):
     app_client = app.app.test_client()
 
     response = app_client.post('/v1.0/goodevening/dan', data={})  # type: flask.Response
     assert response.status_code == 201
     assert response.headers["Location"] == "http://localhost/my/uri"
+
+
+def test_header_not_returned(app):
+    app_client = app.app.test_client()
+
+    response = app_client.post('/v1.0/goodday/noheader', data={})  # type: flask.Response
+    assert response.content_type == 'application/problem+json'
+    assert response.status_code == 500   # view_func has not returned what was promised in spec
+    data = json.loads(response.data.decode('utf-8'))
+    assert data['type'] == 'about:blank'
+    assert data['title'] == 'Internal Server Error'
+    assert data['detail'] == 'Response headers do not conform to specification'
+    assert data['status'] == 500
+
 
 def test_not_content_response(app):
     app_client = app.app.test_client()
@@ -305,6 +321,39 @@ def test_schema(app):
     wrong_type_response = json.loads(wrong_type.data.decode())  # type: dict
     assert wrong_type_response['title'] == 'Bad Request'
     assert wrong_type_response['detail'] == "Wrong type, expected 'object' got 'int'"
+
+
+def test_schema_response(app):
+    app_client = app.app.test_client()
+
+    request = app_client.get('/v1.0/test_schema/response/object/valid', headers={}, data=None)  # type: flask.Response
+    assert request.status_code == 200
+    request = app_client.get('/v1.0/test_schema/response/object/invalid_type', headers={}, data=None)  # type: flask.Response
+    assert request.status_code == 500
+    request = app_client.get('/v1.0/test_schema/response/object/invalid_requirements', headers={}, data=None)  # type: flask.Response
+    assert request.status_code == 500
+    request = app_client.get('/v1.0/test_schema/response/string/valid', headers={}, data=None)  # type: flask.Response
+    assert request.status_code == 200
+    request = app_client.get('/v1.0/test_schema/response/string/invalid', headers={}, data=None)  # type: flask.Response
+    assert request.status_code == 500
+    request = app_client.get('/v1.0/test_schema/response/integer/valid', headers={}, data=None)  # type: flask.Response
+    assert request.status_code == 200
+    request = app_client.get('/v1.0/test_schema/response/integer/invalid', headers={}, data=None)  # type: flask.Response
+    assert request.status_code == 500
+    request = app_client.get('/v1.0/test_schema/response/number/valid', headers={}, data=None)  # type: flask.Response
+    assert request.status_code == 200
+    request = app_client.get('/v1.0/test_schema/response/number/invalid', headers={}, data=None)  # type: flask.Response
+    assert request.status_code == 500
+    request = app_client.get('/v1.0/test_schema/response/boolean/valid', headers={}, data=None)  # type: flask.Response
+    assert request.status_code == 200
+    request = app_client.get('/v1.0/test_schema/response/boolean/invalid', headers={}, data=None)  # type: flask.Response
+    assert request.status_code == 500
+    request = app_client.get('/v1.0/test_schema/response/array/valid', headers={}, data=None)  # type: flask.Response
+    assert request.status_code == 200
+    request = app_client.get('/v1.0/test_schema/response/array/invalid_dict', headers={}, data=None)  # type: flask.Response
+    assert request.status_code == 500
+    request = app_client.get('/v1.0/test_schema/response/array/invalid_string', headers={}, data=None)  # type: flask.Response
+    assert request.status_code == 500
 
 
 def test_schema_in_query(app):


### PR DESCRIPTION
Hi guys,

I wonder if somebody might be willing to review this initial code? (Mentioned by me here: https://github.com/zalando/connexion/issues/76) The idea is to validate the headers and response body returned by the developer from the view func against what was declared in the Swagger specification. If the headers and response schema do not match then an error 500 is generated. I personally think this would be a useful part of the development process because Connexion would be checking to ensure that what is returned as a response actually matches what was promised.

A few notes that came up as I did this work:

1. I passed a reference to the Operation object into the Serializer so that I could access what I needed from the spec. I hope that's okay?
2. The test_app.py unit tests and app.yaml spec are getting quite long now. They might need re-factoring into multiple files? I'm happy to take a look at this if you think it would help.
3. At the moment all declared response headers in the Spec are being treated as required. I can't see a definitive description of the correct behaviour in the spec: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#headersObject. Any ideas/sources on this?
4. TODO: I still need to add actual validation of the header by type etc.
5. I'm not 100% sure on this - but now that I have started validating the schemas of response bodies I have had to alter the response types of some of the early tests. For example, the GET operation on "/greetings/{name}" looks to me like it should be object and not string. Dose this look correct to you?

Comments, feedback, amends etc welcomed :)

Dan