### PR TITLE
Sensible defaults for controller resolution

### DIFF
--- a/connexion/__init__.py
+++ b/connexion/__init__.py
@@ -20,5 +20,6 @@ from .api import Api
 from .problem import problem
 from .decorators.produces import NoContent
 import werkzeug.exceptions as exceptions
+import resolver
 
 __version__ = '0.13'

--- a/connexion/__init__.py
+++ b/connexion/__init__.py
@@ -20,6 +20,6 @@ from .api import Api
 from .problem import problem
 from .decorators.produces import NoContent
 import werkzeug.exceptions as exceptions
-import resolver
+from .resolver import *
 
 __version__ = '0.13'

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -33,7 +33,8 @@ class Api:
     """
 
     def __init__(self, swagger_yaml_path, base_url=None, arguments=None, swagger_ui=None, swagger_path=None,
-                 swagger_url=None, validate_responses=False, resolver=utils.get_function_from_name):
+                 swagger_url=None, validate_responses=False, default_controller_name='',
+                 resolver=utils.get_function_from_name):
         """
         :type swagger_yaml_path: pathlib.Path
         :type base_url: str | None
@@ -76,6 +77,7 @@ class Api:
 
         self.definitions = self.specification.get('definitions', {})
         self.parameter_definitions = self.specification.get('parameters', {})
+        self.default_controller_name = default_controller_name
 
         self.swagger_path = swagger_path or SWAGGER_UI_PATH
         self.swagger_url = swagger_url or SWAGGER_UI_URL
@@ -111,9 +113,9 @@ class Api:
         :type swagger_operation: dict
         """
         operation = Operation(method=method, path=path, operation=swagger_operation,
-                              app_produces=self.produces, app_security=self.security,
-                              security_definitions=self.security_definitions, definitions=self.definitions,
-                              parameter_definitions=self.parameter_definitions,
+                              default_controller_name=self.default_controller_name, app_produces=self.produces,
+                              app_security=self.security, security_definitions=self.security_definitions,
+                              definitions=self.definitions, parameter_definitions=self.parameter_definitions,
                               validate_responses=self.validate_responses, resolver=self.resolver)
         operation_id = operation.operation_id
         logger.debug('... Adding %s -> %s', method.upper(), operation_id, extra=vars(operation))

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -19,6 +19,7 @@ import pathlib
 import yaml
 from .operation import Operation
 from . import utils
+from . import resolver
 
 MODULE_PATH = pathlib.Path(__file__).absolute().parent
 SWAGGER_UI_PATH = MODULE_PATH / 'vendor' / 'swagger-ui'
@@ -33,8 +34,7 @@ class Api:
     """
 
     def __init__(self, swagger_yaml_path, base_url=None, arguments=None, swagger_ui=None, swagger_path=None,
-                 swagger_url=None, validate_responses=False, default_module_name='',
-                 resolver=utils.get_function_from_name):
+                 swagger_url=None, validate_responses=False, resolver=resolver.Resolver()):
         """
         :type swagger_yaml_path: pathlib.Path
         :type base_url: str | None
@@ -77,7 +77,6 @@ class Api:
 
         self.definitions = self.specification.get('definitions', {})
         self.parameter_definitions = self.specification.get('parameters', {})
-        self.default_module_name = default_module_name
 
         self.swagger_path = swagger_path or SWAGGER_UI_PATH
         self.swagger_url = swagger_url or SWAGGER_UI_URL
@@ -112,8 +111,7 @@ class Api:
         :type path: str
         :type swagger_operation: dict
         """
