### PR TITLE
App breaks if error adding operation raise exception

### DIFF
--- a/connexion/api.py
+++ b/connexion/api.py
@@ -150,11 +150,7 @@ class Api:
             for method, endpoint in methods.items():
                 if method == 'parameters':
                     continue
-                try:
-                    self.add_operation(method, path, endpoint, path_parameters)
-                except Exception:  # pylint: disable= W0703
-                    logger.exception('Failed to add operation for %s %s%s',
-                                     method.upper(), self.base_url, path)
+                self.add_operation(method, path, endpoint, path_parameters)
 
     def add_auth_on_not_found(self):
         """

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -156,10 +156,13 @@ class Api:
                 try:
                     self.add_operation(method, path, endpoint, path_parameters)
                 except Exception:  # pylint: disable= W0703
-                    logger.exception('Failed to add operation for %s %s%s',
-                                     method.upper(), self.base_url, path)
-                    if not self.debug:
+                    error_msg = 'Failed to add operation for {} {}{}'.format(
+                        method.upper(), self.base_url, path)
+                    if self.debug:
+                        logger.exception(error_msg)
+                    else:
                         import sys
+                        logger.error(error_msg)
                         et, ei, tb = sys.exc_info()
                         raise ei.with_traceback(tb)
 

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -35,8 +35,10 @@ class Api:
     Single API that corresponds to a flask blueprint
     """
 
-    def __init__(self, swagger_yaml_path, base_url=None, arguments=None, swagger_ui=None, swagger_path=None,
-                 swagger_url=None, validate_responses=False, resolver=resolver.Resolver(), auth_all_paths=False):
+    def __init__(self, swagger_yaml_path, base_url=None, arguments=None,
+                 swagger_ui=None, swagger_path=None, swagger_url=None,
+                 validate_responses=False, resolver=resolver.Resolver(),
+                 auth_all_paths=False, debug=False):
         """
         :type swagger_yaml_path: pathlib.Path
         :type base_url: str | None
@@ -45,16 +47,19 @@ class Api:
         :type swagger_path: string | None
         :type swagger_url: string | None
         :type auth_all_paths: bool
+        :type debug: bool
         :param resolver: Callable that maps operationID to a function
         """
+        self.debug = debug
         self.swagger_yaml_path = pathlib.Path(swagger_yaml_path)
-        logger.debug('Loading specification: %s', swagger_yaml_path, extra={'swagger_yaml': swagger_yaml_path,
-                                                                            'base_url': base_url,
-                                                                            'arguments': arguments,
-                                                                            'swagger_ui': swagger_ui,
-                                                                            'swagger_path': swagger_path,
-                                                                            'swagger_url': swagger_url,
-                                                                            'auth_all_paths': auth_all_paths})
+        logger.debug('Loading specification: %s', swagger_yaml_path,
+                     extra={'swagger_yaml': swagger_yaml_path,
+                            'base_url': base_url,
+                            'arguments': arguments,
+                            'swagger_ui': swagger_ui,
+                            'swagger_path': swagger_path,
+                            'swagger_url': swagger_url,
+                            'auth_all_paths': auth_all_paths})
         arguments = arguments or {}
         with swagger_yaml_path.open() as swagger_yaml:
             swagger_template = swagger_yaml.read()
@@ -150,7 +155,18 @@ class Api:
             for method, endpoint in methods.items():
                 if method == 'parameters':
                     continue
