### PR TITLE
Validate accordingly with content-type defined in spec

### DIFF
--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -88,7 +88,6 @@ class Produces(BaseSerializer):
                 logger.debug('Endpoint returned a Flask Response', extra={'url': url, 'mimetype': data.mimetype})
                 return data
 
-            data = str(data)
             response = flask.current_app.response_class(data, mimetype=self.mimetype)  # type: flask.Response
             response = self.process_headers(response, headers)
 

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -17,6 +17,7 @@ import functools
 import logging
 from ..exceptions import NonConformingResponseBody, NonConformingResponseHeaders
 from ..problem import problem
+from ..utils import produces_json
 from .validation import ResponseBodyValidator
 from .decorator import BaseDecorator
 from jsonschema import ValidationError
@@ -48,7 +49,9 @@ class ResponseValidator(BaseDecorator):
         response_definition = self.operation.resolve_reference(response_definition)
         # TODO handle default response definitions
 
-        if response_definition and response_definition.get("schema"):
+        if response_definition and "schema" in response_definition \
+           and (produces_json([self.mimetype]) or
+                self.mimetype == 'text/plain'):  # text/plain can also be validated with json schema
             schema = response_definition.get("schema")
             v = ResponseBodyValidator(schema)
             try:

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -97,6 +97,8 @@ class SecureOperation(object):
 
 
 class Operation(SecureOperation):
+    DEFAULT_MIMETYPE = 'application/json'
+
     """
     A single API operation on a path.
     """
@@ -265,16 +267,15 @@ class Operation(SecureOperation):
 
     def get_mimetype(self):
         # if the endpoint as no 'produces' then the default is 'application/json'
-        default_mimetype = 'application/json'
         if produces_json(self.produces):  # endpoint will return json
             try:
                 return self.produces[0]
             except IndexError:
-                return default_mimetype
+                return Operation.DEFAULT_MIMETYPE
         elif len(self.produces) == 1:
             return self.produces[0]
         else:
-            return default_mimetype
+            return Operation.DEFAULT_MIMETYPE
 
     def resolve_parameters(self, parameters):
         for param in parameters:

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -266,8 +266,13 @@ class Operation(SecureOperation):
         return definition
 
     def get_mimetype(self):
-        # if the endpoint as no 'produces' then the default is 'application/json'
-        if produces_json(self.produces):  # endpoint will return json
+        """
+        If the endpoint has no 'produces' then the default is
+        'application/json'.
+
+        :rtype str
+        """
+        if produces_json(self.produces):
             try:
                 return self.produces[0]
             except IndexError:

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -264,16 +264,17 @@ class Operation(SecureOperation):
         return definition
 
     def get_mimetype(self):
+        # if the endpoint as no 'produces' then the default is 'application/json'
+        default_mimetype = 'application/json'
         if produces_json(self.produces):  # endpoint will return json
             try:
                 return self.produces[0]
             except IndexError:
-                # if the endpoint as no 'produces' then the default is 'application/json'
-                return 'application/json'
+                return default_mimetype
         elif len(self.produces) == 1:
             return self.produces[0]
         else:
-            return None
+            return default_mimetype
 
     def resolve_parameters(self, parameters):
         for param in parameters:

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -1,4 +1,5 @@
 import json
+from struct import unpack
 
 from connexion.decorators.produces import JSONEncoder
 
@@ -127,3 +128,27 @@ def test_custom_encoder(simple_app):
     assert resp.status_code == 200
     response = json.loads(resp.data.decode())
     assert response['theResult'] == 'cool result'
+
+
+def test_content_type_not_json(simple_app):
+    app_client = simple_app.app.test_client()
+
+    resp = app_client.get('/v1.0/blob-response')
+    assert resp.status_code == 200
+
+    # validate binary content
+    text, number = unpack('!4sh', resp.data)
+    assert text == b'cool'
+    assert number == 8
+
+
+def test_maybe_blob_or_json(simple_app):
+    app_client = simple_app.app.test_client()
+
+    resp = app_client.get('/v1.0/binary-response')
+    assert resp.status_code == 200
+    assert resp.content_type == 'application/octet-stream'
+    # validate binary content
+    text, number = unpack('!4sh', resp.data)
+    assert text == b'cool'
+    assert number == 8

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from decimal import Decimal
-
 from connexion import problem, request
 from connexion import NoContent
 from flask import redirect
@@ -323,3 +321,11 @@ def test_nullable_param_put(contents):
 
 def test_custom_json_response():
     return {'theResult': DummyClass()}, 200
+
+
+def get_blob_data():
+    return b'cool\x00\x08'
+
+
+def get_data_as_binary():
+    return get_blob_data(), 200, {'Content-Type': 'application/octet-stream'}

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -591,6 +591,30 @@ paths:
                 type: string
                 description: the number we wanna test
 
+  /blob-response:
+    get:
+      operationId: fakeapi.hello.get_blob_data
+      produces:
+        - "application/octet-stream"
+      responses:
+        200:
+          description: Some blob response
+          schema:
+            type: string
+            format: binary
+
+  /binary-response:
+    get:
+      operationId: fakeapi.hello.get_data_as_binary
+      produces:
+        - "application/octet-stream"
+      responses:
+        200:
+          description: Everything is ok
+          schema:
+            type: string
+
+
 definitions:
   new_stack:
     type: object


### PR DESCRIPTION
Fixes #203

Connexion should validate the schema of responses that have content-type as JSON.

Changes proposed in this pull request:

 - Validate using json-schema only responses of operations that produces JSON.
 - Makes it possible for Connexion applications to return binary data in operations.