### PR TITLE
Better error handling for non-conforming responses

### DIFF
--- a/connexion/api.py
+++ b/connexion/api.py
@@ -16,8 +16,10 @@ import jinja2
 import json
 import logging
 import pathlib
-import yaml
+import six
+import sys
 import werkzeug.exceptions
+import yaml
 from swagger_spec_validator.validator20 import validate_spec
 from .operation import Operation
 from . import utils
@@ -181,10 +183,8 @@ class Api(object):
                     if self.debug:
                         logger.exception(error_msg)
                     else:
-                        import sys
                         logger.error(error_msg)
-                        et, ei, tb = sys.exc_info()
-                        raise ei.with_traceback(tb)
+                        six.reraise(*sys.exc_info())
 
     def add_auth_on_not_found(self):
         """

--- a/connexion/exceptions.py
+++ b/connexion/exceptions.py
@@ -32,15 +32,26 @@ class InvalidSpecification(ConnexionException):
 
 
 class NonConformingResponse(ConnexionException):
-    def __init__(self, reason='Unknown Reason'):
+    def __init__(self, reason='Unknown Reason', message=None):
         """
         :param reason: Reason why the response did not conform to the specification
         :type reason: str
         """
         self.reason = reason
+        self.message = message
 
     def __str__(self):  # pragma: no cover
         return '<NonConformingResponse: {}>'.format(self.reason)
 
     def __repr__(self):  # pragma: no cover
         return '<NonConformingResponse: {}>'.format(self.reason)
+
+
+class NonConformingResponseBody(NonConformingResponse):
+    def __init__(self, message, reason="Response body does not conform to specification"):
+        super(NonConformingResponseBody, self).__init__(reason=reason, message=message)
+
+
+class NonConformingResponseHeaders(NonConformingResponse):
+    def __init__(self, message, reason="Response headers do not conform to specification"):
+        super(NonConformingResponseHeaders, self).__init__(reason=reason, message=message)

--- a/tests/api/test_headers.py
+++ b/tests/api/test_headers.py
@@ -25,8 +25,8 @@ def test_header_not_returned(simple_app):
     assert response.content_type == 'application/problem+json'
     data = json.loads(response.data.decode('utf-8'))
     assert data['type'] == 'about:blank'
-    assert data['title'] == 'Internal Server Error'
-    assert data['detail'] == 'Response headers do not conform to specification'
+    assert data['title'] == 'Response headers do not conform to specification'
+    assert data['detail'] == "Keys in header don't match response specification. Difference: ['Location']"
     assert data['status'] == 500
 
 


### PR DESCRIPTION
Fixes #153 .

# Description

Changes proposed in this pull request:

 - let the validation error be a validation error
 - catch the validation error when validating the response
 - create exceptions for nonconforming body and headers and use them to differentiate between the different validation errors and to populate a problem response