### PR TITLE
Reorganize imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,8 @@ python:
   - "3.4"
   - "3.5"
 install:
-  - pip install -e .
-  - pip install coveralls
-  - pip install flake8
+  - pip install tox tox-travis coveralls
 script:
-  - python setup.py test
-  - python setup.py flake8
+  - tox
 after_success:
   - coveralls

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -11,20 +11,21 @@ Unless required by applicable law or agreed to in writing, software distributed 
  language governing permissions and limitations under the License.
 """
 
-import flask
-import jinja2
 import json
 import logging
 import pathlib
-import six
 import sys
+
+import flask
+import jinja2
+import six
 import werkzeug.exceptions
 import yaml
 from swagger_spec_validator.validator20 import validate_spec
-from .operation import Operation
-from . import utils
-from . import resolver
+
+from . import resolver, utils
 from .handlers import AuthErrorHandler
+from .operation import Operation
 
 MODULE_PATH = pathlib.Path(__file__).absolute().parent
 SWAGGER_UI_PATH = MODULE_PATH / 'vendor' / 'swagger-ui'

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -13,12 +13,14 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 import logging
 import pathlib
+
 import flask
 import werkzeug.exceptions
-from .problem import problem
-from .api import Api
-from connexion.resolver import Resolver
 from connexion.decorators.produces import JSONEncoder as ConnexionJSONEncoder
+from connexion.resolver import Resolver
+
+from .api import Api
+from .problem import problem
 
 logger = logging.getLogger('connexion.app')
 

--- a/connexion/decorators/decorator.py
+++ b/connexion/decorators/decorator.py
@@ -11,7 +11,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
  language governing permissions and limitations under the License.
 """
 import logging
+
 import flask
+
 from ..utils import is_flask_response
 
 logger = logging.getLogger('connexion.decorators.decorator')

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -1,12 +1,13 @@
-import werkzeug.exceptions as exceptions
 import copy
-import flask
 import functools
 import inspect
 import logging
-import six
 
-from ..utils import boolean, is_nullable, is_null
+import flask
+import six
+import werkzeug.exceptions as exceptions
+
+from ..utils import boolean, is_null, is_nullable
 
 logger = logging.getLogger(__name__)
 

--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -13,12 +13,14 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 # Decorators to change the return type of endpoints
 import datetime
-import flask
-from flask import json
 import functools
 import logging
-from .decorator import BaseDecorator
+
+import flask
+from flask import json
+
 from ..utils import is_flask_response
+from .decorator import BaseDecorator
 
 logger = logging.getLogger('connexion.decorators.produces')
 

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -21,6 +21,7 @@ from jsonschema import ValidationError
 from ..exceptions import (NonConformingResponseBody,
                           NonConformingResponseHeaders)
 from ..problem import problem
+from ..utils import produces_json
 from .decorator import BaseDecorator
 from .validation import ResponseBodyValidator
 

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -12,16 +12,17 @@ Unless required by applicable law or agreed to in writing, software distributed 
 """
 
 # Decorators to change the return type of endpoints
-from flask import json
 import functools
 import logging
-from ..exceptions import NonConformingResponseBody, NonConformingResponseHeaders
-from ..problem import problem
-from ..utils import produces_json
-from .validation import ResponseBodyValidator
-from .decorator import BaseDecorator
+
+from flask import json
 from jsonschema import ValidationError
 
+from ..exceptions import (NonConformingResponseBody,
+                          NonConformingResponseHeaders)
+from ..problem import problem
+from .decorator import BaseDecorator
+from .validation import ResponseBodyValidator
 
 logger = logging.getLogger('connexion.decorators.response')
 

--- a/connexion/decorators/security.py
+++ b/connexion/decorators/security.py
@@ -13,11 +13,13 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 # Authentication and authorization related decorators
 
-from flask import request
 import functools
 import logging
 import os
+
 import requests
+from flask import request
+
 from ..problem import problem
 
 logger = logging.getLogger('connexion.api.security')

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -12,17 +12,19 @@ Unless required by applicable law or agreed to in writing, software distributed 
 """
 
 import copy
