### PR TITLE
Pass formData parameters as keyword arguments

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -62,12 +62,12 @@ def parameter_to_arg(parameters, function):
     query_types = {parameter['name']: parameter
                    for parameter in parameters if parameter['in'] == 'query'}  # type: dict[str, str]
     form_types = {parameter['name']: parameter
-                    for parameter in parameters if parameter['in'] == 'formData'}
+                  for parameter in parameters if parameter['in'] == 'formData'}
     arguments = get_function_arguments(function)
     default_query_params = {param['name']: param['default']
                             for param in parameters if param['in'] == 'query' and 'default' in param}
     default_form_params = {param['name']: param['default']
-                            for param in parameters if param['in'] == 'formData' and 'default' in param}
+                           for param in parameters if param['in'] == 'formData' and 'default' in param}
 
     @functools.wraps(function)
     def wrapper(*args, **kwargs):

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -108,7 +108,7 @@ def parameter_to_arg(parameters, function):
             if key not in arguments:
                 logger.debug("FormData parameter '%s' not in function arguments", key)
             else:
-                logger.debug("FormData parameter '%s' in function arguments, key")
+                logger.debug("FormData parameter '%s' in function arguments", key)
                 form_param = form_types[key]
                 kwargs[key] = get_val_from_param(value, form_param)
 

--- a/tests/fakeapi/api.yaml
+++ b/tests/fakeapi/api.yaml
@@ -616,6 +616,16 @@ paths:
           in: query
           default: 1
 
+  /test-formData-param:
+    post:
+      summary: Test formData parameter
+      operationId: fakeapi.hello.test_formData_param
+      parameters:
+        - name: formData
+          type: string
+          in: formData
+          required: true
+
 definitions:
   new_stack:
     type: object

--- a/tests/fakeapi/api.yaml
+++ b/tests/fakeapi/api.yaml
@@ -626,6 +626,16 @@ paths:
           in: formData
           required: true
 
+  /test-formData-missing-param:
+    post:
+      summary: Test formData missing parameter in handler
+      operationId: fakeapi.hello.test_formData_missing_param
+      parameters:
+        - name: missing_formData
+          type: string
+          in: formData
+          required: true
+
   /test-bool-param:
     get:
       summary: Test usage of boolean default value

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -218,3 +218,7 @@ def test_default_integer_body(stack_version):
 
 def test_falsy_param(falsy):
     return falsy
+
+
+def test_formData_param(formData):
+    return formData

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -224,5 +224,9 @@ def test_formData_param(formData):
     return formData
 
 
+def test_formData_missing_param():
+    return ''
+
+
 def test_bool_default_param(thruthiness):
     return thruthiness

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -575,3 +575,11 @@ def test_falsy_param(app):
     assert resp.status_code == 200
     response = json.loads(resp.data.decode())
     assert response == 1
+
+
+def test_formData_param(app):
+    app_client = app.app.test_client()
+    resp = app_client.post('/v1.0/test-formData-param', data=dict(formData='test'))
+    assert resp.status_code == 200
+    response = json.loads(resp.data.decode())
+    assert response == 'test'

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -585,6 +585,12 @@ def test_formData_param(app):
     assert response == 'test'
 
 
+def test_formData_missing_param(app):
+    app_client = app.app.test_client()
+    resp = app_client.post('/v1.0/test-formData-missing-param', data=dict(missing_formData='test'))
+    assert resp.status_code == 200
+
+
 def test_bool_as_default_param(app):
     app_client = app.app.test_client()
     resp = app_client.get('/v1.0/test-bool-param')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -579,7 +579,7 @@ def test_falsy_param(app):
 
 def test_formData_param(app):
     app_client = app.app.test_client()
-    resp = app_client.post('/v1.0/test-formData-param', data=dict(formData='test'))
+    resp = app_client.post('/v1.0/test-formData-param', data={'formData': 'test'})
     assert resp.status_code == 200
     response = json.loads(resp.data.decode())
     assert response == 'test'
@@ -587,7 +587,7 @@ def test_formData_param(app):
 
 def test_formData_missing_param(app):
     app_client = app.app.test_client()
-    resp = app_client.post('/v1.0/test-formData-missing-param', data=dict(missing_formData='test'))
+    resp = app_client.post('/v1.0/test-formData-missing-param', data={'missing_formData': 'test'})
     assert resp.status_code == 200
 
 


### PR DESCRIPTION
As already commented in https://github.com/zalando/connexion/issues/132 this PR adds support to pass formData parameters as keyword parameters to function handlers.