### PR TITLE
Real version is generated during release process

### DIFF
--- a/connexion/__init__.py
+++ b/connexion/__init__.py
@@ -13,13 +13,13 @@ Unless required by applicable law or agreed to in writing, software distributed 
  language governing permissions and limitations under the License.
 """
 
-from flask import abort, request, send_file, send_from_directory, render_template, render_template_string, \
-    url_for
-import werkzeug.exceptions as exceptions
-from .app import App
-from .api import Api
-from .problem import problem
-from .decorators.produces import NoContent
-from .resolver import Resolution, Resolver, RestyResolver
+from flask import (abort, request, send_file, send_from_directory,  # NOQA
+                   render_template, render_template_string, url_for)
+import werkzeug.exceptions as exceptions  # NOQA
+from .app import App  # NOQA
+from .api import Api  # NOQA
+from .problem import problem  # NOQA
+from .decorators.produces import NoContent  # NOQA
+from .resolver import Resolution, Resolver, RestyResolver  # NOQA
 
-__version__ = '1.0.33'
+__version__ = '0.0.0'  # Replaced during release process.

--- a/connexion/__init__.py
+++ b/connexion/__init__.py
@@ -22,4 +22,5 @@ from .problem import problem  # NOQA
 from .decorators.produces import NoContent  # NOQA
 from .resolver import Resolution, Resolver, RestyResolver  # NOQA
 
-__version__ = '0.0.0'  # Replaced during release process.
+# This version is replaced during release process.
+__version__ = '2016.0.dev1'


### PR DESCRIPTION
Fixes #194

Add placeholder and comment to avoid misunderstanding about versions in development mode.

Changes proposed in this pull request:

 - Change placeholder version to be `2016.0.dev1`
 - Add note to inform that versions are generated during release process.