-import flask
 import functools
 import itertools
 import logging
-import six
 import sys
-from jsonschema import draft4_format_checker, validate, Draft4Validator, ValidationError
+
+import flask
+import six
+from jsonschema import (Draft4Validator, ValidationError,
+                        draft4_format_checker, validate)
 from werkzeug import FileStorage
 
 from ..problem import problem
-from ..utils import boolean, is_nullable, is_null
+from ..utils import boolean, is_null, is_nullable
 
 logger = logging.getLogger('connexion.decorators.validation')
 

--- a/connexion/handlers.py
+++ b/connexion/handlers.py
@@ -1,5 +1,6 @@
 
 import logging
+
 from .operation import SecureOperation
 from .problem import problem
 

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -232,9 +232,7 @@ class Operation(SecureOperation):
                     visited.add(v)
                     stack.append(self._retrieve_reference(v))
                 elif isinstance(v, (list, tuple)):
-                    for item in v:
-                        if hasattr(item, "items"):
-                            stack.append(item)
+                    continue
                 elif hasattr(v, "items"):
                     stack.append(v)
 

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -11,21 +11,23 @@ Unless required by applicable law or agreed to in writing, software distributed 
  language governing permissions and limitations under the License.
 """
 
-from copy import deepcopy
 import functools
 import logging
+from copy import deepcopy
 
 from jsonschema import ValidationError
 
 from .decorators import validation
 from .decorators.metrics import UWSGIMetricsCollector
 from .decorators.parameter import parameter_to_arg
-from .decorators.produces import BaseSerializer, Produces, Jsonifier
+from .decorators.produces import BaseSerializer, Jsonifier, Produces
 from .decorators.response import ResponseValidator
-from .decorators.security import security_passthrough, verify_oauth, get_tokeninfo_url
-from .decorators.validation import RequestBodyValidator, ParameterValidator, TypeValidationError
+from .decorators.security import (get_tokeninfo_url, security_passthrough,
+                                  verify_oauth)
+from .decorators.validation import (ParameterValidator, RequestBodyValidator,
+                                    TypeValidationError)
 from .exceptions import InvalidSpecification
-from .utils import flaskify_endpoint, produces_json, is_nullable
+from .utils import flaskify_endpoint, is_nullable, produces_json
 
 logger = logging.getLogger('connexion.operation')
 

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -343,7 +343,7 @@ class Operation(SecureOperation):
         logger.debug('... Adding security decorator (%r)', security_decorator, extra=vars(self))
         function = security_decorator(function)
 
-        if UWSGIMetricsCollector.is_available():
+        if UWSGIMetricsCollector.is_available():  # pragma: no cover
             decorator = UWSGIMetricsCollector(self.path, self.method)
             function = decorator(function)
 

--- a/connexion/problem.py
+++ b/connexion/problem.py
@@ -10,8 +10,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
  language governing permissions and limitations under the License.
 """
-import flask
 import json
+
+import flask
 
 
 def problem(status, title, detail, type='about:blank', instance=None, headers=None, ext=None):

--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -13,6 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 import logging
 import re
+
 import connexion.utils as utils
 
 logger = logging.getLogger('connexion.resolver')

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -14,6 +14,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 import functools
 import importlib
 import re
+
 import flask
 import werkzeug.wrappers
 

--- a/examples/basicauth/app.py
+++ b/examples/basicauth/app.py
@@ -11,6 +11,7 @@ Warning: It is recommended to use 'decorator' package to create decorators for
 
 import connexion
 import flask
+
 try:
     from decorator import decorator
 except ImportError:

--- a/examples/basicauth/app.py
+++ b/examples/basicauth/app.py
@@ -9,9 +9,8 @@ Warning: It is recommended to use 'decorator' package to create decorators for
          details please check: https://github.com/zalando/connexion/issues/142
 '''
 
-import flask
-
 import connexion
+import flask
 
 try:
     from decorator import decorator

--- a/examples/basicauth/app.py
+++ b/examples/basicauth/app.py
@@ -9,8 +9,9 @@ Warning: It is recommended to use 'decorator' package to create decorators for
          details please check: https://github.com/zalando/connexion/issues/142
 '''
 
-import connexion
 import flask
+
+import connexion
 
 try:
     from decorator import decorator

--- a/examples/oauth2/app.py
+++ b/examples/oauth2/app.py
@@ -3,9 +3,8 @@
 Basic example of a resource server
 '''
 
-import flask
-
 import connexion
+import flask
 
 
 def get_secret() -> str:

--- a/examples/oauth2/app.py
+++ b/examples/oauth2/app.py
@@ -3,8 +3,9 @@
 Basic example of a resource server
 '''
 
-import connexion
 import flask
+
+import connexion
 
 
 def get_secret() -> str:

--- a/examples/restyresolver/api/pets.py
+++ b/examples/restyresolver/api/pets.py
@@ -1,5 +1,6 @@
-from connexion import NoContent
 import datetime
+
+from connexion import NoContent
 
 pets = {}
 

--- a/examples/restyresolver/resty.py
+++ b/examples/restyresolver/resty.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
-import connexion
 import logging
+
+import connexion
 from connexion.resolver import RestyResolver
 
 logging.basicConfig(level=logging.INFO)

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -1,8 +1,7 @@
-from connexion.app import App
-from connexion.exceptions import InvalidSpecification
-
 import pytest
 from conftest import TEST_FOLDER, build_app_from_fixture
+from connexion.app import App
+from connexion.exceptions import InvalidSpecification
 
 
 def test_app_with_relative_path(simple_api_spec_dir):

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -1,7 +1,7 @@
-import pytest
-from connexion.exceptions import InvalidSpecification
 from connexion.app import App
+from connexion.exceptions import InvalidSpecification
 
+import pytest
 from conftest import TEST_FOLDER, build_app_from_fixture
 
 

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -1,7 +1,8 @@
-import pytest
-from conftest import TEST_FOLDER, build_app_from_fixture
 from connexion.app import App
 from connexion.exceptions import InvalidSpecification
+
+import pytest
+from conftest import TEST_FOLDER, build_app_from_fixture
 
 
 def test_app_with_relative_path(simple_api_spec_dir):

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -56,3 +56,7 @@ def test_errors(problem_app):
     assert error_problem2['detail'] == 'Something went wrong somewhere'
     assert error_problem2['status'] == 418
     assert error_problem2['instance'] == 'instance1'
+
+    problematic_json = app_client.get(
+        '/v1.0/json_response_with_undefined_value_to_serialize')  # type: flask.Response
+    assert problematic_json.status_code == 500

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -60,3 +60,9 @@ def test_errors(problem_app):
     problematic_json = app_client.get(
         '/v1.0/json_response_with_undefined_value_to_serialize')  # type: flask.Response
     assert problematic_json.status_code == 500
+
+    custom_problem = app_client.get('/v1.0/customized_problem_response')
+    assert custom_problem.status_code == 402
+    problem_body = json.loads(custom_problem.data.decode('utf-8'))
+    assert 'amount' in problem_body
+    assert problem_body['amount'] == 23.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,9 @@ import json
 import logging
 import pathlib
 
-import pytest
 from connexion.app import App
+
+import pytest
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,8 @@ import json
 import logging
 import pathlib
 
-from connexion.app import App
-
 import pytest
+from connexion.app import App
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
-import pathlib
 import json
 import logging
-import pytest
+import pathlib
 
 from connexion.app import App
+
+import pytest
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/tests/decorators/test_security.py
+++ b/tests/decorators/test_security.py
@@ -1,6 +1,5 @@
 from connexion.decorators.security import get_tokeninfo_url, verify_oauth
 from connexion.problem import problem
-
 from mock import MagicMock
 
 