-        operation = Operation(method=method, path=path, operation=swagger_operation,
-                              default_module_name=self.default_module_name, app_produces=self.produces,
+        operation = Operation(method=method, path=path, operation=swagger_operation, app_produces=self.produces,
                               app_security=self.security, security_definitions=self.security_definitions,
                               definitions=self.definitions, parameter_definitions=self.parameter_definitions,
                               validate_responses=self.validate_responses, resolver=self.resolver)

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -33,7 +33,7 @@ class Api:
     """
 
     def __init__(self, swagger_yaml_path, base_url=None, arguments=None, swagger_ui=None, swagger_path=None,
-                 swagger_url=None, validate_responses=False, default_controller_name='',
+                 swagger_url=None, validate_responses=False, default_module_name='',
                  resolver=utils.get_function_from_name):
         """
         :type swagger_yaml_path: pathlib.Path
@@ -77,7 +77,7 @@ class Api:
 
         self.definitions = self.specification.get('definitions', {})
         self.parameter_definitions = self.specification.get('parameters', {})
-        self.default_controller_name = default_controller_name
+        self.default_module_name = default_module_name
 
         self.swagger_path = swagger_path or SWAGGER_UI_PATH
         self.swagger_url = swagger_url or SWAGGER_UI_URL
@@ -113,7 +113,7 @@ class Api:
         :type swagger_operation: dict
         """
         operation = Operation(method=method, path=path, operation=swagger_operation,
-                              default_controller_name=self.default_controller_name, app_produces=self.produces,
+                              default_module_name=self.default_module_name, app_produces=self.produces,
                               app_security=self.security, security_definitions=self.security_definitions,
                               definitions=self.definitions, parameter_definitions=self.parameter_definitions,
                               validate_responses=self.validate_responses, resolver=self.resolver)

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -13,10 +13,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 import logging
 import pathlib
-
 import flask
 import werkzeug.exceptions
-
 from .problem import problem
 from .api import Api
 from .utils import get_function_from_name
@@ -26,7 +24,7 @@ logger = logging.getLogger('connexion.app')
 
 class App:
     def __init__(self, import_name, port=None, specification_dir='', server=None, arguments=None, debug=False,
-                 swagger_ui=True, swagger_path=None, swagger_url=None, default_controller_name=''):
+                 swagger_ui=True, swagger_path=None, swagger_url=None):
         """
         :param import_name: the name of the application package
         :type import_name: str
@@ -46,8 +44,6 @@ class App:
         :type swagger_path: string | None
         :param swagger_url: URL to access swagger-ui documentation
         :type swagger_url: string | None
-        :param default_controller_name: Default controller name for operations
-        :type default_controller_name: string | import_name
         """
         self.app = flask.Flask(import_name)
 
@@ -70,11 +66,11 @@ class App:
         self.port = port
         self.server = server or 'flask'
         self.debug = debug
+        self.import_name = import_name
         self.arguments = arguments or {}
         self.swagger_ui = swagger_ui
         self.swagger_path = swagger_path
         self.swagger_url = swagger_url
-        self.default_controller_name = default_controller_name or import_name
 
     @staticmethod
     def common_error_handler(exception):
@@ -86,7 +82,8 @@ class App:
         return problem(title=exception.name, detail=exception.description, status=exception.code)
 
     def add_api(self, swagger_file, base_path=None, arguments=None, swagger_ui=None, swagger_path=None,
-                swagger_url=None, validate_responses=False, resolver=get_function_from_name):
+                swagger_url=None, validate_responses=False, resolver=get_function_from_name,
+                default_module_name=''):
         """
         Adds an API to the application based on a swagger file
 
@@ -104,6 +101,8 @@ class App:
         :type swagger_url: string | None
         :param validate_responses: True enables validation. Validation errors generate HTTP 500 responses.
         :type validate_responses: bool
+        :param default_module_name: Default controller name for operations
+        :type default_module_name: string | import_name
         :rtype: Api
         """
         swagger_ui = swagger_ui if swagger_ui is not None else self.swagger_ui
@@ -120,6 +119,7 @@ class App:
                   swagger_path=swagger_path,
                   swagger_url=swagger_url,
                   resolver=resolver,
+                  default_module_name=default_module_name,
                   validate_responses=validate_responses)
         self.app.register_blueprint(api.blueprint)
         return api

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -100,7 +100,8 @@ class App:
         :type swagger_url: string | None
         :param validate_responses: True enables validation. Validation errors generate HTTP 500 responses.
         :type validate_responses: bool
-
+        :param resolver: Operation resolver.
+        :type resolver: Resolver | types.FunctionType
         :rtype: Api
         """
         resolver = Resolver(resolver) if hasattr(resolver, '__call__') else resolver

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -17,7 +17,7 @@ import flask
 import werkzeug.exceptions
 from .problem import problem
 from .api import Api
-from .utils import get_function_from_name
+from connexion.resolver import Resolver
 
 logger = logging.getLogger('connexion.app')
 
@@ -82,8 +82,7 @@ class App:
         return problem(title=exception.name, detail=exception.description, status=exception.code)
 
     def add_api(self, swagger_file, base_path=None, arguments=None, swagger_ui=None, swagger_path=None,
-                swagger_url=None, validate_responses=False, resolver=get_function_from_name,
-                default_module_name=''):
+                swagger_url=None, validate_responses=False, resolver=Resolver()):
         """
         Adds an API to the application based on a swagger file
 
@@ -101,8 +100,7 @@ class App:
         :type swagger_url: string | None
         :param validate_responses: True enables validation. Validation errors generate HTTP 500 responses.
         :type validate_responses: bool
-        :param default_module_name: Default controller name for operations
-        :type default_module_name: string | import_name
+
         :rtype: Api
         """
         swagger_ui = swagger_ui if swagger_ui is not None else self.swagger_ui
@@ -119,7 +117,6 @@ class App:
                   swagger_path=swagger_path,
                   swagger_url=swagger_url,
                   resolver=resolver,
