### PR TITLE
Fixed an issue with query parameters not properly handling arrays

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -36,12 +36,10 @@ def make_type(value, type):
 
 def get_val_from_param(value, query_param):
     if query_param["type"] == "array":  # then logic is more complex
-        if not query_param.get("collectionFormat") or query_param.get("collectionFormat") == "csv":  # default
-            parts = value.split(",")
-        elif query_param["collectionFormat"] == "pipes":  # pipe separated
+        if query_param.get("collectionFormat") and query_param.get("collectionFormat") == "pipes":
             parts = value.split("|")
-        else:  # not supported currently, return as original behaviour
-            return make_type(value, query_param["type"])
+        else:  # default: csv
+            parts = value.split(",")
         return [make_type(part, query_param["items"]["type"]) for part in parts]
     else:
         return make_type(value, query_param["type"])

--- a/tests/fakeapi/api.yaml
+++ b/tests/fakeapi/api.yaml
@@ -407,6 +407,30 @@ paths:
           in: query
           type: number
           required: true
+  /test_array_csv_query_param:
+    get:
+      operationId: fakeapi.hello.test_array_csv_query_param
+      parameters:
+        - name: items
+          in: query
+          description: An comma separated array of items
+          required: true
+          type: array
+          items:
+            type: string
+          collectionFormat: csv
+  /test_array_pipes_query_param:
+    get:
+      operationId: fakeapi.hello.test_array_pipes_query_param
+      parameters:
+        - name: items
+          in: query
+          description: An pipe separated array of items
+          required: true
+          type: array
+          items:
+            type: integer
+          collectionFormat: pipes
   /test_no_content_response:
     get:
       operationId: fakeapi.hello.test_no_content_response

--- a/tests/fakeapi/api.yaml
+++ b/tests/fakeapi/api.yaml
@@ -431,6 +431,18 @@ paths:
           items:
             type: integer
           collectionFormat: pipes
+  /test_array_unsupported_query_param:
+    get:
+      operationId: fakeapi.hello.test_array_unsupported_query_param
+      parameters:
+        - name: items
+          in: query
+          description: An pipe separated array of items
+          required: true
+          type: array
+          items:
+            type: string
+          collectionFormat: unsupported
   /test_no_content_response:
     get:
       operationId: fakeapi.hello.test_no_content_response

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -158,6 +158,10 @@ def test_array_pipes_query_param(items):
     return items
 
 
+def test_array_unsupported_query_param(items):
+    return items
+
+
 def test_no_content_response():
     return NoContent, 204
 

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -150,6 +150,14 @@ def test_required_query_param():
     return ''
 
 
+def test_array_csv_query_param(items):
+    return items
+
+
+def test_array_pipes_query_param(items):
+    return items
+
+
 def test_no_content_response():
     return NoContent, 204
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -477,12 +477,16 @@ def test_array_query_param(app):
     headers = {'Content-type': 'application/json'}
     url = '/v1.0/test_array_csv_query_param?items=one,two,three'
     response = app_client.get(url, headers=headers)
-    array_response = json.loads(response.data.decode())  # type: list
+    array_response = json.loads(response.data.decode())  # type: [str]
     assert array_response == ['one', 'two', 'three']
     url = '/v1.0/test_array_pipes_query_param?items=1|2|3'
     response = app_client.get(url, headers=headers)
-    array_response = json.loads(response.data.decode())  # type: list
+    array_response = json.loads(response.data.decode())  # type: [int]
     assert array_response == [1, 2, 3]
+    url = '/v1.0/test_array_unsupported_query_param?items=1;2;3'
+    response = app_client.get(url, headers=headers)
+    array_response = json.loads(response.data.decode())  # [str] unsupported collectionFormat
+    assert array_response == ["1;2;3"]
 
 
 def test_test_schema_array(app):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -472,6 +472,19 @@ def test_required_query_param(app):
     assert response.status_code == 200
 
 
+def test_array_query_param(app):
+    app_client = app.app.test_client()
+    headers = {'Content-type': 'application/json'}
+    url = '/v1.0/test_array_csv_query_param?items=one,two,three'
+    response = app_client.get(url, headers=headers)
+    array_response = json.loads(response.data.decode())  # type: list
+    assert array_response == ['one', 'two', 'three']
+    url = '/v1.0/test_array_pipes_query_param?items=1|2|3'
+    response = app_client.get(url, headers=headers)
+    array_response = json.loads(response.data.decode())  # type: list
+    assert array_response == [1, 2, 3]
+
+
 def test_test_schema_array(app):
     app_client = app.app.test_client()
     headers = {'Content-type': 'application/json'}


### PR DESCRIPTION
Hi,

I think I have hit a small issue this morning with query parameters passed as a "csv array". So my GET request would look something like this:

/v1.0/test_array_csv_query_param?items=one,two,three

And I was getting parameter items like this:

[u'o', u'n', u'e', u',', u't', u'w', u'o', u',', u't', u'h', u'r', u'e', u'e']

(A string cast to a list).

Please take a look at my suggested fix for this in this pull request. I have only supported the "csv" and "pipes" collectedFormat attributes from the swagger spec currently (http://swagger.io/specification/#parameterObject). Tabs and spaces don't make much sense to me as query parameters.

Let me know what you think guys. I've added a couple of tests that hopefully show the behaviour.