--- a/tests/decorators/test_security.py
+++ b/tests/decorators/test_security.py
@@ -1,6 +1,7 @@
-from mock import MagicMock
 from connexion.decorators.security import get_tokeninfo_url, verify_oauth
 from connexion.problem import problem
+
+from mock import MagicMock
 
 
 def test_get_tokeninfo_url(monkeypatch):

--- a/tests/decorators/test_security.py
+++ b/tests/decorators/test_security.py
@@ -1,5 +1,6 @@
 from connexion.decorators.security import get_tokeninfo_url, verify_oauth
 from connexion.problem import problem
+
 from mock import MagicMock
 
 

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -328,3 +328,7 @@ def get_blob_data():
 
 def get_data_as_binary():
     return get_blob_data(), 200, {'Content-Type': 'application/octet-stream'}
+
+
+def get_invalid_response():
+    return {"simple": object()}

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
-from connexion import problem, request
-from connexion import NoContent
+from connexion import NoContent, problem, request
 from flask import redirect
 
 

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -332,3 +332,8 @@ def get_data_as_binary():
 
 def get_invalid_response():
     return {"simple": object()}
+
+
+def get_custom_problem_response():
+    return problem(402, "You need to pay", "Missing amount",
+                   ext={'amount': 23.0})

--- a/tests/fixtures/problem/swagger.yaml
+++ b/tests/fixtures/problem/swagger.yaml
@@ -71,3 +71,13 @@ paths:
           description: goodbye response
           schema:
             type: string
+
+  /json_response_with_undefined_value_to_serialize:
+    get:
+      description: Will fail
+      operationId: fakeapi.hello.get_invalid_response
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Never happens

--- a/tests/fixtures/problem/swagger.yaml
+++ b/tests/fixtures/problem/swagger.yaml
@@ -81,3 +81,13 @@ paths:
       responses:
         200:
           description: Never happens
+
+  /customized_problem_response:
+    get:
+      description: Custom problem response
+      operationId: fakeapi.hello.get_custom_problem_response
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Custom problem response

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,8 +1,7 @@
 import pathlib
 
-from connexion.api import Api
-
 import pytest
+from connexion.api import Api
 
 TEST_FOLDER = pathlib.Path(__file__).parent
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,8 @@
 import pathlib
 
-import pytest
 from connexion.api import Api
+
+import pytest
 
 TEST_FOLDER = pathlib.Path(__file__).parent
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,5 +1,4 @@
 from connexion.decorators.metrics import UWSGIMetricsCollector
-
 from mock import MagicMock
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,5 @@
 from connexion.decorators.metrics import UWSGIMetricsCollector
+
 from mock import MagicMock
 
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1,11 +1,12 @@
 import pathlib
 import types
 
-import pytest
 from connexion.decorators.security import security_passthrough, verify_oauth
 from connexion.exceptions import InvalidSpecification
 from connexion.operation import Operation
 from connexion.resolver import Resolver
+
+import pytest
 
 TEST_FOLDER = pathlib.Path(__file__).parent
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1,12 +1,11 @@
 import pathlib
 import types
 
+import pytest
 from connexion.decorators.security import security_passthrough, verify_oauth
 from connexion.exceptions import InvalidSpecification
 from connexion.operation import Operation
 from connexion.resolver import Resolver
-
-import pytest
 
 TEST_FOLDER = pathlib.Path(__file__).parent
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1,12 +1,12 @@
 import pathlib
 import types
 
-import pytest
-
 from connexion.decorators.security import security_passthrough, verify_oauth
 from connexion.exceptions import InvalidSpecification
 from connexion.operation import Operation
 from connexion.resolver import Resolver
+
+import pytest
 
 TEST_FOLDER = pathlib.Path(__file__).parent
 

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1,5 +1,6 @@
-import decorator
 from connexion.decorators.parameter import get_function_arguments
+
+import decorator
 
 
 @decorator.decorator

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1,6 +1,6 @@
-from connexion.decorators.parameter import get_function_arguments
-
 import decorator
