### PR TITLE
Add support for responses as references

### DIFF
--- a/connexion/api.py
+++ b/connexion/api.py
@@ -103,6 +103,7 @@ class Api(object):
 
         self.definitions = self.specification.get('definitions', {})
         self.parameter_definitions = self.specification.get('parameters', {})
+        self.response_definitions = self.specification.get('responses', {})
 
         self.swagger_path = swagger_path or SWAGGER_UI_PATH
         self.swagger_url = swagger_url or SWAGGER_UI_URL
@@ -145,6 +146,7 @@ class Api(object):
                               operation=swagger_operation, app_produces=self.produces,
                               app_security=self.security, security_definitions=self.security_definitions,
                               definitions=self.definitions, parameter_definitions=self.parameter_definitions,
+                              response_definitions=self.response_definitions,
                               validate_responses=self.validate_responses, resolver=self.resolver)
         operation_id = operation.operation_id
         logger.debug('... Adding %s -> %s', method.upper(), operation_id, extra=vars(operation))

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -103,7 +103,7 @@ class Operation(SecureOperation):
 
     def __init__(self, method, path, path_parameters, operation, app_produces,
                  app_security, security_definitions, definitions,
-                 parameter_definitions, resolver, validate_responses=False):
+                 parameter_definitions, response_definitions, resolver, validate_responses=False):
         """
         This class uses the OperationID identify the module and function that will handle the operation
 
@@ -144,9 +144,11 @@ class Operation(SecureOperation):
         self.security_definitions = security_definitions
         self.definitions = definitions
         self.parameter_definitions = parameter_definitions
+        self.response_definitions = response_definitions
         self.definitions_map = {
             'definitions': self.definitions,
-            'parameters': self.parameter_definitions
+            'parameters': self.parameter_definitions,
+            'responses': self.response_definitions
         }
         self.validate_responses = validate_responses
         self.operation = operation
@@ -239,7 +241,7 @@ class Operation(SecureOperation):
             definitions = self.definitions_map[definition_type]
         except KeyError:
             raise InvalidSpecification(
-                "{method} {path}  '$ref' needs to point to definitions or parameters".format(**vars(self)))
+                "{method} {path}  '$ref' needs to point to definitions, parameters or responses".format(**vars(self)))
         definition_name = path[-1]
         try:
             # Get sub definition


### PR DESCRIPTION
Fixes # .180

# Adds support for global response definitions

Changes proposed in this pull request:

 -  Support global response definitions in the same way model definitions and parameter definitions are supported.
 -  Allow for validation of responses when `validate_response=True` for specifications that use global response definitions.

