### PR TITLE
Fix when API returns flask response

### DIFF
--- a/connexion/decorators/decorator.py
+++ b/connexion/decorators/decorator.py
@@ -12,6 +12,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 """
 import logging
 import flask
+from ..utils import is_flask_response
 
 logger = logging.getLogger('connexion.decorators.decorator')
 
@@ -32,7 +33,7 @@ class BaseDecorator:
         url = flask.request.url
         logger.debug('Getting data and status code', extra={'data': data, 'data_type': type(data), 'url': url})
         status_code, headers = 200, {}
-        if isinstance(data, flask.Response):
+        if is_flask_response(data):
             data = data
             status_code = data.status_code
             headers = data.headers

--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -18,6 +18,7 @@ import functools
 import json
 import logging
 from .decorator import BaseDecorator
+from ..utils import is_flask_response
 
 logger = logging.getLogger('connexion.decorators.produces')
 
@@ -83,7 +84,7 @@ class Produces(BaseSerializer):
             url = flask.request.url
             data, status_code, headers = self.get_full_response(function(*args, **kwargs))
             logger.debug('Returning %s', url, extra={'url': url, 'mimetype': self.mimetype})
-            if isinstance(data, flask.Response):  # if the function returns a Response object don't change it
+            if is_flask_response(data):
                 logger.debug('Endpoint returned a Flask Response', extra={'url': url, 'mimetype': data.mimetype})
                 return data
 
@@ -114,7 +115,7 @@ class Jsonifier(BaseSerializer):
             url = flask.request.url
             logger.debug('Jsonifing %s', url, extra={'url': url, 'mimetype': self.mimetype})
             data, status_code, headers = self.get_full_response(function(*args, **kwargs))
-            if isinstance(data, flask.Response):  # if the function returns a Response object don't change it
+            if is_flask_response(data):
                 logger.debug('Endpoint returned a Flask Response', extra={'url': url, 'mimetype': data.mimetype})
                 return data
             elif data is NoContent:

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -14,6 +14,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
 import functools
 import importlib
 import re
+import flask
+import werkzeug.wrappers
 
 PATH_PARAMETER = re.compile(r'\{([^}]*)\}')
 
@@ -57,6 +59,21 @@ def flaskify_path(swagger_path, types={}):
     """
     convert_match = functools.partial(convert_path_parameter, types=types)
     return PATH_PARAMETER.sub(convert_match, swagger_path)
+
+
+def is_flask_response(obj):
+    """
+    Verifies if obj is a default Flask response instance.
+
+    :type obj: object
+    :rtype bool
+
+    >>> is_flask_response(redirect('http://example.com/'))
+    True
+    >>> is_flask_response(flask.Response())
+    True
+    """
+    return isinstance(obj, flask.Response) or isinstance(obj, werkzeug.wrappers.Response)
 
 
 def deep_getattr(obj, attr):

--- a/tests/fakeapi/api.yaml
+++ b/tests/fakeapi/api.yaml
@@ -656,6 +656,22 @@ paths:
           in: query
           required: true
 
+  /test-redirect-endpoint:
+    get:
+      summary: Tests handlers returning flask.Response objects
+      operationId: fakeapi.hello.test_redirect_endpoint
+      responses:
+        302:
+          description: 302 Found
+
+  /test-redirect-response-endpoint:
+    get:
+      summary: Tests handlers returning flask.Response objects
+      operationId: fakeapi.hello.test_redirect_response_endpoint
+      responses:
+        302:
+          description: 302 Found
+
 definitions:
   new_stack:
     type: object

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -2,6 +2,7 @@
 
 from connexion import problem, request
 from connexion import NoContent
+from flask import redirect
 
 
 class DummyClass:
@@ -234,3 +235,12 @@ def test_bool_default_param(thruthiness):
 
 def test_required_param(simple):
     return simple
+
+
+def test_redirect_endpoint():
+    headers = {'Location': 'http://www.google.com/'}
+    return '', 302, headers
+
+
+def test_redirect_response_endpoint():
+    return redirect('http://www.google.com/')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -613,3 +613,15 @@ def test_required_param_miss_config(app):
 
     resp = app_client.get('/v1.0/test-required-param')
     assert resp.status_code == 400
+
+
+def test_redirect_endpoint(app):
+    app_client = app.app.test_client()
+    resp = app_client.get('/v1.0/test-redirect-endpoint')
+    assert resp.status_code == 302
+
+
+def test_redirect_response_endpoint(app):
+    app_client = app.app.test_client()
+    resp = app_client.get('/v1.0/test-redirect-response-endpoint')
+    assert resp.status_code == 302


### PR DESCRIPTION
Fixes #133 

The function [`redirect`](https://github.com/mitsuhiko/flask/blob/master/flask/__init__.py#L18) does not return a `flask.Response` instance, but a [Werkzeug response](https://github.com/mitsuhiko/werkzeug/blob/master/werkzeug/wrappers.py#L1838) causing the Connexion code to break.