### PR TITLE
make api.add_paths() exception handler work in python 2.7

### DIFF
--- a/connexion/api.py
+++ b/connexion/api.py
@@ -170,7 +170,7 @@ class Api:
                             raise et, "Fatal error found while addding '{}': {}".format(
                                         endpoint.get('operationId'),
                                         str(ei)), tb
-                                        
+
     def add_auth_on_not_found(self):
         """
         Adds a 404 error handler to authenticate and only expose the 404 status if the security validation pass.

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -165,12 +165,10 @@ class Api:
                         import sys
                         import six
                         et, ei, tb = sys.exc_info()
-                        if six.PY3:
-                            raise ei.with_traceback(tb)
-                        else:
-                            raise et, "Fatal error found while addding '{}': {}".format(
+                        message = "Fatal error found while addding '{}': {}".format(
                                         endpoint.get('operationId'),
-                                        str(ei)), tb
+                                        str(ei))
+                        six.reraise(et, message, exc_traceback=tb)
 
     def add_auth_on_not_found(self):
         """

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -168,7 +168,7 @@ class Api:
                         message = "Fatal error found while addding '{}': {}".format(
                                         endpoint.get('operationId'),
                                         str(ei))
-                        six.reraise(et, message, exc_traceback=tb)
+                        six.reraise(et, message, tb)
 
     def add_auth_on_not_found(self):
         """

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -169,7 +169,8 @@ class Api:
                         else:
                             raise et, "Fatal error found while addding '{}': {}".format(
                                         endpoint.get('operationId'),
-                                        str(ei) ), tb
+                                        str(ei)), tb
+                                        
     def add_auth_on_not_found(self):
         """
         Adds a 404 error handler to authenticate and only expose the 404 status if the security validation pass.

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -161,12 +161,15 @@ class Api:
                     if self.debug:
                         logger.exception(error_msg)
                     else:
-                        import sys
                         logger.error(error_msg)
+                        import sys
                         et, ei, tb = sys.exc_info()
-                        ei.__traceback__ = tb
-                        raise ei
-
+                        if sys.version_info[0] == 3:
+                            raise ei.with_traceback(tb)
+                        else:
+                            raise et, "Fatal error found while addding '{}': {}".format(
+                                        endpoint.get('operationId'),
+                                        str(ei) ), tb
     def add_auth_on_not_found(self):
         """
         Adds a 404 error handler to authenticate and only expose the 404 status if the security validation pass.

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -168,7 +168,7 @@ class Api:
                         message = "Fatal error found while addding '{}': {}".format(
                                         endpoint.get('operationId'),
                                         str(ei))
-                        six.reraise(et, message, tb)
+                        six.reraise(et, AttributeError(message), tb)
 
     def add_auth_on_not_found(self):
         """

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -164,7 +164,8 @@ class Api:
                         import sys
                         logger.error(error_msg)
                         et, ei, tb = sys.exc_info()
-                        raise ei.with_traceback(tb)
+                        ei.__traceback__ = tb
+                        raise ei
 
     def add_auth_on_not_found(self):
         """

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -163,8 +163,9 @@ class Api:
                     else:
                         logger.error(error_msg)
                         import sys
+                        import six
                         et, ei, tb = sys.exc_info()
-                        if sys.version_info[0] == 3:
+                        if six.PY3:
                             raise ei.with_traceback(tb)
                         else:
                             raise et, "Fatal error found while addding '{}': {}".format(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -25,13 +25,16 @@ def test_template():
     assert api2.specification['info']['title'] == 'other test'
 
 
+
 def test_invalid_operation_does_stop_application_to_setup():
-    with pytest.raises(AttributeError):
-        Api(TEST_FOLDER / "fakeapi/op_error_api.yaml", "/api/v1.0",
-            {'title': 'OK'})
+    with pytest.raises(AttributeError) as exc_info:
+        Api(TEST_FOLDER / "fakeapi/op_error_api.yaml", "/api/v1.0", {'title': 'OK'})
+
+    assert 'fakeapi.module_with_error.something' in str(exc_info.value)
+    # TODO: I would be nice to show the root cause or the import error of 'module_with_error' like this ?
+    #assert 'No module named foo.bar' in str(exc_info.value)
 
 
 def test_invalid_operation_does_not_stop_application_in_debug_mode():
-    api = Api(TEST_FOLDER / "fakeapi/op_error_api.yaml", "/api/v1.0",
-              {'title': 'OK'}, debug=True)
+    api = Api(TEST_FOLDER / "fakeapi/op_error_api.yaml", "/api/v1.0", {'title': 'OK'}, debug=True)
     assert api.specification['info']['title'] == 'OK'


### PR DESCRIPTION
The re-raising of the exception in this version fails in python 2.7raising an AttributeError since  "with_traceback" is know known.
using the ` ei.__traceback__ = tb` and than just raising `ie` again works fine in Python 2.7.
Note: I did not test this in Python 3, but I assume this should work just fine there to !