### PR TITLE
Support for default fields in operation parameters

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -50,11 +50,12 @@ def parameter_to_arg(parameters, function):
     Pass query and body parameters as keyword arguments to handler function.
 
     See (https://github.com/zalando/connexion/issues/59)
-    :type body_schema: dict|None
+    :type parameters: dict|None
     :type parameters: dict|None
     """
     body_parameters = [parameter for parameter in parameters if parameter['in'] == 'body'] or [{}]
     body_name = body_parameters[0].get('name')
+    default_body = body_parameters[0].get('default')
     query_types = {parameter['name']: parameter
                    for parameter in parameters if parameter['in'] == 'query'}  # type: dict[str, str]
     arguments = get_function_arguments(function)
@@ -66,7 +67,7 @@ def parameter_to_arg(parameters, function):
         try:
             request_body = flask.request.json
         except exceptions.BadRequest:
-            request_body = None
+            request_body = default_body
 
         # Add body parameters
         if request_body is not None:
@@ -84,7 +85,7 @@ def parameter_to_arg(parameters, function):
                 logger.debug("Query Parameter '%s' in function arguments", key)
                 query_param = query_types[key]
                 logger.debug('%s is a %s', key, query_param)
-                kwargs[key] = get_val_from_param(value, query_param)
+                kwargs[key] = get_val_from_param(value, query_param) or query_param.get('default')
 
         return function(*args, **kwargs)
 

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -80,8 +80,13 @@ def validate_type(param, value, parameter_type, parameter_name=None):
 
 
 class RequestBodyValidator:
-    def __init__(self, schema):
+    def __init__(self, schema, has_default=False):
+        """
+        :param schema: The schema of the request body
+        :param has_default: Flag to indicate if default value is present.
+        """
         self.schema = schema
+        self.has_default = has_default
 
     def __call__(self, function):
         """
@@ -95,7 +100,7 @@ class RequestBodyValidator:
 
             logger.debug("%s validating schema...", flask.request.url)
             error = self.validate_schema(data, self.schema)
-            if error:
+            if error and not self.has_default:
                 return error
 
             response = function(*args, **kwargs)

--- a/tests/fakeapi/api.yaml
+++ b/tests/fakeapi/api.yaml
@@ -571,6 +571,41 @@ paths:
         - name: somefloat
           in: path
           type: number
+
+
+  /test-default-query-parameter:
+    get:
+      summary: Test if default parameter is passed to function
+      operationId: fakeapi.hello.test_default_param
+      parameters:
+        - name: name
+          in: query
+          type: string
+          default: connexion
+
+  /test-default-object-body:
+    post:
+      summary: Test if default object body param is passed to handler.
+      operationId: fakeapi.hello.test_default_object_body
+      parameters:
+        - name: stack
+          type: object
+          in: body
+          default:
+            'image_version': 'default_image'
+          schema:
+            $ref: '#/definitions/new_stack'
+
+  /test-default-integer-body:
+    post:
+      summary: Test if default integer body param is passed to handler.
+      operationId: fakeapi.hello.test_default_integer_body
+      parameters:
+        - name: stack_version
+          type: integer
+          in: body
+          default: 1
+
 definitions:
   new_stack:
     type: object

--- a/tests/fakeapi/api.yaml
+++ b/tests/fakeapi/api.yaml
@@ -606,6 +606,16 @@ paths:
           in: body
           default: 1
 
+  /test-falsy-param:
+    get:
+      summary: Test if default value when argument is falsy.
+      operationId: fakeapi.hello.test_falsy_param
+      parameters:
+        - name: falsy
+          type: integer
+          in: query
+          default: 1
+
 definitions:
   new_stack:
     type: object

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -214,3 +214,7 @@ def test_default_object_body(stack):
 
 def test_default_integer_body(stack_version):
     return stack_version
+
+
+def test_falsy_param(falsy):
+    return falsy

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -202,3 +202,15 @@ def test_get_someint(someint):
 
 def test_get_somefloat(somefloat):
     return type(somefloat).__name__
+
+
+def test_default_param(name):
+    return {"app_name": name}
+
+
+def test_default_object_body(stack):
+    return {"stack": stack}
+
+
+def test_default_integer_body(stack_version):
+    return stack_version

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -544,3 +544,25 @@ def test_path_parameter_somefloat(app):
     # non-float values will not match Flask route
     resp = app_client.get('/v1.0/test-float-path/123,45')  # type: flask.Response
     assert resp.status_code == 404
+
+
+def test_default_param(app):
+    app_client = app.app.test_client()
+    resp = app_client.get('/v1.0/test-default-query-parameter')
+    assert resp.status_code == 200
+    response = json.loads(resp.data.decode())
+    assert response['app_name'] == 'connexion'
+
+
+def test_default_object_body(app):
+    app_client = app.app.test_client()
+    resp = app_client.post('/v1.0/test-default-object-body')
+    assert resp.status_code == 200
+    response = json.loads(resp.data.decode())
+    assert response['stack'] == {'image_version': 'default_image'}
+
+    resp = app_client.post('/v1.0/test-default-integer-body')
+    assert resp.status_code == 200
+    response = json.loads(resp.data.decode())
+    assert response == 1
+

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -566,3 +566,16 @@ def test_default_object_body(app):
     response = json.loads(resp.data.decode())
     assert response == 1
 
+
+def test_falsy_param(app):
+    app_client = app.app.test_client()
+    resp = app_client.get('/v1.0/test-falsy-param', query_string={'falsy': 0})
+    assert resp.status_code == 200
+    response = json.loads(resp.data.decode())
+    assert response == 0
+
+    resp = app_client.get('/v1.0/test-falsy-param')
+    assert resp.status_code == 200
+    response = json.loads(resp.data.decode())
+    assert response == 1
+

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1,11 +1,11 @@
 import pathlib
-import pytest
 import types
-import jsonschema
-from connexion.decorators.validation import TypeValidationError
+
+import pytest
+
+from connexion.decorators.security import security_passthrough, verify_oauth
 from connexion.exceptions import InvalidSpecification
 from connexion.operation import Operation
-from connexion.decorators.security import security_passthrough, verify_oauth
 from connexion.resolver import Resolver
 
 TEST_FOLDER = pathlib.Path(__file__).parent
@@ -109,7 +109,7 @@ OPERATION6 = {'description': 'Adds a new stack to be created by lizzy and return
                       'in': 'body',
                       'name': 'new_stack',
                       'required': True,
-                      'schema': {'$ref': '#/notdefinitions/new_stack'}
+                      'schema': {'$ref': '#/definitions/new_stack'}
                   },
                   {
                       'in': 'query',
@@ -130,7 +130,6 @@ OPERATION6 = {'description': 'Adds a new stack to be created by lizzy and return
                                                  'access token was not provided or was '
                                                  'not valid for this operation',
                                   'schema': {'$ref': '#/definitions/problem'}}},
-              'security': [{'oauth': ['uid']}],
               'summary': 'Create new stack'}
 
 OPERATION7 = {
@@ -306,6 +305,7 @@ def test_resolve_invalid_reference():
     exception = exc_info.value  # type: InvalidSpecification
     assert exception.reason == "GET endpoint  '$ref' needs to start with '#/'"
 
+
 def test_bad_default():
     with pytest.raises(InvalidSpecification) as exc_info:
         Operation(method='GET', path='endpoint', operation=OPERATION6, app_produces=['application/json'],
@@ -343,11 +343,13 @@ def test_bad_default():
 def test_default():
     op = OPERATION6.copy()
     op['parameters'][1]['default'] = 1
-    Operation(method='GET', path='endpoint', operation=op, app_produces=['application/json'],
-              app_security=[], security_definitions={}, definitions={}, parameter_definitions=PARAMETER_DEFINITIONS,
+    Operation(method='GET', path='endpoint', operation=op, app_produces=['application/json'], app_security=[],
+              security_definitions={}, definitions=DEFINITIONS, parameter_definitions=PARAMETER_DEFINITIONS,
               resolver=Resolver())
-
     op = OPERATION8.copy()
     op['parameters'][0]['default'] = {
-        'keep_stack': 1, 'image_version': 'one', 'senza_yaml': 'senza.yaml', 'new_traffic': 100
+        'keep_stacks': 1, 'image_version': 'one', 'senza_yaml': 'senza.yaml', 'new_traffic': 100
     }
+    Operation(method='POST', path='endpoint', operation=op, app_produces=['application/json'],
+              app_security=[], security_definitions={}, definitions=DEFINITIONS, parameter_definitions={},
+              resolver=Resolver())


### PR DESCRIPTION
In this PR I have implemented support for defaults for query and body parameters. Support for header parameters is not implemented because headers and not treated as arguments to functions. If this changes in the future then adding the support is not difficult. Finally there is no support for _default_ in individual fields of object types. I think this is not directly related to the parameters it can be implemented in another PR.