### PR TITLE
Make JSON printing a bit nicer

### DIFF
--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -124,7 +124,7 @@ class Jsonifier(BaseSerializer):
                 logger.debug('Endpoint returned an empty response (204)', extra={'url': url, 'mimetype': self.mimetype})
                 return '', 204, headers
 
-            data = json.dumps(data, indent=2)
+            data = [json.dumps(data, indent=2), '\n']
             response = flask.current_app.response_class(data, mimetype=self.mimetype)  # type: flask.Response
             response = self.process_headers(response, headers)
 

--- a/connexion/problem.py
+++ b/connexion/problem.py
@@ -46,7 +46,7 @@ def problem(status, title, detail, type='about:blank', instance=None, headers=No
     if ext:
         problem_response.update(ext)
 
-    body = json.dumps(problem_response)
+    body = [json.dumps(problem_response, indent=2), '\n']
     response = flask.current_app.response_class(body, mimetype='application/problem+json',
                                                 status=status)  # type: flask.Response
     if headers:

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -100,13 +100,13 @@ def test_single_route(simple_app):
 def test_resolve_method(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/resolver-test/method')  # type: flask.Response
-    assert resp.data.decode() == '"DummyClass"'
+    assert resp.data.decode() == '"DummyClass"\n'
 
 
 def test_resolve_classmethod(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/resolver-test/classmethod')  # type: flask.Response
-    assert resp.data.decode() == '"DummyClass"'
+    assert resp.data.decode() == '"DummyClass"\n'
 
 
 def test_add_api_with_function_resolver_function_is_wrapped(simple_api_spec_dir):

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -56,7 +56,7 @@ def test_array_query_param(simple_app):
 def test_path_parameter_someint(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-int-path/123')  # type: flask.Response
-    assert resp.data.decode() == '"int"'
+    assert resp.data.decode() == '"int"\n'
 
     # non-integer values will not match Flask route
     resp = app_client.get('/v1.0/test-int-path/foo')  # type: flask.Response
@@ -66,7 +66,7 @@ def test_path_parameter_someint(simple_app):
 def test_path_parameter_somefloat(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-float-path/123.45')  # type: flask.Response
-    assert resp.data.decode() == '"float"'
+    assert resp.data.decode() == '"float"\n'
 
     # non-float values will not match Flask route
     resp = app_client.get('/v1.0/test-float-path/123,45')  # type: flask.Response

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -11,7 +11,7 @@ def test_parameter_validator(monkeypatch):
     request.headers = {}
     request.params = {}
     app = MagicMock(name='app')
-    app.response_class = lambda a, mimetype, status: json.loads(a)['detail']
+    app.response_class = lambda a, mimetype, status: json.loads(''.join(a))['detail']
     monkeypatch.setattr('flask.request', request)
     monkeypatch.setattr('flask.current_app', app)
 


### PR DESCRIPTION
This change makes JSON generation more consistent and human-friendly:

- Adding a trailing newline is nicer to people using `curl` from the command line, without making the machine case worse.
- Add `indent=2` to errors so they are pretty printed as well.