### PR TITLE
Defer user error handing for swagger spec validator

### DIFF
--- a/connexion/api.py
+++ b/connexion/api.py
@@ -17,10 +17,9 @@ import logging
 import pathlib
 import sys
 
-import six
-
 import flask
 import jinja2
+import six
 import werkzeug.exceptions
 import yaml
 from swagger_spec_validator.validator20 import validate_spec

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -17,9 +17,10 @@ import logging
 import pathlib
 import sys
 
+import six
+
 import flask
 import jinja2
-import six
 import werkzeug.exceptions
 import yaml
 from swagger_spec_validator.validator20 import validate_spec
@@ -40,12 +41,16 @@ def compatibility_layer(spec):
     # Make all response codes be string
     for path_name, methods_available in spec.get('paths', {}).items():
         for method_name, method_def in methods_available.items():
-            if method_name == 'parameters':
+            if (method_name == 'parameters'
+                or not isinstance(method_def, dict)):
                 continue
+
             response_definitions = {}
-            for response_code, response_def in method_def.get('responses', {}).items():
+            for response_code, response_def in method_def.get(
+                    'responses', {}).items():
                 response_definitions[str(response_code)] = response_def
-                method_def['responses'] = response_definitions
+
+            method_def['responses'] = response_definitions
     return spec
 
 

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -41,8 +41,8 @@ def compatibility_layer(spec):
     # Make all response codes be string
     for path_name, methods_available in spec.get('paths', {}).items():
         for method_name, method_def in methods_available.items():
-            if (method_name == 'parameters'
-                or not isinstance(method_def, dict)):
+            if (method_name == 'parameters' or not isinstance(
+                    method_def, dict)):
                 continue
 
             response_definitions = {}

--- a/tests/fixtures/invalid_schema/swagger.yaml
+++ b/tests/fixtures/invalid_schema/swagger.yaml
@@ -1,0 +1,12 @@
+swagger: "2.0"
+
+info:
+  title: "Bar"
+  version: "1.0"
+
+basePath: /v1.0
+
+paths:
+  /foobar:
+    post:
+      invalidValue

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,8 +1,8 @@
 import pathlib
 
-from connexion.api import Api
-
 import pytest
+from connexion.api import Api
+from swagger_spec_validator.common import SwaggerValidationError
 
 TEST_FOLDER = pathlib.Path(__file__).parent
 
@@ -36,3 +36,13 @@ def test_invalid_operation_does_not_stop_application_in_debug_mode():
     api = Api(TEST_FOLDER / "fakeapi/op_error_api.yaml", "/api/v1.0",
               {'title': 'OK'}, debug=True)
     assert api.specification['info']['title'] == 'OK'
+
+
+def test_invalid_schema_file_structure():
+    try:
+        api = Api(TEST_FOLDER / "fixtures/invalid_schema/swagger.yaml", "/api/v1.0",
+                  {'title': 'OK'}, debug=True)
+    except SwaggerValidationError:
+        pass
+    else:
+        pytest.fail("Validation of swagger schema should had failed for this invalid spec.")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,8 +1,9 @@
 import pathlib
 
-import pytest
 from connexion.api import Api
 from swagger_spec_validator.common import SwaggerValidationError
+
+import pytest
 
 TEST_FOLDER = pathlib.Path(__file__).parent
 


### PR DESCRIPTION
Fixes #220

If a developer write an invalid Swagger spec the `compatibility_layer` function was failing to navigate through the invalid spec structure misleading to an error in Connexion instead of exposing the invalid Swagger spec structure. Now we defer the handing of the error to the swagger spec validator.

Changes proposed in this pull request:

 - Verify if the method definition is a dict before calling `.get` in `compatibility_layer` function.