-                  default_module_name=default_module_name,
                   validate_responses=validate_responses)
         self.app.register_blueprint(api.blueprint)
         return api

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -103,6 +103,8 @@ class App:
 
         :rtype: Api
         """
+        resolver = Resolver(resolver) if hasattr(resolver, '__call__') else resolver
+
         swagger_ui = swagger_ui if swagger_ui is not None else self.swagger_ui
         swagger_path = swagger_path if swagger_path is not None else self.swagger_path
         swagger_url = swagger_url if swagger_url is not None else self.swagger_url

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -26,7 +26,7 @@ logger = logging.getLogger('connexion.app')
 
 class App:
     def __init__(self, import_name, port=None, specification_dir='', server=None, arguments=None, debug=False,
-                 swagger_ui=True, swagger_path=None, swagger_url=None):
+                 swagger_ui=True, swagger_path=None, swagger_url=None, default_controller_name=''):
         """
         :param import_name: the name of the application package
         :type import_name: str
@@ -46,6 +46,8 @@ class App:
         :type swagger_path: string | None
         :param swagger_url: URL to access swagger-ui documentation
         :type swagger_url: string | None
+        :param default_controller_name: Default controller name for operations
+        :type default_controller_name: string | import_name
         """
         self.app = flask.Flask(import_name)
 
@@ -72,6 +74,7 @@ class App:
         self.swagger_ui = swagger_ui
         self.swagger_path = swagger_path
         self.swagger_url = swagger_url
+        self.default_controller_name = default_controller_name or import_name
 
     @staticmethod
     def common_error_handler(exception):

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -14,6 +14,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 import functools
 import logging
 import os
+import re
 from .decorators.parameter import parameter_to_arg
 from .decorators.produces import BaseSerializer, Produces, Jsonifier
 from .decorators.security import security_passthrough, verify_oauth
@@ -32,7 +33,7 @@ class Operation:
     """
 
     def __init__(self, method, path, operation, app_produces, app_security, security_definitions, definitions,
-                 parameter_definitions, resolver, default_controller_name='', validate_responses=False):
+                 parameter_definitions, resolver, default_module_name='', validate_responses=False):
         """
         This class uses the OperationID identify the module and function that will handle the operation
 
@@ -74,7 +75,7 @@ class Operation:
             'parameters': self.parameter_definitions
         }
         self.validate_responses = validate_responses
-        self.default_router_controller_name = default_controller_name
+        self.default_module_name = default_module_name
         self.operation = operation
 
         self.operation_id = self.detect_controller()
@@ -96,12 +97,24 @@ class Operation:
                 return x_router_controller + '.' + operation_id
             return operation_id
 
+        function = self.method.lower()
+
         if x_router_controller:
             mod_name = x_router_controller
         else:
-            mod_name = self.default_router_controller_name
+            if not self.default_module_name:
+                raise InvalidSpecification(
+                    "Neither operationId or x-swagger-router-controller was "
+                    + "configured and no default module set for Api"
+                )
 
-        return mod_name + '.' + self.method.lower()
+            mod_name = self.default_module_name
+            match = re.search('^/(.+?)(/.?|$)', self.path)
+            if match:
+                mod_name += '.' + match.group(1)
+                function = ('search' if function == 'get' and match.group(2).strip('/') == '' else function)
+
+        return mod_name + '.' + function
 
     def resolve_reference(self, schema):
         schema = schema.copy()  # avoid changing the original schema

--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -97,18 +97,20 @@ class RestyResolver(Resolver):
         if operation_id:
             return Resolver.resolve_operation_id(self, operation)
 
-        function = operation.method.lower()
         x_router_controller = spec.get('x-swagger-router-controller')
+
+        match = re.search('^/(.+?)(/.?|$)', operation.path)
+
+        mod_name = self.default_module_name
 
         if x_router_controller:
             mod_name = x_router_controller
-        else:
-            mod_name = self.default_module_name
-            match = re.search('^/(.+?)(/.?|$)', operation.path)
-            if match:
-                mod_name += '.' + match.group(1)
-                if function == 'get' and match.group(2).strip('/') == '':
-                    function = self.collection_endpoint_name
+        elif match:
+            mod_name += '.' + match.group(1)
+
+        function = operation.method.lower()
+        if function == 'get' and match and match.group(2).strip('/') == '':
+            function = self.collection_endpoint_name
 
         operation_id = mod_name + '.' + function
 

--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -31,9 +31,14 @@ class Resolution:
 
 
 class Resolver:
-    """
-    Standard resolver
-    """
+    def __init__(self, function_resolver=utils.get_function_from_name):
+        """
+        Standard resolver
+
+        :param function_resolver: Function that resolves functions using an operationId
+        :type function_resolver: function
+        """
+        self.function_resolver = function_resolver
 
     def resolve(self, operation):
         """
@@ -59,11 +64,11 @@ class Resolver:
 
     def resolve_function_from_operation_id(self, operation_id):
         """
-        Default function resolver, tries to get function by fully qualified name (e.g. "mymodule.myobj.myfunc")
+        Invokes the function_resolver
 
         :type operation_id: str
         """
-        return utils.get_function_from_name(operation_id)
+        return self.function_resolver(operation_id)
 
 
 class RestyResolver(Resolver):
