### PR TITLE
Recommend usage of `decorator` package in Connexion projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ htmlcov/
 .eggs
 .cache/
 *.swp
+.tox/

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     license='Apache License Version 2.0',
     setup_requires=['flake8'],
     install_requires=get_install_requirements('requirements.txt'),
-    tests_require=['pytest-cov', 'pytest', 'mock'],
+    tests_require=['pytest-cov', 'pytest', 'mock', 'decorator'],
     cmdclass={'test': PyTest},
     test_suite='tests',
     classifiers=[

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1,0 +1,23 @@
+import decorator
+from connexion.decorators.parameter import get_function_arguments
+
+
+@decorator.decorator
+def the_decorator(f, *args, **kwargs):
+    return f(*args, **kwargs)
+
+
+def stub_function(foo, bar):
+    """stub function to be used in tests."""
+    pass
+
+
+def test_get_proper_argument_list():
+    """Test get the proper argument list of the decorated function."""
+
+    assert len(get_function_arguments(stub_function)) == 2
+    assert get_function_arguments(stub_function) == ['foo', 'bar']
+
+    decorated_stub_function = the_decorator(stub_function)
+    assert len(get_function_arguments(decorated_stub_function)) == 2
+    assert get_function_arguments(decorated_stub_function) == ['foo', 'bar']

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,9 @@
 [flake8]
-max-line-length = 120
-exclude = connexion/__init__.py
+max-line-length=120
+exclude=connexion/__init__.py
+
+[tox]
+envlist=pypy,py27,py35
+
+[testenv]
+commands=python setup.py test


### PR DESCRIPTION
## The problem

The `functools.wraps` does not pass the information about parameters of the original function to the decorated instance. This makes Connexion fail to get the argument list defined in the original function. So in case you create a decorator with `functools.wraps` and use in your Connexion view function with parameters it will fail on **Python 2.x**.

## Solution

Due to that problem we should advise the users of Connexion to use the [`decorator`](https://github.com/micheles/decorator) package while creating decorators for their Connexion view functions. This will keep Connextion working as expected specially in case of handing endpoints with parameters in decorated view functions.

## What was changed in this PR

Updates our `/basicauth` example project to use the `decorator` package so it drives the users to the recommended usage. Also a test was added to make sure that Connexion will keep working if followed the recommendation.

Fixes #142 