### PR TITLE
Support parameters definitions in path level

### DIFF
--- a/connexion/api.py
+++ b/connexion/api.py
@@ -154,7 +154,7 @@ class Api:
                     self.add_operation(method, path, endpoint, path_parameters)
                 except Exception:  # pylint: disable= W0703
                     logger.exception('Failed to add operation for %s %s%s',
-                            method.upper(), self.base_url, path)
+                                     method.upper(), self.base_url, path)
 
     def add_auth_on_not_found(self):
         """

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -99,9 +99,13 @@ def parameter_to_arg(parameters, function):
                 logger.debug("Query Parameter '%s' not in function arguments", key)
             else:
                 logger.debug("Query Parameter '%s' in function arguments", key)
-                query_param = query_types[key]
-                logger.debug('%s is a %s', key, query_param)
-                kwargs[key] = get_val_from_param(value, query_param)
+                try:
+                    query_param = query_types[key]
+                except KeyError:  # pragma: no cover
+                    logger.error("Function argument '{}' not defined in specification".format(key))
+                else:
+                    logger.debug('%s is a %s', key, query_param)
+                    kwargs[key] = get_val_from_param(value, query_param)
 
         # Add formData parameters
         form_arguments = copy.deepcopy(default_form_params)
@@ -111,8 +115,12 @@ def parameter_to_arg(parameters, function):
                 logger.debug("FormData parameter '%s' not in function arguments", key)
             else:
                 logger.debug("FormData parameter '%s' in function arguments", key)
-                form_param = form_types[key]
-                kwargs[key] = get_val_from_param(value, form_param)
+                try:
+                    form_param = form_types[key]
+                except KeyError:  # pragma: no cover
+                    logger.error("Function argument '{}' not defined in specification".format(key))
+                else:
+                    kwargs[key] = get_val_from_param(value, form_param)
 
         return function(*args, **kwargs)
 

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -105,7 +105,8 @@ class Operation(SecureOperation):
     A single API operation on a path.
     """
 
