### PR TITLE
Do not provide too much detailed information on unauthorized access

### DIFF
--- a/connexion/decorators/security.py
+++ b/connexion/decorators/security.py
@@ -1,18 +1,3 @@
-"""
-Copyright 2015 Zalando SE
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
-License. You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
- language governing permissions and limitations under the License.
-"""
-
-# Authentication and authorization related decorators
-
 import functools
 import logging
 import os
@@ -69,18 +54,20 @@ def verify_oauth(token_info_url, allowed_scopes, function):
         logger.debug("%s Oauth verification...", request.url)
         authorization = request.headers.get('Authorization')  # type: str
         if not authorization:
-            logger.info("... No auth provided. Aborting with 401.")
-            return problem(401, 'Unauthorized', "No authorization token provided")
+            logger.debug("... No auth provided. Aborting with 401.")
+            return problem(401, 'Unauthorized', '')
         else:
             try:
                 _, token = authorization.split()  # type: str, str
             except ValueError:
-                return problem(401, 'Unauthorized', 'Invalid authorization header')
+                logger.debug("... Invalid authorization header. Aborting with 401.")
+                return problem(401, 'Unauthorized', '')
             logger.debug("... Getting token '%s' from %s", token, token_info_url)
             token_request = session.get(token_info_url, params={'access_token': token}, timeout=5)
             logger.debug("... Token info (%d): %s", token_request.status_code, token_request.text)
             if not token_request.ok:
-                return problem(401, 'Unauthorized', "Provided oauth token is not valid")
+                logger.debug("... Provided oauth token is not valid. Aborting with 401.")
+                return problem(401, 'Unauthorized', '')
             token_info = token_request.json()  # type: dict
             user_scopes = set(token_info['scope'])
             scopes_intersection = user_scopes & allowed_scopes

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,4 +33,3 @@ Contents:
 .. _Flask: http://flask.pocoo.org/
 .. _OpenAPI 2.0 Specification: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md
 .. _YAML format: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#format
-


### PR DESCRIPTION
Connexion is giving too much information to unauthorized entities trying to access the Connexion secured applications. 

In my opinion a malicious user could investigate, with "debugging" level detail, how the authentication is being handled inside the applications secured by Connexion.

Changes proposed in this pull request:
 - Removed the debugging messages related to authentication of requests.
 - Moved the messages to proper debug logging.
