### PR TITLE
Fix #128 - document `x-swagger-router-controller`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ For example:
           operationId: myapp.api.hello_world
 
 If you provided this path in your specification POST requests to ``http://MYHOST/hello_world`` would be handled by the
-function ``hello_world`` in ``myapp.api``. Optionally you can include `x-swagger-router-controller` in your operation definition, making ``operationId`` relative:
+function ``hello_world`` in ``myapp.api``. Optionally you can include ``x-swagger-router-controller`` in your operation definition, making ``operationId`` relative:
 
 .. code-block:: yaml
 

--- a/README.rst
+++ b/README.rst
@@ -74,14 +74,14 @@ For example:
           operationId: myapp.api.hello_world
 
 If you provided this path in your specification POST requests to ``http://MYHOST/hello_world`` would be handled by the
-function ``hello_world`` in ``myapp.api``. Optionally you can include `x-router-controller` in your operation definition, making ``operationId`` relative:
+function ``hello_world`` in ``myapp.api``. Optionally you can include `x-swagger-router-controller` in your operation definition, making ``operationId`` relative:
 
 .. code-block:: yaml
 
     paths:
       /hello_world:
         post:
-          x-router-controller: myapp.api
+          x-swagger-router-controller: myapp.api
           operationId: hello_world
 
 


### PR DESCRIPTION
Minor documentation fix for issue #128. Documentation incorrectly referred to the operation property `x-router-controller`, which should actually be `x-swagger-router-controller`.