### PR TITLE
Feature/option to disable swagger json

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -296,6 +296,21 @@ Swagger JSON
 Connexion makes the OpenAPI/Swagger specification in JSON format
 available from ``swagger.json`` in the base path of the API.
 
+You can disable the Swagger JSON at the application level:
+
+.. code-block:: python
+
+    app = connexion.App(__name__, specification_dir='swagger/',
+                        swagger_json=False)
+    app.add_api('my_api.yaml')
+
+You can also disable it at the API level:
+
+.. code-block:: python
+
+    app = connexion.App(__name__, specification_dir='swagger/')
+    app.add_api('my_api.yaml', swagger_json=False)
+
 HTTPS Support
 -------------
 

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -53,13 +53,14 @@ class Api(object):
     """
 
     def __init__(self, swagger_yaml_path, base_url=None, arguments=None,
-                 swagger_ui=None, swagger_path=None, swagger_url=None,
+                 swagger_json=None, swagger_ui=None, swagger_path=None, swagger_url=None,
                  validate_responses=False, resolver=resolver.Resolver(),
                  auth_all_paths=False, debug=False):
         """
         :type swagger_yaml_path: pathlib.Path
         :type base_url: str | None
         :type arguments: dict | None
+        :type swagger_json: bool
         :type swagger_ui: bool
         :type swagger_path: string | None
         :type swagger_url: string | None
@@ -118,7 +119,8 @@ class Api(object):
         # Create blueprint and endpoints
         self.blueprint = self.create_blueprint()
 
-        self.add_swagger_json()
+        if swagger_json:
+            self.add_swagger_json()
         if swagger_ui:
             self.add_swagger_ui()
 

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -25,7 +25,7 @@ logger = logging.getLogger('connexion.app')
 class App(object):
     def __init__(self, import_name, port=None, specification_dir='',
                  server=None, arguments=None, auth_all_paths=False,
-                 debug=False, swagger_ui=True, swagger_path=None,
+                 debug=False, swagger_json=True, swagger_ui=True, swagger_path=None,
                  swagger_url=None):
         """
         :param import_name: the name of the application package
@@ -42,6 +42,8 @@ class App(object):
         :type auth_all_paths: bool
         :param debug: include debugging information
         :type debug: bool
+        :param swagger_json: whether to include swagger json or not
+        :type swagger_json: bool
         :param swagger_ui: whether to include swagger ui or not
         :type swagger_ui: bool
         :param swagger_path: path to swagger-ui directory
@@ -72,6 +74,7 @@ class App(object):
         self.debug = debug
         self.import_name = import_name
         self.arguments = arguments or {}
+        self.swagger_json = swagger_json
         self.swagger_ui = swagger_ui
         self.swagger_path = swagger_path
         self.swagger_url = swagger_url
@@ -86,8 +89,9 @@ class App(object):
             exception = werkzeug.exceptions.InternalServerError()
         return problem(title=exception.name, detail=exception.description, status=exception.code)
 
-    def add_api(self, swagger_file, base_path=None, arguments=None, auth_all_paths=None, swagger_ui=None,
-                swagger_path=None, swagger_url=None, validate_responses=False, resolver=Resolver()):
+    def add_api(self, swagger_file, base_path=None, arguments=None, auth_all_paths=None, swagger_json=None,
+                swagger_ui=None, swagger_path=None, swagger_url=None, validate_responses=False,
+                resolver=Resolver()):
         """
         Adds an API to the application based on a swagger file
 
@@ -99,6 +103,8 @@ class App(object):
         :type arguments: dict | None
         :param auth_all_paths: whether to authenticate not defined paths
         :type auth_all_paths: bool
+        :param swagger_json: whether to include swagger json or not
+        :type swagger_json: bool
         :param swagger_ui: whether to include swagger ui or not
         :type swagger_ui: bool
         :param swagger_path: path to swagger-ui directory
