### PR TITLE
Handle dashes in resource names in RestyResolver

### DIFF
--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -103,19 +103,21 @@ class RestyResolver(Resolver):
         :type operation: connexion.operation.Operation
         """
         path_match = re.search(
-            '^/?(?P<resource_name>(\w(?<!/))*)(?P<trailing_slash>/*)(?P<extended_path>.*)$', operation.path
+            '^/?(?P<resource_name>([\w\-](?<!/))*)(?P<trailing_slash>/*)(?P<extended_path>.*)$', operation.path
         )
 
         def get_controller_name():
             x_router_controller = operation.operation.get('x-swagger-router-controller')
 
             name = self.default_module_name
+            resource_name = path_match.group('resource_name')
 
             if x_router_controller:
                 name = x_router_controller
 
-            elif path_match.group('resource_name'):
-                name += '.' + path_match.group('resource_name')
+            elif resource_name:
+                resource_controller_name = resource_name.replace('-', '_')
+                name += '.' + resource_controller_name
 
             return name
 

--- a/tests/fakeapi/foo_bar.py
+++ b/tests/fakeapi/foo_bar.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+
+def search():
+    return ''

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -90,6 +90,19 @@ def test_resty_resolve_with_default_module_name():
     assert operation.operation_id == 'fakeapi.hello.get'
 
 
+def test_resty_resolve_with_default_module_name_will_translate_dashes_in_resource_name():
+    operation = Operation(method='GET',
+                          path='/foo-bar',
+                          operation={},
+                          app_produces=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=RestyResolver('fakeapi'))
+    assert operation.operation_id == 'fakeapi.foo_bar.search'
+
+
 def test_resty_resolve_with_default_module_name_can_resolve_api_root():
     operation = Operation(method='GET',
                           path='/',


### PR DESCRIPTION
Minor improvement which will replace dashes to underscores in the resource name in the URI path.