### PR TITLE
Copy spec before validation occurs

### DIFF
--- a/connexion/api.py
+++ b/connexion/api.py
@@ -11,11 +11,11 @@ Unless required by applicable law or agreed to in writing, software distributed 
  language governing permissions and limitations under the License.
 """
 
+import copy
 import json
 import logging
 import pathlib
 import sys
-import copy
 
 import flask
 import jinja2
@@ -88,9 +88,10 @@ class Api(object):
 
         logger.debug('Read specification', extra=self.specification)
 
+        self.specification = compatibility_layer(self.specification)
         # Avoid validator having ability to modify specification
         spec = copy.deepcopy(self.specification)
-        validate_spec(compatibility_layer(spec))
+        validate_spec(spec)
 
         # https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#fixed-fields
         # If base_url is not on provided then we try to read it from the swagger.yaml or use / by default

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -15,6 +15,7 @@ import json
 import logging
 import pathlib
 import sys
+import copy
 
 import flask
 import jinja2
@@ -87,7 +88,9 @@ class Api(object):
 
         logger.debug('Read specification', extra=self.specification)
 
-        validate_spec(compatibility_layer(self.specification))
+        # Avoid validator having ability to modify specification
+        spec = copy.deepcopy(self.specification)
+        validate_spec(compatibility_layer(spec))
 
         # https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#fixed-fields
         # If base_url is not on provided then we try to read it from the swagger.yaml or use / by default


### PR DESCRIPTION
Fixes #214 

Changes proposed in this pull request:
 - Copies the spec and passes the copy to validator instead of passing the original spec used later in the code