### PR TITLE
Support header params on 204 response code

### DIFF
--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -119,10 +119,10 @@ class Jsonifier(BaseSerializer):
                 logger.debug('Endpoint returned a Flask Response', extra={'url': url, 'mimetype': data.mimetype})
                 return data
             elif data is NoContent:
-                return '', status_code
+                return '', status_code, headers
             elif status_code == 204:
                 logger.debug('Endpoint returned an empty response (204)', extra={'url': url, 'mimetype': self.mimetype})
-                return '', 204
+                return '', 204, headers
 
             data = json.dumps(data, indent=2, cls=JSONEncoder)
             response = flask.current_app.response_class(data, mimetype=self.mimetype)  # type: flask.Response

--- a/tests/fakeapi/api.yaml
+++ b/tests/fakeapi/api.yaml
@@ -721,6 +721,30 @@ paths:
         302:
           description: 302 Found
 
+  /test-204-with-headers:
+    get:
+      summary: Tests that response code 204 can have headers set
+      operationId: fakeapi.hello.test_204_with_headers
+      responses:
+        204:
+          headers:
+            X-Something:
+              description: A value that might be send in the response
+              type: string
+          description: 204 no content
+
+  /test-204-with-headers-nocontent-obj:
+    get:
+      summary: Tests that response code 204 using NoContent obj can have headers set
+      operationId: fakeapi.hello.test_nocontent_obj_with_headers
+      responses:
+        204:
+          headers:
+            X-Something:
+              description: A value that might be send in the response
+              type: string
+          description: 204 no content
+
 definitions:
   new_stack:
     type: object

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -15,17 +15,22 @@ class DummyClass:
 
 class_instance = DummyClass()
 
+
 def get():
     return ''
+
 
 def search():
     return ''
 
+
 def list():
     return ''
 
+
 def post():
     return ''
+
 
 def post_greeting(name):
     data = {'greeting': 'Hello {name}'.format(name=name)}
@@ -160,11 +165,14 @@ def schema_query(image_version=None):
 def schema_list():
     return ''
 
+
 def schema_map():
     return ''
 
+
 def schema_recursive():
     return ''
+
 
 def schema_format():
     return ''
@@ -253,3 +261,13 @@ def test_redirect_endpoint():
 
 def test_redirect_response_endpoint():
     return redirect('http://www.google.com/')
+
+
+def test_204_with_headers():
+    headers = {'X-Something': 'test'}
+    return '', 204, headers
+
+
+def test_nocontent_obj_with_headers():
+    headers = {'X-Something': 'test'}
+    return NoContent, 204, headers

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,7 +2,6 @@ import pathlib
 import json
 import logging
 import pytest
-import _pytest.monkeypatch
 from connexion.app import App
 
 logging.basicConfig(level=logging.DEBUG)
@@ -397,6 +396,7 @@ def test_schema_list(app):
     assert wrong_items_response['title'] == 'Bad Request'
     assert wrong_items_response['detail'].startswith("42 is not of type 'string'")
 
+
 def test_schema_map(app):
     app_client = app.app.test_client()
     headers = {'Content-type': 'application/json'}
@@ -432,6 +432,7 @@ def test_schema_map(app):
     right_type = app_client.post('/v1.0/test_schema_map', headers=headers,
                                   data=json.dumps(valid_object))  # type: flask.Response
     assert right_type.status_code == 200
+
 
 def test_schema_recursive(app):
     app_client = app.app.test_client()
@@ -469,6 +470,7 @@ def test_schema_recursive(app):
     right_type = app_client.post('/v1.0/test_schema_recursive', headers=headers,
                                   data=json.dumps(valid_object))  # type: flask.Response
     assert right_type.status_code == 200
+
 
 def test_schema_format(app):
     app_client = app.app.test_client()
@@ -671,7 +673,7 @@ def test_bool_as_default_param(app):
     resp = app_client.get('/v1.0/test-bool-param', query_string={'thruthiness': True})
     assert resp.status_code == 200
     response = json.loads(resp.data.decode())
-    assert response == True
+    assert response is True
 
 
 def test_bool_param(app):
@@ -679,12 +681,12 @@ def test_bool_param(app):
     resp = app_client.get('/v1.0/test-bool-param', query_string={'thruthiness': True})
     assert resp.status_code == 200
     response = json.loads(resp.data.decode())
-    assert response == True
+    assert response is True
 
     resp = app_client.get('/v1.0/test-bool-param', query_string={'thruthiness': False})
     assert resp.status_code == 200
     response = json.loads(resp.data.decode())
-    assert response == False
+    assert response is False
 
 
 def test_bool_array_param(app):
@@ -692,13 +694,14 @@ def test_bool_array_param(app):
     resp = app_client.get('/v1.0/test-bool-array-param?thruthiness=true,true,true')
     assert resp.status_code == 200
     response = json.loads(resp.data.decode())
-    assert response == True
+    assert response is True
 
     app_client = app.app.test_client()
     resp = app_client.get('/v1.0/test-bool-array-param?thruthiness=true,true,false')
     assert resp.status_code == 200
     response = json.loads(resp.data.decode())
-    assert response == False
+    assert response is False
+
 
 def test_required_param_miss_config(app):
     app_client = app.app.test_client()
@@ -753,3 +756,17 @@ def test_security_over_inexistent_endpoints(oauth_requests):
 
     post_greeting = app_client.post('/v1.0/greeting/rcaricio', data={})  # type: flask.Response
     assert post_greeting.status_code == 401
+
+
+def test_no_content_response_have_headers(app):
+    app_client = app.app.test_client()
+    resp = app_client.get('/v1.0/test-204-with-headers')
+    assert resp.status_code == 204
+    assert 'X-Something' in resp.headers
+
+
+def test_no_content_object_and_have_headers(app):
+    app_client = app.app.test_client()
+    resp = app_client.get('/v1.0/test-204-with-headers-nocontent-obj')
+    assert resp.status_code == 204
+    assert 'X-Something' in resp.headers


### PR DESCRIPTION
Fixes #144 

Connexion should support header parameters on 204 response codes. As specified in [RFC-2616 section 10.2.5](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) of HTTP/1.1. Also if you define in your OpenAPI yaml like that:

```yaml
  /test-204-with-headers:
    get:
      summary: Tests that response code 204 can have headers set
      operationId: fakeapi.hello.test_204_with_headers
      responses:
        204:
          headers:
            X-Something:
              description: A value that might be send in the response
              type: string
          description: 204 no content
```

And your handler function (`fakeapi.hello.test_204_with_headers`) do not set the "X-Something" header Connexion will throw an exception (500 Internal Error) that notifying you that the "X-Something" header wasn't set in the response of your handler. But when you set the header Connexion was not able to return the header parameter in the actual response object. This PR fixes in that case too.

PS.: This PR also fixes some spacing format issues that used to not follow a consistent pattern.