### PR TITLE
Allow True/False for query parameters

### DIFF
--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -131,9 +131,9 @@ def boolean(s):
     >>> boolean('false')
     False
     '''
-    if s == 'true':
+    if s in ['true', 'True']:
         return True
-    elif s == 'false':
+    elif s in ['false', 'False']:
         return False
     else:
         raise ValueError('Invalid boolean value')

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -131,7 +131,9 @@ def boolean(s):
     >>> boolean('false')
     False
     '''
-    if s.lower() == 'true':
+    if not hasattr(s, 'lower'):
+        raise ValueError('Invalid boolean value')
+    elif s.lower() == 'true':
         return True
     elif s.lower() == 'false':
         return False

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -131,9 +131,9 @@ def boolean(s):
     >>> boolean('false')
     False
     '''
-    if s in ['true', 'True']:
+    if s.lower() == 'true':
         return True
-    elif s in ['false', 'False']:
+    elif s.lower() == 'false':
         return False
     else:
         raise ValueError('Invalid boolean value')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -454,7 +454,7 @@ def test_parameter_validation(app):
     response = app_client.get(url, query_string={'int': '123'})  # type: flask.Response
     assert response.status_code == 200
 
-    for invalid_bool in '', 'foo', 'yes', 'False':
+    for invalid_bool in '', 'foo', 'yes':
         response = app_client.get(url, query_string={'bool': invalid_bool})  # type: flask.Response
         assert response.status_code == 400
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,3 +41,6 @@ def test_boolean():
 
     with pytest.raises(ValueError):
         utils.boolean('foo')
+
+    with pytest.raises(ValueError):
+        utils.boolean(None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,4 +33,9 @@ def test_get_function_from_name_for_class_method():
 
 def test_boolean():
     assert utils.boolean('true')
+    assert utils.boolean('True')
     assert not utils.boolean('false')
+    assert not utils.boolean('False')
+
+    with pytest.raises(ValueError):
+        utils.boolean('foo')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,8 +34,10 @@ def test_get_function_from_name_for_class_method():
 def test_boolean():
     assert utils.boolean('true')
     assert utils.boolean('True')
+    assert utils.boolean('TRUE')
     assert not utils.boolean('false')
     assert not utils.boolean('False')
+    assert not utils.boolean('FALSE')
 
     with pytest.raises(ValueError):
         utils.boolean('foo')


### PR DESCRIPTION
I think 'True' / 'False' should be allowed for query parameters. And that would also make swagger client like Bravado compatible with connexion (as it send query parameters with a capital letter).