### PR TITLE
Remove unecessary argument

### DIFF
--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -49,7 +49,7 @@ class ResponseValidator(BaseDecorator):
         if response_definition and response_definition.get("schema"):
             schema = response_definition.get("schema")
             v = RequestBodyValidator(schema)
-            error = v.validate_schema(data, schema)
+            error = v.validate_schema(data)
             if error:
                 raise NonConformingResponse("Response body does not conform to specification")
 

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -100,7 +100,7 @@ class RequestBodyValidator(object):
             data = flask.request.json
 
             logger.debug("%s validating schema...", flask.request.url)
-            error = self.validate_schema(data, self.schema)
+            error = self.validate_schema(data)
             if error and not self.has_default:
                 return error
 
@@ -109,13 +109,13 @@ class RequestBodyValidator(object):
 
         return wrapper
 
-    def validate_schema(self, data, schema):
+    def validate_schema(self, data):
         """
         :type schema: dict
         :rtype: flask.Response | None
         """
         try:
-            validate(data, schema, format_checker=draft4_format_checker)
+            validate(data, self.schema, format_checker=draft4_format_checker)
         except ValidationError as exception:
             return problem(400, 'Bad Request', str(exception))
 


### PR DESCRIPTION
Code cleaning. This remove an unnecessary argument in `decorators.py:RequestBodyValidator.validate_schema` method.

Changes proposed in this pull request:

 - Remove the argument `schema` which this value is already available in an instance attribute of `RequestBodyValidator`.