-                self.add_operation(method, path, endpoint, path_parameters)
+                try:
+                    self.add_operation(method, path, endpoint, path_parameters)
+                except Exception:  # pylint: disable= W0703
+                    logger.exception('Failed to add operation for %s %s%s',
+                                     method.upper(), self.base_url, path)
+                    if self.debug:
+                        import traceback
+                        traceback.print_exc()
+                    else:
+                        import sys
+                        et, ei, tb = sys.exec_info()
+                        raise ei.with_traceback(tb)
 
     def add_auth_on_not_found(self):
         """

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -158,10 +158,7 @@ class Api:
                 except Exception:  # pylint: disable= W0703
                     logger.exception('Failed to add operation for %s %s%s',
                                      method.upper(), self.base_url, path)
-                    if self.debug:
-                        import traceback
-                        traceback.print_exc()
-                    else:
+                    if not self.debug:
                         import sys
                         et, ei, tb = sys.exc_info()
                         raise ei.with_traceback(tb)

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -147,9 +147,7 @@ class Api:
 
             # search for parameters definitions in the path level
             # http://swagger.io/specification/#pathItemObject
-            path_parameters = []
-            if 'parameters' in methods:
-                path_parameters = methods['parameters']
+            path_parameters = methods.get('parameters', [])
 
             # TODO Error handling
             for method, endpoint in methods.items():
@@ -165,7 +163,7 @@ class Api:
                         traceback.print_exc()
                     else:
                         import sys
-                        et, ei, tb = sys.exec_info()
+                        et, ei, tb = sys.exc_info()
                         raise ei.with_traceback(tb)
 
     def add_auth_on_not_found(self):

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -127,7 +127,8 @@ class App:
                   swagger_url=swagger_url,
                   resolver=resolver,
                   validate_responses=validate_responses,
-                  auth_all_paths=auth_all_paths)
+                  auth_all_paths=auth_all_paths,
+                  debug=self.debug)
         self.app.register_blueprint(api.blueprint)
         return api
 

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -23,8 +23,10 @@ logger = logging.getLogger('connexion.app')
 
 
 class App:
-    def __init__(self, import_name, port=None, specification_dir='', server=None, arguments=None, auth_all_paths=False,
-                 debug=False, swagger_ui=True, swagger_path=None, swagger_url=None):
+    def __init__(self, import_name, port=None, specification_dir='',
+                 server=None, arguments=None, auth_all_paths=False,
+                 debug=False, swagger_ui=True, swagger_path=None,
+                 swagger_url=None):
         """
         :param import_name: the name of the application package
         :type import_name: str

--- a/tests/fakeapi/api.yaml
+++ b/tests/fakeapi/api.yaml
@@ -430,25 +430,6 @@ paths:
           schema:
             type: string
 
-  /test_not_implemented:
-    post:
-      summary: Returns empty response
-      description: Returns empty response
-      operationId: fakeapi.hello.test_not_implemented
-      parameters:
-        - name: new_stack
-          required: true
-          in: body
-          schema:
-            $ref: '#/definitions/new_stack'
-      produces:
-        - application/json
-      responses:
-        200:
-          description: goodbye response
-          schema:
-            type: string
-
   /test_parameter_validation:
     get:
       operationId: fakeapi.hello.test_parameter_validation

--- a/tests/fakeapi/module_with_error.py
+++ b/tests/fakeapi/module_with_error.py
@@ -1,0 +1,4 @@
+# This is a test file, please do not delete.
+# It is used by the test:
+#  - `test_operation.py:test_invalid_operation_does_stop_application_to_setup`
+from foo.bar import foobar  # noqa

--- a/tests/fakeapi/op_error_api.yaml
+++ b/tests/fakeapi/op_error_api.yaml
@@ -1,0 +1,17 @@
+swagger: "2.0"
+
+info:
+  title: "{{title}}"
+  version: "1.0"
+
+basePath: /v1.0
+
+paths:
+  /welcome:
+    get:
+      operationId: fakeapi.module_with_error.something
+      responses:
+        200:
+          description: greeting response
+          schema:
+            type: object

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,4 +27,11 @@ def test_template():
 
 def test_invalid_operation_does_stop_application_to_setup():
     with pytest.raises(AttributeError):
-        Api(TEST_FOLDER / "fakeapi/op_error_api.yaml", "/api/v1.0", {})
+        Api(TEST_FOLDER / "fakeapi/op_error_api.yaml", "/api/v1.0",
+            {'title': 'OK'})
+
+
+def test_invalid_operation_does_not_stop_application_in_debug_mode():
+    api = Api(TEST_FOLDER / "fakeapi/op_error_api.yaml", "/api/v1.0",
+              {'title': 'OK'}, debug=True)
+    assert api.specification['info']['title'] == 'OK'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,6 @@
 import pathlib
+
+import pytest
 from connexion.api import Api
 
 TEST_FOLDER = pathlib.Path(__file__).parent
@@ -21,3 +23,8 @@ def test_template():
 
     api2 = Api(TEST_FOLDER / "fakeapi/api.yaml", "/api/v1.0", {'title': 'other test'})
     assert api2.specification['info']['title'] == 'other test'
+
+
+def test_invalid_operation_does_stop_application_to_setup():
+    with pytest.raises(AttributeError):
+        Api(TEST_FOLDER / "fakeapi/op_error_api.yaml", "/api/v1.0", {})


### PR DESCRIPTION
Fixes #155.

Question is should we change that behaviour in Connexion? It is a breaking change since older versions would keep going even if the `operationId` is invalid.