@@ -76,6 +81,7 @@ class RestyResolver(Resolver):
         :param default_module_name: Default module name for operations
         :type default_module_name: string
         """
+        Resolver.__init__(self)
         self.default_module_name = default_module_name
         self.collection_endpoint_name = collection_endpoint_name
 

--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -1,0 +1,105 @@
+"""
+Copyright 2015 Zalando SE
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ language governing permissions and limitations under the License.
+"""
+
+import logging
+import re
+import connexion.utils as utils
+
+logger = logging.getLogger('connexion.resolver')
+
+
+class Resolution:
+    def __init__(self, function, operation_id):
+        """
+        Represents the result of operation resolution
+
+        :param function: The endpoint function
+        :type function: function
+        """
+        self.function = function
+        self.operation_id = operation_id
+
+
+class Resolver:
+    """
+    Standard resolver
+    """
+
+    def resolve(self, operation):
+        """
+        Default operation resolver
+
+        :type operation: Operation
+        """
+        operation_id = self.resolve_operation_id(operation)
+        return Resolution(self.resolve_function_from_operation_id(operation_id), operation_id)
+
+    def resolve_operation_id(self, operation):
+        """
+        Default operationId resolver
+
+        :type operation: Operation
+        """
+        spec = operation.operation
+        operation_id = spec.get('operationId')
+        x_router_controller = spec.get('x-swagger-router-controller')
+        if x_router_controller is None:
+            return operation_id
+        return x_router_controller + '.' + operation_id
+
+    def resolve_function_from_operation_id(self, operation_id):
+        """
+        Default function resolver, tries to get function by fully qualified name (e.g. "mymodule.myobj.myfunc")
+
+        :type operation_id: str
+        """
+        return utils.get_function_from_name(operation_id)
+
+
+class RestyResolver(Resolver):
+    """
+    Resolves endpoint functions using REST semantics (unless overridden by specifying operationId)
+    """
+
+    def __init__(self, default_module_name, collection_endpoint_name='search'):
+        """
+        :param default_module_name: Default module name for operations
+        :type default_module_name: string
+        """
+        self.default_module_name = default_module_name
+        self.collection_endpoint_name = collection_endpoint_name
+
+    def resolve_operation_id(self, operation):
+
+        spec = operation.operation
+        operation_id = spec.get('operationId')
+
+        if operation_id:
+            return Resolver.resolve_operation_id(self, operation)
+
+        function = operation.method.lower()
+        x_router_controller = spec.get('x-swagger-router-controller')
+
+        if x_router_controller:
+            mod_name = x_router_controller
+        else:
+            mod_name = self.default_module_name
+            match = re.search('^/(.+?)(/.?|$)', operation.path)
+            if match:
+                mod_name += '.' + match.group(1)
+                if function == 'get' and match.group(2).strip('/') == '':
+                    function = self.collection_endpoint_name
+
+        operation_id = mod_name + '.' + function
+
+        return operation_id

--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -24,7 +24,7 @@ class Resolution:
         Represents the result of operation resolution
 
         :param function: The endpoint function
-        :type function: function
+        :type function: types.FunctionType
         """
         self.function = function
         self.operation_id = operation_id
@@ -36,7 +36,7 @@ class Resolver:
         Standard resolver
 
         :param function_resolver: Function that resolves functions using an operationId
-        :type function_resolver: function
+        :type function_resolver: types.FunctionType
         """
         self.function_resolver = function_resolver
 
@@ -44,7 +44,7 @@ class Resolver:
         """
         Default operation resolver
 
-        :type operation: Operation
+        :type operation: connexion.operation.Operation
         """
         operation_id = self.resolve_operation_id(operation)
         return Resolution(self.resolve_function_from_operation_id(operation_id), operation_id)
@@ -53,7 +53,7 @@ class Resolver:
         """
         Default operationId resolver
 
-        :type operation: Operation
+        :type operation: connexion.operation.Operation
         """
         spec = operation.operation
         operation_id = spec.get('operationId')
@@ -79,14 +79,18 @@ class RestyResolver(Resolver):
     def __init__(self, default_module_name, collection_endpoint_name='search'):
         """
         :param default_module_name: Default module name for operations
-        :type default_module_name: string
+        :type default_module_name: str
         """
         Resolver.__init__(self)
         self.default_module_name = default_module_name
         self.collection_endpoint_name = collection_endpoint_name
 
     def resolve_operation_id(self, operation):
+        """
+        Resolves the operationId using REST semantics unless explicitly configured in the spec
 
+        :type operation: connexion.operation.Operation
+        """
         spec = operation.operation
         operation_id = spec.get('operationId')
 

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -56,13 +56,13 @@ def deep_getattr(obj, attr):
     return functools.reduce(getattr, attr.split('.'), obj)
 
 
-def get_function_from_name(operation_id):
+def get_function_from_name(function_name):
     """
-    Default operation resolver, tries to get function by fully qualified name (e.g. "mymodule.myobj.myfunc")
+    Tries to get function by fully qualified name (e.g. "mymodule.myobj.myfunc")
 
