### PR TITLE
Json encoder customization

### DIFF
--- a/connexion/app.py
+++ b/connexion/app.py
@@ -18,6 +18,7 @@ import werkzeug.exceptions
 from .problem import problem
 from .api import Api
 from connexion.resolver import Resolver
+from connexion.decorators.produces import JSONEncoder as ConnexionJSONEncoder
 
 logger = logging.getLogger('connexion.app')
 
@@ -52,6 +53,8 @@ class App(object):
         :type swagger_url: string | None
         """
         self.app = flask.Flask(import_name)
+
+        self.app.json_encoder = ConnexionJSONEncoder
 
         # we get our application root path from flask to avoid duplicating logic
         self.root_path = pathlib.Path(self.app.root_path)

--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -14,8 +14,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
 # Decorators to change the return type of endpoints
 import datetime
 import flask
+from flask import json
 import functools
-import json
 import logging
 from .decorator import BaseDecorator
 from ..utils import is_flask_response
@@ -124,7 +124,7 @@ class Jsonifier(BaseSerializer):
                 logger.debug('Endpoint returned an empty response (204)', extra={'url': url, 'mimetype': self.mimetype})
                 return '', 204, headers
 
-            data = json.dumps(data, indent=2, cls=JSONEncoder)
+            data = json.dumps(data, indent=2)
             response = flask.current_app.response_class(data, mimetype=self.mimetype)  # type: flask.Response
             response = self.process_headers(response, headers)
 

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -12,6 +12,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 """
 
 # Decorators to change the return type of endpoints
+from flask import json
 import functools
 import logging
 from ..exceptions import NonConformingResponseBody, NonConformingResponseHeaders
@@ -51,6 +52,11 @@ class ResponseValidator(BaseDecorator):
             schema = response_definition.get("schema")
             v = ResponseBodyValidator(schema)
             try:
+                # For cases of custom encoders, we need to encode and decode to
+                # transform to the actual types that are going to be returned.
+                data = json.dumps(data)
+                data = json.loads(data)
+
                 v.validate_schema(data)
             except ValidationError as e:
                 raise NonConformingResponseBody(message=str(e))

--- a/docs/response.rst
+++ b/docs/response.rst
@@ -12,6 +12,14 @@ for you and set the right content type in the HTTP header.
 If the endpoint produces a single non JSON mimetype then Connexion will
 automatically set the right content type in the HTTP header.
 
+Customizing JSON encoder
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Connexion allows you to customize the `JSONEncoder` class in the Flask app
+instance `json_encoder` (`connexion.App:app`). If you wanna reuse the
+Connexion's date-time sezialization, inherit your custom encoder from
+`connexion.decorators.produces.JSONEncoder`.
+
 Returning status codes
 ----------------------
 There are two ways of returning a specific status code.

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -1,5 +1,7 @@
 import json
 
+from connexion.decorators.produces import JSONEncoder
+
 
 def test_app(simple_app):
     assert simple_app.port == 5001
@@ -107,3 +109,21 @@ def test_default_object_body(simple_app):
     assert resp.status_code == 200
     response = json.loads(resp.data.decode())
     assert response == 1
+
+
+def test_custom_encoder(simple_app):
+
+    class CustomEncoder(JSONEncoder):
+        def default(self, o):
+            if o.__class__.__name__ == 'DummyClass':
+                return "cool result"
+            return JSONEncoder.default(self, o)
+
+    flask_app = simple_app.app
+    flask_app.json_encoder = CustomEncoder
+    app_client = flask_app.test_client()
+
+    resp = app_client.get('/v1.0/custom-json-response')
+    assert resp.status_code == 200
+    response = json.loads(resp.data.decode())
+    assert response['theResult'] == 'cool result'

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from decimal import Decimal
+
 from connexion import problem, request
 from connexion import NoContent
 from flask import redirect
@@ -317,3 +319,7 @@ def test_nullable_param_put(contents):
     if contents is None:
         return 'it was None'
     return contents
+
+
+def test_custom_json_response():
+    return {'theResult': DummyClass()}, 200

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -576,6 +576,20 @@ paths:
         200:
           description: OK
 
+  /custom-json-response:
+    get:
+      operationId: fakeapi.hello.test_custom_json_response
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              theResult:
+                type: string
+                description: the number we wanna test
 
 definitions:
   new_stack:


### PR DESCRIPTION
Fixes #196.

Connexion should remain as must compatible as possible with usual Flask applications. This PR adds back the support of developers to customize the [json_encoder](http://flask.pocoo.org/snippets/119/) in Connexion applications exactly as in pure Flask apps.

Changes proposed in this pull request:

 - Make use the flask [`JSONEncoder`](http://flask.pocoo.org/docs/0.10/api/#flask.json.JSONEncoder) internally in Connexion.
 - Relay on [`flask.Flask.json_encoder`](http://flask.pocoo.org/docs/0.10/api/#flask.Flask.json_encoder) for customization of encoding. This makes possible for users of Connexion to override the encoder they wanna use.
 - Adds documentation for this feature.