### PR TITLE
Updated body validation error detail to be more easily human readable

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -117,7 +117,7 @@ class RequestBodyValidator(object):
         try:
             validate(data, self.schema, format_checker=draft4_format_checker)
         except ValidationError as exception:
-            return problem(400, 'Bad Request', str(exception))
+            return problem(400, 'Bad Request', str(exception.message))
 
         return None
 


### PR DESCRIPTION
The class documentation in problem.py indicates that the detail parameter should be "An human readable explanation specific to this occurrence of the problem."  I've updated the body validation code to issue a problem containing just the jsonschema ValidationError message instead of the entire exception object converted to a string.  

When using a large schema for a model that is being validated, this entire exception object renders the detail portion of the error message unusable for quick and easy debugging.