### PR TITLE
Handle correctly boolean values in default property

### DIFF
--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -131,7 +131,9 @@ def boolean(s):
     >>> boolean('false')
     False
     '''
-    if not hasattr(s, 'lower'):
+    if isinstance(s, bool):
+        return s
+    elif not hasattr(s, 'lower'):
         raise ValueError('Invalid boolean value')
     elif s.lower() == 'true':
         return True

--- a/tests/fakeapi/api.yaml
+++ b/tests/fakeapi/api.yaml
@@ -616,6 +616,16 @@ paths:
           in: query
           default: 1
 
+  /test-bool-param:
+    get:
+      summary: Test usage of boolean default value
+      operationId: fakeapi.hello.test_bool_default_param
+      parameters:
+        - name: thruthiness
+          type: boolean
+          in: query
+          default: false
+
 definitions:
   new_stack:
     type: object

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -218,3 +218,7 @@ def test_default_integer_body(stack_version):
 
 def test_falsy_param(falsy):
     return falsy
+
+
+def test_bool_default_param(thruthiness):
+    return thruthiness

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -575,3 +575,13 @@ def test_falsy_param(app):
     assert resp.status_code == 200
     response = json.loads(resp.data.decode())
     assert response == 1
+
+def test_bool_as_default_param(app):
+    app_client = app.app.test_client()
+    resp = app_client.get('/v1.0/test-bool-param')
+    assert resp.status_code == 200
+
+    resp = app_client.get('/v1.0/test-bool-param', query_string={'thruthiness': True})
+    assert resp.status_code == 200
+    response = json.loads(resp.data.decode())
+    assert response == True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,9 +35,11 @@ def test_boolean():
     assert utils.boolean('true')
     assert utils.boolean('True')
     assert utils.boolean('TRUE')
+    assert utils.boolean(True)
     assert not utils.boolean('false')
     assert not utils.boolean('False')
     assert not utils.boolean('FALSE')
+    assert not utils.boolean(False)
 
     with pytest.raises(ValueError):
         utils.boolean('foo')


### PR DESCRIPTION
This PR fixes the issue #127. 

[Here](http://www.yaml.org/spec/1.2/spec.html#id2803629) in the spec, it seems that Booleans can be true or false, without quotes.