+
+from connexion.decorators.parameter import get_function_arguments
 
 
 @decorator.decorator

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1,6 +1,6 @@
-import decorator
-
 from connexion.decorators.parameter import get_function_arguments
+
+import decorator
 
 
 @decorator.decorator

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,7 +1,6 @@
 import connexion.app
-from connexion.resolver import Resolver
-from connexion.resolver import RestyResolver
 from connexion.operation import Operation
+from connexion.resolver import Resolver, RestyResolver
 
 PARAMETER_DEFINITIONS = {'myparam': {'in': 'path', 'type': 'integer'}}
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,9 @@
 import math
 
-import pytest
-
 import connexion.app
 import connexion.utils as utils
+
+import pytest
 
 
 def test_flaskify_path():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import math
 
 import connexion.app
 import connexion.utils as utils
+
 import pytest
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,6 @@ import math
 
 import connexion.app
 import connexion.utils as utils
-
 import pytest
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,7 +1,6 @@
 import json
 
 from connexion.decorators.validation import ParameterValidator
-
 # we are using "mock" module here for Py 2.7 support
 from mock import MagicMock
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,7 @@
 import json
 
 from connexion.decorators.validation import ParameterValidator
+
 # we are using "mock" module here for Py 2.7 support
 from mock import MagicMock
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,8 +1,9 @@
 import json
-# we are using "mock" module here for Py 2.7 support
-from mock import MagicMock
 
 from connexion.decorators.validation import ParameterValidator
+
+# we are using "mock" module here for Py 2.7 support
+from mock import MagicMock
 
 
 def test_parameter_validator(monkeypatch):

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,8 +2,9 @@ import json
 import logging
 import pathlib
 
-import pytest
 from connexion.app import App
+
+import pytest
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,9 +2,8 @@ import json
 import logging
 import pathlib
 
-from connexion.app import App
-
 import pytest
+from connexion.app import App
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,9 +1,10 @@
-import pathlib
 import json
 import logging
-import pytest
+import pathlib
 
 from connexion.app import App
+
+import pytest
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,20 @@ max-line-length=120
 exclude=connexion/__init__.py
 
 [tox]
-envlist=pypy,py27,py34,py35,isort-check
+envlist=pypy,py27,py34,py35,isort-check,flake8
+
+[tox:travis]
+pypy=pypy
+2.7=py27
+3.4=py34
+3.5=py35,isort-check,flake8
 
 [testenv]
 commands=python setup.py test
+
+[testenv:flake8]
+deps=flake8
+commands=python setup.py flake8
 
 [testenv:isort-check]
 basepython=python3

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,12 @@ max-line-length=120
 exclude=connexion/__init__.py
 
 [tox]
-envlist=pypy,py27,py34,py35
+envlist=pypy,py27,py34,py35,isort-check
 
 [testenv]
 commands=python setup.py test
+
+[testenv:isort-check]
+basepython=python3
+deps=isort
+commands=isort -ns __init__.py -rc {toxinidir}/connexion {toxinidir}/examples {toxinidir}/tests

--- a/tox.ini
+++ b/tox.ini
@@ -11,4 +11,4 @@ commands=python setup.py test
 [testenv:isort-check]
 basepython=python3
 deps=isort
-commands=isort -ns __init__.py -rc {toxinidir}/connexion {toxinidir}/examples {toxinidir}/tests
+commands=isort -ns __init__.py -rc -c {toxinidir}/connexion {toxinidir}/examples {toxinidir}/tests


### PR DESCRIPTION
We had many different ways to organize our imports until now. I think it is nice to adopt a common way to write our imports and even better have it automatically fixed.

Changes proposed in this pull request:

 - Ran the `isort` development tool to reorganise our imports automatically
 - Added the isort check step into the `tox` tests pipeline (`$ tox -e isort-check`)
 - Use `tox` tool in travis testing pipeline
 - Set 100% test coverage