-    :type operation_id: str
+    :type function_name: str
     """
-    module_name, attr_path = operation_id.rsplit('.', 1)
+    module_name, attr_path = function_name.rsplit('.', 1)
     module = None
 
     while not module:

--- a/tests/fakeapi/__init__.py
+++ b/tests/fakeapi/__init__.py
@@ -1,0 +1,2 @@
+def get():
+    return ''

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -17,6 +17,12 @@ class_instance = DummyClass()
 def get():
     return ''
 
+def search():
+    return ''
+
+def post():
+    return ''
+
 def post_greeting(name):
     data = {'greeting': 'Hello {name}'.format(name=name)}
     return data

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -14,6 +14,8 @@ class DummyClass:
 
 class_instance = DummyClass()
 
+def get():
+    return ''
 
 def post_greeting(name):
     data = {'greeting': 'Hello {name}'.format(name=name)}

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -20,6 +20,9 @@ def get():
 def search():
     return ''
 
+def list():
+    return ''
+
 def post():
     return ''
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,4 @@
-
 import pathlib
-
 from connexion.api import Api
 
 TEST_FOLDER = pathlib.Path(__file__).parent

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -64,6 +64,11 @@ def test_app_with_relative_path():
     test_app(app)
 
 
+def test_default_controller_name_defaults_to_app_module(app):
+    app = App(__name__)
+    assert app.default_controller_name == 'test_app'
+
+
 def test_app(app):
     assert app.port == 5001
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -64,11 +64,6 @@ def test_app_with_relative_path():
     test_app(app)
 
 
-def test_default_controller_name_defaults_to_app_module(app):
-    app = App(__name__)
-    assert app.default_controller_name == 'test_app'
-
-
 def test_app(app):
     assert app.port == 5001
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -56,6 +56,12 @@ def app():
     return app
 
 
+def test_add_api_with_function_resolver_function_is_wrapped():
+    app = App(__name__, specification_dir=SPEC_FOLDER)
+    api = app.add_api('api.yaml', resolver=lambda oid: (lambda foo: 'bar'))
+    assert api.resolver.resolve_function_from_operation_id('faux')('bah') == 'bar'
+
+
 def test_app_with_relative_path():
     # Create the app with a realative path and run the test_app testcase below.
     app = App(__name__, 5001, SPEC_FOLDER.relative_to(TEST_FOLDER),

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -276,6 +276,25 @@ def test_controller_resolution_with_x_controller_router():
     assert operation.operation_id == 'fakeapi.hello.get'
 
 
+def test_controller_resolution_without_default_module_name_will_fail():
+    with pytest.raises(InvalidSpecification) as exc_info:  # type: py.code.ExceptionInfo
+        Operation(method='GET',
+                  path='/hello',
+                  operation={},
+                  app_produces=['application/json'],
+                  app_security=[],
+                  security_definitions={},
+                  definitions={},
+                  parameter_definitions=PARAMETER_DEFINITIONS,
+                  resolver=get_function_from_name)
+
+    exception = exc_info.value
+    assert str(exception) == "<InvalidSpecification: Neither operationId or x-swagger-router-controller was " \
+                             + "configured and no default module set for Api>"
+    assert repr(exception) == "<InvalidSpecification: Neither operationId or x-swagger-router-controller was " \
+                              + "configured and no default module set for Api>"
+
+
 def test_controller_resolution_with_default_module_name():
     operation = Operation(method='GET',
                           path='/hello/{id}',

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -122,6 +122,8 @@ OPERATION6 = {'description': 'Adds a new stack to be created by lizzy and return
               'security': [{'oauth': ['uid']}],
               'summary': 'Create new stack'}
 
+OPERATION7 = {'x-swagger-router-controller': 'fakeapi.hello'}
+
 SECURITY_DEFINITIONS = {'oauth': {'type': 'oauth2',
                                   'flow': 'password',
                                   'x-tokenInfoUrl': 'https://ouath.example/token_info',
@@ -249,6 +251,7 @@ def test_resolve_invalid_reference():
     exception = exc_info.value  # type: InvalidSpecification
     assert exception.reason == "GET endpoint  '$ref' needs to start with '#/'"
 
+
 def test_detect_controller():
     operation = Operation(method='GET',
                           path='endpoint',
@@ -260,3 +263,30 @@ def test_detect_controller():
                           parameter_definitions=PARAMETER_DEFINITIONS,
                           resolver=get_function_from_name)
     assert operation.operation_id == 'fakeapi.hello.post_greeting'
+
+
+def test_controller_resolution_with_x_controller_router():
+    operation = Operation(method='GET',
+                          path='endpoint',
+                          operation=OPERATION7,
+                          app_produces=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=get_function_from_name)
+    assert operation.operation_id == 'fakeapi.hello.get'
+
+
+def test_controller_resolution_with_default_controller_name():
+    operation = Operation(method='GET',
+                          path='endpoint',
+                          operation={},
+                          default_controller_name='fakeapi.hello',
+                          app_produces=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=get_function_from_name)
+    assert operation.operation_id == 'fakeapi.hello.get'

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -4,7 +4,7 @@ import types
 from connexion.exceptions import InvalidSpecification
 from connexion.operation import Operation
 from connexion.decorators.security import security_passthrough, verify_oauth
-from connexion.utils import get_function_from_name
+from connexion.resolver import Resolver
 
 TEST_FOLDER = pathlib.Path(__file__).parent
 
@@ -99,29 +99,6 @@ OPERATION4 = {'operationId': 'fakeapi.hello.post_greeting',
 OPERATION5 = {'operationId': 'fakeapi.hello.post_greeting',
               'parameters': [{'$ref': '/parameters/fail'}]}
 
-OPERATION6 = {'description': 'Adds a new stack to be created by lizzy and returns the '
-                             'information needed to keep track of deployment',
-              'operationId': 'post_greeting',
-              'x-swagger-router-controller': 'fakeapi.hello',
-              'parameters': [{'in': 'body',
-                              'name': 'new_stack',
-                              'required': True,
-                              'schema': {'$ref': '#/definitions/new_stack'}}],
-              'responses': {201: {'description': 'Stack to be created. The '
-                                                 'CloudFormation Stack creation can '
-                                                 "still fail if it's rejected by senza "
-                                                 'or AWS CF.',
-                                  'schema': {'$ref': '#/definitions/stack'}},
-                            400: {'description': 'Stack was not created because request '
-                                                 'was invalid',
-                                  'schema': {'$ref': '#/definitions/problem'}},
-                            401: {'description': 'Stack was not created because the '
-                                                 'access token was not provided or was '
-                                                 'not valid for this operation',
-                                  'schema': {'$ref': '#/definitions/problem'}}},
-              'security': [{'oauth': ['uid']}],
-              'summary': 'Create new stack'}
-
 SECURITY_DEFINITIONS = {'oauth': {'type': 'oauth2',
                                   'flow': 'password',
                                   'x-tokenInfoUrl': 'https://ouath.example/token_info',
@@ -141,7 +118,7 @@ def test_operation():
                           security_definitions=SECURITY_DEFINITIONS,
                           definitions=DEFINITIONS,
                           parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=get_function_from_name)
+                          resolver=Resolver())
     assert isinstance(operation.function, types.FunctionType)
     # security decorator should be a partial with verify_oauth as the function and token url and scopes as arguments.
     # See https://docs.python.org/2/library/functools.html#partial-objects
@@ -163,7 +140,7 @@ def test_non_existent_reference():
                           security_definitions={},
                           definitions={},
                           parameter_definitions={},
-                          resolver=get_function_from_name)
+                          resolver=Resolver())
     with pytest.raises(InvalidSpecification) as exc_info:  # type: py.code.ExceptionInfo
         schema = operation.body_schema
 
@@ -181,7 +158,7 @@ def test_multi_body():
                           security_definitions={},
                           definitions=DEFINITIONS,
                           parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=get_function_from_name)
+                          resolver=Resolver())
     with pytest.raises(InvalidSpecification) as exc_info:  # type: py.code.ExceptionInfo
         schema = operation.body_schema
 
@@ -199,7 +176,7 @@ def test_invalid_reference():
                           security_definitions={},
                           definitions=DEFINITIONS,
                           parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=get_function_from_name)
+                          resolver=Resolver())
     with pytest.raises(InvalidSpecification) as exc_info:  # type: py.code.ExceptionInfo
         schema = operation.body_schema
 
@@ -217,7 +194,7 @@ def test_no_token_info():
                           security_definitions=SECURITY_DEFINITIONS_WO_INFO,
                           definitions=DEFINITIONS,
                           parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=get_function_from_name)
+                          resolver=Resolver())
     assert isinstance(operation.function, types.FunctionType)
     assert operation._Operation__security_decorator is security_passthrough
 
@@ -236,7 +213,7 @@ def test_parameter_reference():
                           security_definitions={},
                           definitions={},
                           parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=get_function_from_name)
+                          resolver=Resolver())
     assert operation.parameters == [{'in': 'path', 'type': 'integer'}]
 
 
@@ -244,108 +221,9 @@ def test_resolve_invalid_reference():
     with pytest.raises(InvalidSpecification) as exc_info:
         Operation(method='GET', path='endpoint', operation=OPERATION5, app_produces=['application/json'],
                   app_security=[], security_definitions={}, definitions={}, parameter_definitions=PARAMETER_DEFINITIONS,
-                  resolver=get_function_from_name)
+                  resolver=Resolver())
 
     exception = exc_info.value  # type: InvalidSpecification
     assert exception.reason == "GET endpoint  '$ref' needs to start with '#/'"
 
 
-def test_detect_controller():
-    operation = Operation(method='GET',
-                          path='endpoint',
-                          operation=OPERATION6,
-                          app_produces=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=get_function_from_name)
-    assert operation.operation_id == 'fakeapi.hello.post_greeting'
-
-
-def test_controller_resolution_with_x_controller_router():
-    operation = Operation(method='GET',
-                          path='endpoint',
-                          operation={'x-swagger-router-controller': 'fakeapi.hello'},
-                          app_produces=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=get_function_from_name)
-    assert operation.operation_id == 'fakeapi.hello.get'
-
-
-def test_controller_resolution_without_default_module_name_will_fail():
-    with pytest.raises(InvalidSpecification) as exc_info:  # type: py.code.ExceptionInfo
-        Operation(method='GET',
-                  path='/hello',
-                  operation={},
-                  app_produces=['application/json'],
-                  app_security=[],
-                  security_definitions={},
-                  definitions={},
-                  parameter_definitions=PARAMETER_DEFINITIONS,
-                  resolver=get_function_from_name)
-
-    exception = exc_info.value
-    assert str(exception) == "<InvalidSpecification: Neither operationId or x-swagger-router-controller was " \
-                             + "configured and no default module set for Api>"
-    assert repr(exception) == "<InvalidSpecification: Neither operationId or x-swagger-router-controller was " \
-                              + "configured and no default module set for Api>"
-
-
-def test_controller_resolution_with_default_module_name():
-    operation = Operation(method='GET',
-                          path='/hello/{id}',
-                          operation={},
-                          default_module_name='fakeapi',
-                          app_produces=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=get_function_from_name)
-    assert operation.operation_id == 'fakeapi.hello.get'
-
-
-def test_controller_resolution_with_default_module_name_can_resolve_api_root():
-    operation = Operation(method='GET',
-                          path='/',
-                          operation={},
-                          default_module_name='fakeapi',
-                          app_produces=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=get_function_from_name)
-    assert operation.operation_id == 'fakeapi.get'
-
-
-def test_controller_resolution_with_default_module_name_will_resolve_resource_root_get_as_search():
-    operation = Operation(method='GET',
-                          path='/hello',
-                          operation={},
-                          default_module_name='fakeapi',
-                          app_produces=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=get_function_from_name)
-    assert operation.operation_id == 'fakeapi.hello.search'
-
-
-def test_controller_resolution_with_default_module_name_will_resolve_resource_root_post_as_post():
-    operation = Operation(method='POST',
-                          path='/hello',
-                          operation={},
-                          default_module_name='fakeapi',
-                          app_produces=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=get_function_from_name)
-    assert operation.operation_id == 'fakeapi.hello.post'

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -122,8 +122,6 @@ OPERATION6 = {'description': 'Adds a new stack to be created by lizzy and return
               'security': [{'oauth': ['uid']}],
               'summary': 'Create new stack'}
 
-OPERATION7 = {'x-swagger-router-controller': 'fakeapi.hello'}
-
 SECURITY_DEFINITIONS = {'oauth': {'type': 'oauth2',
                                   'flow': 'password',
                                   'x-tokenInfoUrl': 'https://ouath.example/token_info',
@@ -268,7 +266,7 @@ def test_detect_controller():
 def test_controller_resolution_with_x_controller_router():
     operation = Operation(method='GET',
                           path='endpoint',
-                          operation=OPERATION7,
+                          operation={'x-swagger-router-controller': 'fakeapi.hello'},
                           app_produces=['application/json'],
                           app_security=[],
                           security_definitions={},
@@ -278,11 +276,11 @@ def test_controller_resolution_with_x_controller_router():
     assert operation.operation_id == 'fakeapi.hello.get'
 
 
-def test_controller_resolution_with_default_controller_name():
+def test_controller_resolution_with_default_module_name():
     operation = Operation(method='GET',
-                          path='endpoint',
+                          path='/hello/{id}',
                           operation={},
-                          default_controller_name='fakeapi.hello',
+                          default_module_name='fakeapi',
                           app_produces=['application/json'],
                           app_security=[],
                           security_definitions={},
@@ -290,3 +288,45 @@ def test_controller_resolution_with_default_controller_name():
                           parameter_definitions=PARAMETER_DEFINITIONS,
                           resolver=get_function_from_name)
     assert operation.operation_id == 'fakeapi.hello.get'
+
+
+def test_controller_resolution_with_default_module_name_can_resolve_api_root():
+    operation = Operation(method='GET',
+                          path='/',
+                          operation={},
+                          default_module_name='fakeapi',
+                          app_produces=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=get_function_from_name)
+    assert operation.operation_id == 'fakeapi.get'
+
+
+def test_controller_resolution_with_default_module_name_will_resolve_resource_root_get_as_search():
+    operation = Operation(method='GET',
+                          path='/hello',
+                          operation={},
+                          default_module_name='fakeapi',
+                          app_produces=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=get_function_from_name)
+    assert operation.operation_id == 'fakeapi.hello.search'
+
+
+def test_controller_resolution_with_default_module_name_will_resolve_resource_root_post_as_post():
+    operation = Operation(method='POST',
+                          path='/hello',
+                          operation={},
+                          default_module_name='fakeapi',
+                          app_produces=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=get_function_from_name)
+    assert operation.operation_id == 'fakeapi.hello.post'

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -116,6 +116,21 @@ def test_resty_resolve_with_default_module_name_will_resolve_resource_root_get_a
     assert operation.operation_id == 'fakeapi.hello.search'
 
 
+def test_resty_resolve_with_default_module_name_and_x_router_controller_will_resolve_resource_root_get_as_search():
+    operation = Operation(method='GET',
+                          path='/hello',
+                          operation={
+                              'x-swagger-router-controller': 'fakeapi.hello',
+                          },
+                          app_produces=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=RestyResolver('fakeapi'))
+    assert operation.operation_id == 'fakeapi.hello.search'
+
+
 def test_resty_resolve_with_default_module_name_will_resolve_resource_root_as_configured():
     operation = Operation(method='GET',
                           path='/hello',

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,142 @@
+import pytest
+import connexion.app
+from connexion.resolver import Resolver
+from connexion.resolver import RestyResolver
+from connexion.operation import Operation
+
+PARAMETER_DEFINITIONS = {'myparam': {'in': 'path', 'type': 'integer'}}
+
+
+def test_standard_get_function():
+    function = Resolver().resolve_function_from_operation_id('connexion.app.App.common_error_handler')
+    assert function == connexion.app.App.common_error_handler
+
+
+def test_resty_get_function():
+    function = RestyResolver('connexion').resolve_function_from_operation_id('connexion.app.App.common_error_handler')
+    assert function == connexion.app.App.common_error_handler
+
+
+def test_standard_resolve_x_router_controller():
+    operation = Operation(method='GET',
+                          path='endpoint',
+                          operation={
+                              'x-swagger-router-controller': 'fakeapi.hello',
+                              'operationId': 'post_greeting',
+                          },
+                          app_produces=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=Resolver())
+    assert operation.operation_id == 'fakeapi.hello.post_greeting'
+
+
+def test_resty_resolve_operation_id():
+    operation = Operation(method='GET',
+                          path='endpoint',
+                          operation={
+                              'operationId': 'fakeapi.hello.post_greeting',
+                          },
+                          app_produces=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=RestyResolver('fakeapi'))
+    assert operation.operation_id == 'fakeapi.hello.post_greeting'
+
+
+def test_resty_resolve_x_router_controller_with_operation_id():
+    operation = Operation(method='GET',
+                          path='endpoint',
+                          operation={
+                              'x-swagger-router-controller': 'fakeapi.hello',
+                              'operationId': 'post_greeting',
+                          },
+                          app_produces=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=RestyResolver('fakeapi'))
+    assert operation.operation_id == 'fakeapi.hello.post_greeting'
+
+
+def test_resty_resolve_x_router_controller_without_operation_id():
+    operation = Operation(method='GET',
+                          path='endpoint',
+                          operation={'x-swagger-router-controller': 'fakeapi.hello'},
+                          app_produces=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=RestyResolver('fakeapi'))
+    assert operation.operation_id == 'fakeapi.hello.get'
+
+
+def test_resty_resolve_with_default_module_name():
+    operation = Operation(method='GET',
+                          path='/hello/{id}',
+                          operation={},
+                          app_produces=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=RestyResolver('fakeapi'))
+    assert operation.operation_id == 'fakeapi.hello.get'
+
+
+def test_resty_resolve_with_default_module_name_can_resolve_api_root():
+    operation = Operation(method='GET',
+                          path='/',
+                          operation={},
+                          app_produces=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=RestyResolver('fakeapi'))
+    assert operation.operation_id == 'fakeapi.get'
+
+
+def test_resty_resolve_with_default_module_name_will_resolve_resource_root_get_as_search():
+    operation = Operation(method='GET',
+                          path='/hello',
+                          operation={},
+                          app_produces=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=RestyResolver('fakeapi'))
+    assert operation.operation_id == 'fakeapi.hello.search'
+
+
+def test_resty_resolve_with_default_module_name_will_resolve_resource_root_as_configured():
+    operation = Operation(method='GET',
+                          path='/hello',
+                          operation={},
+                          app_produces=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=RestyResolver('fakeapi', 'list'))
+    assert operation.operation_id == 'fakeapi.hello.list'
+
+
+def test_resty_resolve_with_default_module_name_will_resolve_resource_root_post_as_post():
+    operation = Operation(method='POST',
+                          path='/hello',
+                          operation={},
+                          app_produces=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=RestyResolver('fakeapi'))
+    assert operation.operation_id == 'fakeapi.hello.post'

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -66,7 +66,7 @@ def test_resty_resolve_x_router_controller_with_operation_id():
 
 def test_resty_resolve_x_router_controller_without_operation_id():
     operation = Operation(method='GET',
-                          path='endpoint',
+                          path='/hello/{id}',
                           operation={'x-swagger-router-controller': 'fakeapi.hello'},
                           app_produces=['application/json'],
                           app_security=[],


### PR DESCRIPTION
Adds a `default_controller_name` and uses HTTP method name in absence of `operationId`. See #98 