### PR TITLE
Remove usage of HTTP_TOKENINFO_URL environment variable

### DIFF
--- a/connexion/decorators/security.py
+++ b/connexion/decorators/security.py
@@ -37,12 +37,8 @@ def get_tokeninfo_url(security_definition):
     >>> get_tokeninfo_url({'x-tokenInfoUrl': 'foo'})
     'foo'
     '''
-    token_info_url = security_definition.get('x-tokenInfoUrl') or \
-        os.environ.get('HTTP_TOKENINFO_URL') or \
-        os.environ.get('TOKENINFO_URL')
-    # https://github.com/zalando/connexion/issues/148
-    if token_info_url and token_info_url == os.environ.get('HTTP_TOKENINFO_URL'):
-        logger.warn('The HTTP_TOKENINFO_URL environment variable is deprecated. Please use TOKENINFO_URL instead.')
+    token_info_url = (security_definition.get('x-tokenInfoUrl') or
+                      os.environ.get('TOKENINFO_URL'))
     return token_info_url
 
 

--- a/examples/oauth2/app.yaml
+++ b/examples/oauth2/app.yaml
@@ -24,7 +24,7 @@ securityDefinitions:
     flow: implicit
     authorizationUrl: https://example.com/oauth2/dialog
     # the token info URL is hardcoded for our mock_tokeninfo.py script
-    # you can also pass it as an environment variable HTTP_TOKENINFO_URL
+    # you can also pass it as an environment variable TOKENINFO_URL
     x-tokenInfoUrl: http://localhost:7979/tokeninfo
     scopes:
       uid: Unique identifier of the user accessing the service.

--- a/tests/decorators/test_security.py
+++ b/tests/decorators/test_security.py
@@ -14,9 +14,6 @@ def test_get_tokeninfo_url(monkeypatch):
     env['TOKENINFO_URL'] = 'issue-146'
     assert get_tokeninfo_url(security_def) == 'issue-146'
     logger.warn.assert_not_called()
-    env['HTTP_TOKENINFO_URL'] = 'foo'
-    assert get_tokeninfo_url(security_def) == 'foo'
-    logger.warn.assert_called_once_with('The HTTP_TOKENINFO_URL environment variable is deprecated. Please use TOKENINFO_URL instead.')
     logger.warn.reset_mock()
     security_def = {'x-tokenInfoUrl': 'bar'}
     assert get_tokeninfo_url(security_def) == 'bar'


### PR DESCRIPTION
Fixes 148.

# Description

Changes proposed in this pull request:

 - Remove all usages of the HTTP_TOKENINFO_URL environment variable