### PR TITLE
Allow files to be passed into handler

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -130,6 +130,15 @@ def parameter_to_arg(parameters, function):
                 else:
                     kwargs[key] = get_val_from_param(value, form_param)
 
+        # Add file parameters
+        file_arguments = flask.request.files
+        for key, value in file_arguments.items():
+            if key not in arguments:
+                logger.debug("File parameter (formData) '%s' not in function arguments", key)
+            else:
+                logger.debug("File parameter (formData) '%s' in function arguments", key)
+                kwargs[key] = value
+
         return function(*args, **kwargs)
 
     return wrapper

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -1,4 +1,5 @@
 import json
+from StringIO import StringIO
 
 
 def test_parameter_validation(simple_app):
@@ -102,10 +103,42 @@ def test_formdata_param(simple_app):
     assert response == 'test'
 
 
+def test_formdata_bad_request(simple_app):
+    app_client = simple_app.app.test_client()
+    resp = app_client.post('/v1.0/test-formData-param')
+    assert resp.status_code == 400
+    response = json.loads(resp.data.decode())
+    assert response['detail'] == "Missing formdata parameter 'formData'"
+
+
 def test_formdata_missing_param(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.post('/v1.0/test-formData-missing-param',
                            data={'missing_formData': 'test'})
+    assert resp.status_code == 200
+
+
+def test_formdata_file_upload(simple_app):
+    app_client = simple_app.app.test_client()
+    resp = app_client.post('/v1.0/test-formData-file-upload',
+                           data={'formData': (StringIO('file contents'), 'filename.txt')})
+    assert resp.status_code == 200
+    response = json.loads(resp.data.decode())
+    assert response == {'filename.txt': 'file contents'}
+
+
+def test_formdata_file_upload_bad_request(simple_app):
+    app_client = simple_app.app.test_client()
+    resp = app_client.post('/v1.0/test-formData-file-upload')
+    assert resp.status_code == 400
+    response = json.loads(resp.data.decode())
+    assert response['detail'] == "Missing formdata parameter 'formData'"
+
+
+def test_formdata_file_upload_missing_param(simple_app):
+    app_client = simple_app.app.test_client()
+    resp = app_client.post('/v1.0/test-formData-file-upload-missing-param',
+                           data={'missing_formData': (StringIO('file contents'), 'example.txt')})
     assert resp.status_code == 200
 
 

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -1,5 +1,5 @@
 import json
-from StringIO import StringIO
+from io import BytesIO
 
 
 def test_parameter_validation(simple_app):
@@ -121,7 +121,7 @@ def test_formdata_missing_param(simple_app):
 def test_formdata_file_upload(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.post('/v1.0/test-formData-file-upload',
-                           data={'formData': (StringIO('file contents'), 'filename.txt')})
+                           data={'formData': (BytesIO(b'file contents'), 'filename.txt')})
     assert resp.status_code == 200
     response = json.loads(resp.data.decode())
     assert response == {'filename.txt': 'file contents'}
@@ -138,7 +138,7 @@ def test_formdata_file_upload_bad_request(simple_app):
 def test_formdata_file_upload_missing_param(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.post('/v1.0/test-formData-file-upload-missing-param',
-                           data={'missing_formData': (StringIO('file contents'), 'example.txt')})
+                           data={'missing_formData': (BytesIO(b'file contents'), 'example.txt')})
     assert resp.status_code == 200
 
 

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -244,7 +244,7 @@ def test_formdata_missing_param():
 
 def test_formdata_file_upload(formData):
     filename = formData.filename
-    contents = formData.read()
+    contents = formData.read().decode('utf-8')
     return {filename: contents}
 
 

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -242,6 +242,16 @@ def test_formdata_missing_param():
     return ''
 
 
+def test_formdata_file_upload(formData):
+    filename = formData.filename
+    contents = formData.read()
+    return {filename: contents}
+
+
+def test_formdata_file_upload_missing_param():
+    return ''
+
+
 def test_bool_default_param(thruthiness):
     return thruthiness
 

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -334,6 +334,36 @@ paths:
         200:
           description: OK
 
+  /test-formData-file-upload:
+    post:
+      summary: Test formData with file type, for file upload
+      operationId: fakeapi.hello.test_formdata_file_upload
+      consumes:
+      - multipart/form-data
+      parameters:
+        - name: formData
+          type: file
+          in: formData
+          required: true
+      responses:
+        200:
+          description: OK
+
+  /test-formData-file-upload-missing-param:
+    post:
+      summary: Test formData with file type, missing parameter in handler
+      operationId: fakeapi.hello.test_formdata_file_upload_missing_param
+      consumes:
+      - multipart/form-data
+      parameters:
+        - name: missing_formData
+          type: file
+          in: formData
+          required: true
+      responses:
+        200:
+          description: OK
+
   /test-bool-param:
     get:
       summary: Test usage of boolean default value


### PR DESCRIPTION
Fixes #191.

# Description

Changes proposed in this pull request:

 - Pass files (which are of type FileStorage in werkzeug) from the flask request (`flask.request.files`) to the handler function. Previously these were dropped, as flask seems to take these out of the form data (`flask.request.form`).

 - This enables file uploads (via multipart/form mimetype) to work, and for the filelike FileStorage object to make it to the handler.

I haven't included any tests, but I've manually tested.