### PR TITLE
Response definitions can be defined globally in spec

### DIFF
--- a/connexion/api.py
+++ b/connexion/api.py
@@ -103,6 +103,7 @@ class Api(object):
 
         self.definitions = self.specification.get('definitions', {})
         self.parameter_definitions = self.specification.get('parameters', {})
+        self.response_definitions = self.specification.get('responses', {})
 
         self.swagger_path = swagger_path or SWAGGER_UI_PATH
         self.swagger_url = swagger_url or SWAGGER_UI_URL
@@ -141,13 +142,21 @@ class Api(object):
         :type path: str
         :type swagger_operation: dict
         """
-        operation = Operation(method=method, path=path, path_parameters=path_parameters,
-                              operation=swagger_operation, app_produces=self.produces,
-                              app_security=self.security, security_definitions=self.security_definitions,
-                              definitions=self.definitions, parameter_definitions=self.parameter_definitions,
-                              validate_responses=self.validate_responses, resolver=self.resolver)
+        operation = Operation(method=method,
+                              path=path,
+                              path_parameters=path_parameters,
+                              operation=swagger_operation,
+                              app_produces=self.produces,
+                              app_security=self.security,
+                              security_definitions=self.security_definitions,
+                              definitions=self.definitions,
+                              parameter_definitions=self.parameter_definitions,
+                              response_definitions=self.response_definitions,
+                              validate_responses=self.validate_responses,
+                              resolver=self.resolver)
         operation_id = operation.operation_id
-        logger.debug('... Adding %s -> %s', method.upper(), operation_id, extra=vars(operation))
+        logger.debug('... Adding %s -> %s', method.upper(), operation_id,
+                     extra=vars(operation))
 
         flask_path = utils.flaskify_path(path, operation.get_path_parameter_types())
         self.blueprint.add_url_rule(flask_path, operation.endpoint_name, operation.function, methods=[method])

--- a/tests/api/test_schema.py
+++ b/tests/api/test_schema.py
@@ -223,3 +223,9 @@ def test_schema_int(schema_app):
     assert array_request.content_type == 'application/json'
     array_response = json.loads(array_request.data.decode())  # type: list
     assert array_response == 42
+
+
+def test_global_response_definitions(schema_app):
+    app_client = schema_app.app.test_client()
+    resp = app_client.get('/v1.0/define_global_response')
+    assert json.loads(resp.data.decode()) == ['general', 'list']

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -285,3 +285,7 @@ def test_default_missmatch_definition(age):
 
 def test_array_in_path(names):
     return names, 200
+
+
+def test_global_response_definition():
+    return ['general', 'list'], 200

--- a/tests/fixtures/different_schemas/swagger.yaml
+++ b/tests/fixtures/different_schemas/swagger.yaml
@@ -6,6 +6,14 @@ info:
 
 basePath: /v1.0
 
+responses:
+  GeneralList:
+    description: A nice string array
+    schema:
+      type: array
+      items:
+        type: string
+
 paths:
   /test_schema:
     post:
@@ -274,6 +282,14 @@ paths:
       responses:
         200:
           description: OK
+
+  /define_global_response:
+    get:
+      description: Should allow global response definitions
+      operationId: fakeapi.hello.test_global_response_definition
+      responses:
+        200:
+          $ref: '#/responses/GeneralList'
 
 definitions:
   new_stack:

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -371,8 +371,8 @@ def test_invalid_reference():
         operation.body_schema
 
     exception = exc_info.value
-    assert str(exception) == "<InvalidSpecification: GET endpoint  '$ref' needs to point to definitions or parameters>"
-    assert repr(exception) == "<InvalidSpecification: GET endpoint  '$ref' needs to point to definitions or parameters>"
+    assert str(exception).startswith("<InvalidSpecification: GET endpoint $ref")
+    assert repr(exception).startswith("<InvalidSpecification: GET endpoint $ref")
 
 
 def test_no_token_info():
@@ -423,7 +423,7 @@ def test_resolve_invalid_reference():
                   resolver=Resolver())
 
     exception = exc_info.value  # type: InvalidSpecification
-    assert exception.reason == "GET endpoint  '$ref' needs to start with '#/'"
+    assert exception.reason == "GET endpoint '$ref' needs to start with '#/'"
 
 
 def test_default():


### PR DESCRIPTION
Fixes #180 .

# Description
As described in [Swagger Specification](http://swagger.io/specification/#responsesDefinitionsObject) it is possible to define global responses to be used in endpoint specs.
 
Changes proposed in this pull request:

 - Added possibility to reference (exp.: `$ref: '#/responses/Something'`) responses defined globally in specification.