@@ -113,6 +119,7 @@ class App(object):
         """
         resolver = Resolver(resolver) if hasattr(resolver, '__call__') else resolver
 
+        swagger_json = swagger_json if swagger_json is not None else self.swagger_json
         swagger_ui = swagger_ui if swagger_ui is not None else self.swagger_ui
         swagger_path = swagger_path if swagger_path is not None else self.swagger_path
         swagger_url = swagger_url if swagger_url is not None else self.swagger_url
@@ -124,6 +131,7 @@ class App(object):
         yaml_path = self.specification_dir / swagger_file
         api = Api(swagger_yaml_path=yaml_path,
                   base_url=base_path, arguments=arguments,
+                  swagger_json=swagger_json,
                   swagger_ui=swagger_ui,
                   swagger_path=swagger_path,
                   swagger_url=swagger_url,

--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -100,3 +100,18 @@ Swagger JSON
 ------------
 Connexion makes the OpenAPI/Swagger specification in JSON format
 available from ``swagger.json`` in the base path of the API.
+
+You can disable the Swagger JSON at the application level:
+
+.. code-block:: python
+
+    app = connexion.App(__name__, specification_dir='swagger/',
+                        swagger_json=False)
+    app.add_api('my_api.yaml')
+
+You can also disable it at the API level:
+
+.. code-block:: python
+
+    app = connexion.App(__name__, specification_dir='swagger/')
+    app.add_api('my_api.yaml', swagger_json=False)

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -17,7 +17,7 @@ def test_app_with_relative_path(simple_api_spec_dir):
     assert get_bye.data == b'Goodbye jsantos'
 
 
-def test_no_swagger(simple_api_spec_dir):
+def test_no_swagger_ui(simple_api_spec_dir):
     app = App(__name__, 5001, simple_api_spec_dir, swagger_ui=False, debug=True)
     app.add_api('swagger.yaml')
 
@@ -30,6 +30,46 @@ def test_no_swagger(simple_api_spec_dir):
     app2_client = app2.app.test_client()
     swagger_ui2 = app2_client.get('/v1.0/ui/')  # type: flask.Response
     assert swagger_ui2.status_code == 404
+
+
+def test_swagger_json_app(simple_api_spec_dir):
+    """ Verify the swagger.json file is returned for default setting passed to app. """
+    app = App(__name__, 5001, simple_api_spec_dir, debug=True)
+    app.add_api('swagger.yaml')
+
+    app_client = app.app.test_client()
+    swagger_json = app_client.get('/v1.0/swagger.json')  # type: flask.Response
+    assert swagger_json.status_code == 200
+
+
+def test_no_swagger_json_app(simple_api_spec_dir):
+    """ Verify the swagger.json file is not returned when set to False when creating app. """
+    app = App(__name__, 5001, simple_api_spec_dir, swagger_json=False, debug=True)
+    app.add_api('swagger.yaml')
+
+    app_client = app.app.test_client()
+    swagger_json = app_client.get('/v1.0/swagger.json')  # type: flask.Response
+    assert swagger_json.status_code == 404
+
+
+def test_swagger_json_api(simple_api_spec_dir):
+    """ Verify the swagger.json file is returned for default setting passed to api. """
+    app = App(__name__, 5001, simple_api_spec_dir, debug=True)
+    app.add_api('swagger.yaml')
+
+    app_client = app.app.test_client()
+    swagger_json = app_client.get('/v1.0/swagger.json')  # type: flask.Response
+    assert swagger_json.status_code == 200
+
+
+def test_no_swagger_json_api(simple_api_spec_dir):
+    """ Verify the swagger.json file is not returned when set to False when adding api. """
+    app = App(__name__, 5001, simple_api_spec_dir, debug=True)
+    app.add_api('swagger.yaml', swagger_json=False)
+
+    app_client = app.app.test_client()
+    swagger_json = app_client.get('/v1.0/swagger.json')  # type: flask.Response
+    assert swagger_json.status_code == 404
 
 
 def test_single_route(simple_app):


### PR DESCRIPTION
Adds an option to disable the swagger.json route when creating an app or adding an api.  You may not want this exposed, particularly if you've added security to your other routes.

Changes proposed in this pull request:
- adds swagger_json boolean to app and api with proper glue bits
- adds tests
- updates docs