### PR TITLE
Remove assignment to prevent unexpected keyword argument 'port' error

### DIFF
--- a/connexion/app.py
+++ b/connexion/app.py
@@ -246,7 +246,7 @@ class App(object):
             wsgi_container = tornado.wsgi.WSGIContainer(self.app)
             http_server = tornado.httpserver.HTTPServer(wsgi_container, **options)
             http_server.listen(self.port)
-            logger.info('Listening on port %s..', port=self.port)
+            logger.info('Listening on port %s..', self.port)
             tornado.ioloop.IOLoop.instance().start()
         elif self.server == 'gevent':
             try:


### PR DESCRIPTION
When using the tornado web server, the following error was thrown: 

TypeError: _log() got an unexpected keyword argument 'port'

This is resolved by removing the assignment in the logging statement in the tornado section of the app run function.