### PR TITLE
Attempt to convert string representation of the error back to a pytho…

### DIFF
--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -14,6 +14,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 # Decorators to change the return type of endpoints
 import functools
 import logging
+import ast
 from ..exceptions import NonConformingResponse
 from ..problem import problem
 from .validation import RequestBodyValidator
@@ -51,6 +52,9 @@ class ResponseValidator(BaseDecorator):
             v = RequestBodyValidator(schema)
             error = v.validate_schema(data, schema)
             if error:
+                if isinstance(error.response, list) and len(error.response) > 0:
+                    error_dict = ast.literal_eval(error.response[0])
+                    logger.debug('Validation error in response body was:\n{0}'.format(error_dict["detail"]))
                 raise NonConformingResponse("Response body does not conform to specification")
 
         if response_definition and response_definition.get("headers"):


### PR DESCRIPTION
So this is my proposal for enhancement #153

This is a second attempt - hopefully a clean commit following #171.

So the main difficulty is that RequestBodyValidator.validate_schema() returns a problem like so:

problem(400, 'Bad Request', str(exception))

So the exception is basically cast to a string - even though this is quite a complex python data structure in the case of these validation errors.

So my small tweak is to use the ast module to safely convert this string back to a python data structure. I then attempt a couple of sanity checks - it's a list with at least one item - and then pull the error dictionary out. Once I have this object I'm able to log the error in a way that is easier to read (for me at least!) than just logging the returned string representation of the error.

Do you think this is worth doing? Is it safe? I'm not too sure about what RequestBodyValidator is doing - handling the error from json-schema I assume?

Maybe the better way to solve this issue would be to alter the behaviour in RequestBodyValidator.validate_schema() to not blindy convert the retuned exception to a string? 
 
I've also not been able to test this properly under Python 3. It seems to work fine with 2.7 in my tests so far. Feedback welcomed :)