### PR TITLE
Add __call__ method for WSGI-compliance

### DIFF
--- a/connexion/app.py
+++ b/connexion/app.py
@@ -271,8 +271,8 @@ class App(object):
             http_server.serve_forever()
         else:
             raise Exception('Server %s not recognized', self.server)
- 
-    def __call__(self, environ, start_response):
+
+    def __call__(self, environ, start_response):  # pragma: no cover
         """
         Makes the class callable to be WSGI-compliant. As Flask is used to handle requests,
         this is a passthrough-call to the Flask callable class.

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -271,12 +271,11 @@ class App(object):
             http_server.serve_forever()
         else:
             raise Exception('Server %s not recognized', self.server)
-            
+ 
     def __call__(self, environ, start_response):
         """
         Makes the class callable to be WSGI-compliant. As Flask is used to handle requests,
         this is a passthrough-call to the Flask callable class.
-        
         This is an abstraction to avoid directly referencing the app attribute from outside the
         class and protect it from unwanted modification.
         """

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -271,3 +271,13 @@ class App(object):
             http_server.serve_forever()
         else:
             raise Exception('Server %s not recognized', self.server)
+            
+    def __call__(self, environ, start_response):
+         """
+        Makes the class callable to be WSGI-compliant. As Flask is used to handle requests,
+        this is a passthrough-call to the Flask callable class.
+        
+        This is an abstraction to avoid directly referencing the app attribute from outside the
+        class and protect it from unwanted modification.
+        """
+        return self.app(environ, start_response)

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -273,7 +273,7 @@ class App(object):
             raise Exception('Server %s not recognized', self.server)
             
     def __call__(self, environ, start_response):
-         """
+        """
         Makes the class callable to be WSGI-compliant. As Flask is used to handle requests,
         this is a passthrough-call to the Flask callable class.
         


### PR DESCRIPTION
Changes proposed in this pull request:

WSGI standard requires the handler to be callable - so either be a method or implement __call__. Currently, in order to use Connexion apps with a WSGI handler, one would have to directly pass the MyApp.app attribute instead of the MyApp instance of the connexion.App class. 

Such behaviour should be discouraged as it can lead to unwanted modification of the attribute and limits the amount of backwards-compatible changes possible in the future. Also, the current implementation leads to unwanted side-effects on IIS / wfastcgi.py which is used on the Azure platform.

This small change makes the App class WSGI-compliant and reduces the use of directly referencing the app attribute from outside the class, which should be considered unsafe.