-    def __init__(self, method, path, operation, app_produces, app_security, security_definitions, definitions,
+    def __init__(self, method, path, path_parameters, operation, app_produces,
+                 app_security, security_definitions, definitions,
                  parameter_definitions, resolver, validate_responses=False):
         """
         This class uses the OperationID identify the module and function that will handle the operation
@@ -121,6 +122,8 @@ class Operation(SecureOperation):
         :type method: str
         :param path:
         :type path: str
+        :param path_parameters: Parameters defined in the path level
+        :type path_parameters: list
         :param operation: swagger operation object
         :type operation: dict
         :param app_produces: list of content types the application can return by default
@@ -133,6 +136,8 @@ class Operation(SecureOperation):
         :param definitions: `Definitions Object
             <https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#definitionsObject>`_
         :type definitions: dict
+        :param parameter_definitions: Global parameter definitions
+        :type parameter_definitions: dict
         :param resolver: Callable that maps operationID to a function
         :param validate_responses: True enables validation. Validation errors generate HTTP 500 responses.
         :type validate_responses: bool
@@ -153,6 +158,9 @@ class Operation(SecureOperation):
         # todo support definition references
         # todo support references to application level parameters
         self.parameters = list(self.resolve_parameters(operation.get('parameters', [])))
+        if path_parameters:
+            self.parameters += list(self.resolve_parameters(path_parameters))
+
         self.security = operation.get('security', app_security)
         self.produces = operation.get('produces', app_produces)
 

--- a/tests/fakeapi/api.yaml
+++ b/tests/fakeapi/api.yaml
@@ -34,6 +34,7 @@ paths:
           description: Name of the person to greet.
           required: true
           type: string
+
   /greetings/{name}:
     get:
       summary: Generate greeting
@@ -52,6 +53,7 @@ paths:
           description: Name of the person to greet.
           required: true
           type: string
+
   /bye/{name}:
     get:
       summary: Generate goodbye
@@ -74,6 +76,7 @@ paths:
           description: Name of the person to say bye.
           required: true
           type: string
+
   /problem:
     get:
       summary: Fails
@@ -86,6 +89,7 @@ paths:
           description: goodbye response
           schema:
             type: string
+
   /other_problem:
     get:
       summary: Fails
@@ -101,6 +105,7 @@ paths:
           description: goodbye response
           schema:
             type: string
+
   /list/{name}:
     get:
       summary: Generate a greeting in a list
@@ -125,6 +130,7 @@ paths:
           description: Name of the person to say hello to.
           required: true
           type: string
+
   /byesecure/{name}:
     get:
       summary: Generate goodbye
@@ -146,6 +152,7 @@ paths:
           description: Name of the person to say bye.
           required: true
           type: string
+
   /except:
     get:
       summary: Fails badly
@@ -158,6 +165,7 @@ paths:
           description: goodbye response
           schema:
             type: string
+
   /multimime:
     get:
       summary: Has multiple content types
@@ -171,6 +179,7 @@ paths:
           description: goodbye response
           schema:
             type: string
+
   /empty:
     get:
       summary: Returns empty response
@@ -181,6 +190,7 @@ paths:
       responses:
         204:
           description: empty
+
   /test_schema:
     post:
       summary: Returns the image_version
@@ -199,6 +209,7 @@ paths:
           description: goodbye response
           schema:
             $ref: '#/definitions/new_stack'
+
   /test_schema/response/object/{valid}:
     get:
       summary: Returns an image_version as an object
@@ -217,6 +228,7 @@ paths:
           description: Requested new_stack data model
           schema:
             $ref: '#/definitions/new_stack'
+
   /test_schema/response/string/{valid}:
     get:
       summary: Returns an image_version as a string
@@ -235,6 +247,7 @@ paths:
           description: Requested new_stack data model
           schema:
             type: string
+
   /test_schema/response/integer/{valid}:
     get:
       summary: Returns an image_version as an integer
@@ -253,6 +266,7 @@ paths:
           description: Requested new_stack data model
           schema:
             type: integer
+
   /test_schema/response/number/{valid}:
     get:
       summary: Returns an image_version as a number(float)
@@ -271,6 +285,7 @@ paths:
           description: Requested new_stack data model
           schema:
             type: number
+
   /test_schema/response/boolean/{valid}:
     get:
       summary: Returns an image_version as a boolean
@@ -289,6 +304,7 @@ paths:
           description: Requested new_stack data model
           schema:
             type: boolean
+
   /test_schema/response/array/{valid}:
     get:
       summary: Returns an image_version as a boolean
@@ -310,6 +326,7 @@ paths:
             items:
               schema:
                 $ref: '#/definitions/new_stack'
+
   /test_schema_in_query:
     post:
       summary: Returns the image_version
@@ -352,6 +369,7 @@ paths:
           description: goodbye response
           schema:
             type: string
+
   /test_schema_map:
     post:
       summary: Returns empty response
@@ -372,6 +390,7 @@ paths:
           description: goodbye response
           schema:
             type: string
+
   /test_schema_recursive:
     post:
       summary: Returns empty response
@@ -390,6 +409,7 @@ paths:
           description: goodbye response
           schema:
             type: string
+
   /test_schema_format:
     post:
       summary: Returns empty response
@@ -409,6 +429,7 @@ paths:
           description: goodbye response
           schema:
             type: string
+
   /test_not_implemented:
     post:
       summary: Returns empty response
@@ -427,6 +448,7 @@ paths:
           description: goodbye response
           schema:
             type: string
+
   /test_parameter_validation:
     get:
       operationId: fakeapi.hello.test_parameter_validation
@@ -441,6 +463,7 @@ paths:
         - name: bool
           in: query
           type: boolean
+
   /test_required_query_param:
     get:
       operationId: fakeapi.hello.test_required_query_param
@@ -449,6 +472,7 @@ paths:
           in: query
           type: number
           required: true
+
   /test_array_csv_query_param:
     get:
       operationId: fakeapi.hello.test_array_csv_query_param
@@ -461,6 +485,7 @@ paths:
           items:
             type: string
           collectionFormat: csv
+
   /test_array_pipes_query_param:
     get:
       operationId: fakeapi.hello.test_array_pipes_query_param
@@ -473,6 +498,7 @@ paths:
           items:
             type: integer
           collectionFormat: pipes
+
   /test_array_unsupported_query_param:
     get:
       operationId: fakeapi.hello.test_array_unsupported_query_param
@@ -485,12 +511,14 @@ paths:
           items:
             type: string
           collectionFormat: unsupported
+
   /test_no_content_response:
     get:
       operationId: fakeapi.hello.test_no_content_response
       responses:
         204:
           description: No content returned
+
   /schema_array:
     get:
       tags:
@@ -507,6 +535,7 @@ paths:
       responses:
         200:
           description: OK
+
   /schema_int:
     get:
       tags:
@@ -521,6 +550,7 @@ paths:
       responses:
         200:
           description: OK
+
   /goodday/{name}:
     post:
       summary: Generate good day greeting
@@ -545,6 +575,7 @@ paths:
           description: Name of the person to greet.
           required: true
           type: string
+
   /goodday/noheader:
     post:
       summary: Generate good day greeting
@@ -559,6 +590,7 @@ paths:
               description: The URI of the created resource
           schema:
             type: object
+
   /goodevening/{name}:
     post:
       summary: Generate good evening
@@ -585,14 +617,17 @@ paths:
           description: Name of the person to say good evening.
           required: true
           type: string
+
   /resolver-test/method:
     get:
       summary: Test class instance method
       operationId: fakeapi.hello.class_instance.test_method
+
   /resolver-test/classmethod:
     get:
       summary: Test class instance method
       operationId: fakeapi.hello.DummyClass.test_classmethod
+
   /test-int-path/{someint}:
     get:
       summary: Test type casting of path parameter
@@ -744,6 +779,20 @@ paths:
               description: A value that might be send in the response
               type: string
           description: 204 no content
+
+  /parameters-in-root-path:
+    parameters:
+      - in: query
+        name: title
+        type: string
+        description: Some parameter in the path
+        required: true
+    get:
+      summary: Test the method GET with parameter from path
+      operationId: fakeapi.hello.path_parameters_in_get_method
+      responses:
+        200:
+          description: Everything is OK
 
 definitions:
   new_stack:

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -246,7 +246,9 @@ def test_bool_default_param(thruthiness):
     return thruthiness
 
 
-def test_bool_array_param(thruthiness):
+def test_bool_array_param(thruthiness=None):
+    if thruthiness is None:
+        thruthiness = []
     return all(thruthiness)
 
 
@@ -271,3 +273,7 @@ def test_204_with_headers():
 def test_nocontent_obj_with_headers():
     headers = {'X-Something': 'test'}
     return NoContent, 204, headers
+
+
+def path_parameters_in_get_method(title):
+    return [title], 200, {}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -702,6 +702,10 @@ def test_bool_array_param(app):
     response = json.loads(resp.data.decode())
     assert response is False
 
+    app_client = app.app.test_client()
+    resp = app_client.get('/v1.0/test-bool-array-param')
+    assert resp.status_code == 200
+
 
 def test_required_param_miss_config(app):
     app_client = app.app.test_client()
@@ -770,3 +774,13 @@ def test_no_content_object_and_have_headers(app):
     resp = app_client.get('/v1.0/test-204-with-headers-nocontent-obj')
     assert resp.status_code == 204
     assert 'X-Something' in resp.headers
+
+
+def test_parameters_defined_in_path_level(app):
+    app_client = app.app.test_client()
+    resp = app_client.get('/v1.0/parameters-in-root-path?title=nice-get')
+    assert resp.status_code == 200
+    assert json.loads(resp.data.decode()) == ["nice-get"]
+
+    resp = app_client.get('/v1.0/parameters-in-root-path')
+    assert resp.status_code == 400

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 import pathlib
 import types
 
@@ -239,6 +238,7 @@ SECURITY_DEFINITIONS_WO_INFO = {'oauth': {'type': 'oauth2',
 def test_operation():
     operation = Operation(method='GET',
                           path='endpoint',
+                          path_parameters=[],
                           operation=OPERATION1,
                           app_produces=['application/json'],
                           app_security=[],
@@ -266,6 +266,7 @@ def test_operation():
 def test_operation_array():
     operation = Operation(method='GET',
                           path='endpoint',
+                          path_parameters=[],
                           operation=OPERATION9,
                           app_produces=['application/json'],
                           app_security=[],
@@ -283,7 +284,7 @@ def test_operation_array():
     assert operation.produces == ['application/json']
     assert operation.security == [{'oauth': ['uid']}]
     expected_body_schema = {
-        'type': 'array', 
+        'type': 'array',
         'items': {'$ref': '#/definitions/new_stack'},
         'definitions': DEFINITIONS
     }
@@ -293,6 +294,7 @@ def test_operation_array():
 def test_operation_composed_definition():
     operation = Operation(method='GET',
                           path='endpoint',
+                          path_parameters=[],
                           operation=OPERATION10,
                           app_produces=['application/json'],
                           app_security=[],
@@ -320,6 +322,7 @@ def test_non_existent_reference():
     with pytest.raises(InvalidSpecification) as exc_info:  # type: py.code.ExceptionInfo
         operation = Operation(method='GET',
                             path='endpoint',
+                            path_parameters=[],
                             operation=OPERATION1,
                             app_produces=['application/json'],
                             app_security=[],
@@ -327,7 +330,7 @@ def test_non_existent_reference():
                             definitions={},
                             parameter_definitions={},
                             resolver=Resolver())
-        schema = operation.body_schema
+        operation.body_schema
 
     exception = exc_info.value
     assert str(exception) == "<InvalidSpecification: GET endpoint Definition 'new_stack' not found>"
@@ -338,6 +341,7 @@ def test_multi_body():
     with pytest.raises(InvalidSpecification) as exc_info:  # type: py.code.ExceptionInfo
         operation = Operation(method='GET',
                             path='endpoint',
+                            path_parameters=[],
                             operation=OPERATION2,
                             app_produces=['application/json'],
                             app_security=[],
@@ -345,7 +349,7 @@ def test_multi_body():
                             definitions=DEFINITIONS,
                             parameter_definitions=PARAMETER_DEFINITIONS,
                             resolver=Resolver())
-        schema = operation.body_schema
+        operation.body_schema
 
     exception = exc_info.value
     assert str(exception) == "<InvalidSpecification: GET endpoint There can be one 'body' parameter at most>"
@@ -356,6 +360,7 @@ def test_invalid_reference():
     with pytest.raises(InvalidSpecification) as exc_info:  # type: py.code.ExceptionInfo
         operation = Operation(method='GET',
                             path='endpoint',
+                            path_parameters=[],
                             operation=OPERATION3,
                             app_produces=['application/json'],
                             app_security=[],
@@ -363,7 +368,7 @@ def test_invalid_reference():
                             definitions=DEFINITIONS,
                             parameter_definitions=PARAMETER_DEFINITIONS,
                             resolver=Resolver())
-        schema = operation.body_schema
+        operation.body_schema
 
     exception = exc_info.value
     assert str(exception) == "<InvalidSpecification: GET endpoint  '$ref' needs to point to definitions or parameters>"
@@ -373,6 +378,7 @@ def test_invalid_reference():
 def test_no_token_info():
     operation = Operation(method='GET',
                           path='endpoint',
+                          path_parameters=[],
                           operation=OPERATION1,
                           app_produces=['application/json'],
                           app_security=SECURITY_DEFINITIONS_WO_INFO,
@@ -397,6 +403,7 @@ def test_no_token_info():
 def test_parameter_reference():
     operation = Operation(method='GET',
                           path='endpoint',
+                          path_parameters=[],
                           operation=OPERATION4,
                           app_produces=['application/json'],
                           app_security=[],
@@ -409,8 +416,10 @@ def test_parameter_reference():
 
 def test_resolve_invalid_reference():
     with pytest.raises(InvalidSpecification) as exc_info:
-        Operation(method='GET', path='endpoint', operation=OPERATION5, app_produces=['application/json'],
-                  app_security=[], security_definitions={}, definitions={}, parameter_definitions=PARAMETER_DEFINITIONS,
+        Operation(method='GET', path='endpoint', path_parameters=[],
+                  operation=OPERATION5, app_produces=['application/json'],
+                  app_security=[], security_definitions={}, definitions={},
+                  parameter_definitions=PARAMETER_DEFINITIONS,
                   resolver=Resolver())
 
     exception = exc_info.value  # type: InvalidSpecification
@@ -419,8 +428,11 @@ def test_resolve_invalid_reference():
 
 def test_bad_default():
     with pytest.raises(InvalidSpecification) as exc_info:
-        Operation(method='GET', path='endpoint', operation=OPERATION6, app_produces=['application/json'],
-                  app_security=[], security_definitions={}, definitions=DEFINITIONS, parameter_definitions=PARAMETER_DEFINITIONS,
+        Operation(method='GET', path='endpoint', path_parameters=[],
+                  operation=OPERATION6, app_produces=['application/json'],
+                  app_security=[], security_definitions={},
+                  definitions=DEFINITIONS,
+                  parameter_definitions=PARAMETER_DEFINITIONS,
                   resolver=Resolver())
     exception = exc_info.value
     assert str(exception) == "<InvalidSpecification: The parameter 'stack_version' has a default value which " \
@@ -429,8 +441,10 @@ def test_bad_default():
                               "is not of type 'number'>"
 
     with pytest.raises(InvalidSpecification) as exc_info:
-        Operation(method='GET', path='endpoint', operation=OPERATION7, app_produces=['application/json'],
-                  app_security=[], security_definitions={}, definitions=DEFINITIONS, parameter_definitions={},
+        Operation(method='GET', path='endpoint', path_parameters=[],
+                  operation=OPERATION7, app_produces=['application/json'],
+                  app_security=[], security_definitions={},
+                  definitions=DEFINITIONS, parameter_definitions={},
                   resolver=Resolver())
     exception = exc_info.value
     assert str(exception) == "<InvalidSpecification: The parameter 'new_stack' has a default value which " \
@@ -440,8 +454,10 @@ def test_bad_default():
 
     with pytest.raises(InvalidSpecification) as exc_info:
         Operation(
-                method='GET', path='endpoint', operation=OPERATION8, app_produces=['application/json'],
-                app_security=[], security_definitions={}, definitions=DEFINITIONS, parameter_definitions={},
+                method='GET', path='endpoint', path_parameters=[],
+                operation=OPERATION8, app_produces=['application/json'],
+                app_security=[], security_definitions={},
+                definitions=DEFINITIONS, parameter_definitions={},
                 resolver=Resolver()
         )
     exception = exc_info.value
@@ -454,13 +470,15 @@ def test_bad_default():
 def test_default():
     op = OPERATION6.copy()
     op['parameters'][1]['default'] = 1
-    Operation(method='GET', path='endpoint', operation=op, app_produces=['application/json'], app_security=[],
-              security_definitions={}, definitions=DEFINITIONS, parameter_definitions=PARAMETER_DEFINITIONS,
+    Operation(method='GET', path='endpoint', path_parameters=[], operation=op,
+              app_produces=['application/json'], app_security=[],
+              security_definitions={}, definitions=DEFINITIONS,
+              parameter_definitions=PARAMETER_DEFINITIONS,
               resolver=Resolver())
     op = OPERATION8.copy()
     op['parameters'][0]['default'] = {
         'keep_stacks': 1, 'image_version': 'one', 'senza_yaml': 'senza.yaml', 'new_traffic': 100
     }
-    Operation(method='POST', path='endpoint', operation=op, app_produces=['application/json'],
+    Operation(method='POST', path='endpoint', path_parameters=[], operation=op, app_produces=['application/json'],
               app_security=[], security_definitions={}, definitions=DEFINITIONS, parameter_definitions={},
               resolver=Resolver())

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,4 +1,3 @@
-import pytest
 import connexion.app
 from connexion.resolver import Resolver
 from connexion.resolver import RestyResolver
@@ -20,6 +19,7 @@ def test_resty_get_function():
 def test_standard_resolve_x_router_controller():
     operation = Operation(method='GET',
                           path='endpoint',
+                          path_parameters=[],
                           operation={
                               'x-swagger-router-controller': 'fakeapi.hello',
                               'operationId': 'post_greeting',
@@ -36,6 +36,7 @@ def test_standard_resolve_x_router_controller():
 def test_resty_resolve_operation_id():
     operation = Operation(method='GET',
                           path='endpoint',
+                          path_parameters=[],
                           operation={
                               'operationId': 'fakeapi.hello.post_greeting',
                           },
@@ -51,6 +52,7 @@ def test_resty_resolve_operation_id():
 def test_resty_resolve_x_router_controller_with_operation_id():
     operation = Operation(method='GET',
                           path='endpoint',
+                          path_parameters=[],
                           operation={
                               'x-swagger-router-controller': 'fakeapi.hello',
                               'operationId': 'post_greeting',
@@ -67,6 +69,7 @@ def test_resty_resolve_x_router_controller_with_operation_id():
 def test_resty_resolve_x_router_controller_without_operation_id():
     operation = Operation(method='GET',
                           path='/hello/{id}',
+                          path_parameters=[],
                           operation={'x-swagger-router-controller': 'fakeapi.hello'},
                           app_produces=['application/json'],
                           app_security=[],
@@ -80,6 +83,7 @@ def test_resty_resolve_x_router_controller_without_operation_id():
 def test_resty_resolve_with_default_module_name():
     operation = Operation(method='GET',
                           path='/hello/{id}',
+                          path_parameters=[],
                           operation={},
                           app_produces=['application/json'],
                           app_security=[],
@@ -93,6 +97,7 @@ def test_resty_resolve_with_default_module_name():
 def test_resty_resolve_with_default_module_name_lowercase_verb():
     operation = Operation(method='get',
                           path='/hello/{id}',
+                          path_parameters=[],
                           operation={},
                           app_produces=['application/json'],
                           app_security=[],
@@ -106,6 +111,7 @@ def test_resty_resolve_with_default_module_name_lowercase_verb():
 def test_resty_resolve_with_default_module_name_will_translate_dashes_in_resource_name():
     operation = Operation(method='GET',
                           path='/foo-bar',
+                          path_parameters=[],
                           operation={},
                           app_produces=['application/json'],
                           app_security=[],
@@ -119,6 +125,7 @@ def test_resty_resolve_with_default_module_name_will_translate_dashes_in_resourc
 def test_resty_resolve_with_default_module_name_can_resolve_api_root():
     operation = Operation(method='GET',
                           path='/',
+                          path_parameters=[],
                           operation={},
                           app_produces=['application/json'],
                           app_security=[],
@@ -132,6 +139,7 @@ def test_resty_resolve_with_default_module_name_can_resolve_api_root():
 def test_resty_resolve_with_default_module_name_will_resolve_resource_root_get_as_search():
     operation = Operation(method='GET',
                           path='/hello',
+                          path_parameters=[],
                           operation={},
                           app_produces=['application/json'],
                           app_security=[],
@@ -145,6 +153,7 @@ def test_resty_resolve_with_default_module_name_will_resolve_resource_root_get_a
 def test_resty_resolve_with_default_module_name_and_x_router_controller_will_resolve_resource_root_get_as_search():
     operation = Operation(method='GET',
                           path='/hello',
+                          path_parameters=[],
                           operation={
                               'x-swagger-router-controller': 'fakeapi.hello',
                           },
@@ -160,6 +169,7 @@ def test_resty_resolve_with_default_module_name_and_x_router_controller_will_res
 def test_resty_resolve_with_default_module_name_will_resolve_resource_root_as_configured():
     operation = Operation(method='GET',
                           path='/hello',
+                          path_parameters=[],
                           operation={},
                           app_produces=['application/json'],
                           app_security=[],
@@ -173,6 +183,7 @@ def test_resty_resolve_with_default_module_name_will_resolve_resource_root_as_co
 def test_resty_resolve_with_default_module_name_will_resolve_resource_root_post_as_post():
     operation = Operation(method='POST',
                           path='/hello',
+                          path_parameters=[],
                           operation={},
                           app_produces=['application/json'],
                           app_security=[],

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ max-line-length=120
 exclude=connexion/__init__.py
 
 [tox]
-envlist=pypy,py27,py35
+envlist=pypy,py27,py34,py35
 
 [testenv]
 commands=python setup.py test


### PR DESCRIPTION
OpenAPI Specification allow [parameters definitions in path level](http://swagger.io/specification/#pathItemObject) of the API specification, but connexion did not support that. This PR adds support for that in Connexion.

### Additional changes
More clear error message when there is no parameter defined for a endpoint and the function expects an argument. Before user was just seeing a `TypeError` and it was very obscure to identify what was going on underneath.

Related to #48