### PR TITLE
Cleanup decorators

### DIFF
--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -66,10 +66,12 @@ class ResponseValidator(BaseDecorator):
 
         if response_definition and response_definition.get("headers"):
             response_definition_header_keys = response_definition.get("headers").keys()
-            if not all(item in headers.keys() for item in response_definition_header_keys):
-                raise NonConformingResponseHeaders(
-                    message="Keys in header don't match response specification. Difference: %s"
-                    % list(set(headers.keys()).symmetric_difference(set(response_definition_header_keys))))
+            missing_keys = response_definition_header_keys - headers.keys()
+            if missing_keys:
+                pretty_list = ', '.join(missing_keys)
+                msg = ("Keys in header don't match response specification. "
+                       "Difference: {0}").format(pretty_list)
+                raise NonConformingResponseHeaders(message=msg)
         return True
 
     def is_json_schema_compatible(self, response_definition):

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -65,8 +65,10 @@ class ResponseValidator(BaseDecorator):
                 raise NonConformingResponseBody(message=str(e))
 
         if response_definition and response_definition.get("headers"):
-            response_definition_header_keys = response_definition.get("headers").keys()
-            missing_keys = response_definition_header_keys - headers.keys()
+            # converting to set is needed to support python 2.7
+            response_definition_header_keys = set(response_definition.get("headers").keys())
+            header_keys = set(headers.keys())
+            missing_keys = response_definition_header_keys - header_keys
             if missing_keys:
                 pretty_list = ', '.join(missing_keys)
                 msg = ("Keys in header don't match response specification. "

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -126,7 +126,8 @@ class RequestBodyValidator(object):
         try:
             validate(data, self.schema, format_checker=draft4_format_checker)
         except ValidationError as exception:
-            logger.error("%s validation error: %s" % (flask.request.url, exception))
+            logger.error("{url} validation error: {error}".format(url=flask.request.url,
+                                                                  error=exception))
             return problem(400, 'Bad Request', str(exception))
 
         return None
@@ -149,7 +150,8 @@ class ResponseBodyValidator(object):
         try:
             validate(data, self.schema, format_checker=draft4_format_checker)
         except ValidationError as exception:
-            logger.error("%s validation error: %s" % (flask.request.url, exception))
+            logger.error("{url} validation error: {error}".format(url=flask.request.url,
+                                                                  error=exception))
             six.reraise(*sys.exc_info())
 
         return None

--- a/tests/api/test_headers.py
+++ b/tests/api/test_headers.py
@@ -26,7 +26,7 @@ def test_header_not_returned(simple_app):
     data = json.loads(response.data.decode('utf-8'))
     assert data['type'] == 'about:blank'
     assert data['title'] == 'Response headers do not conform to specification'
-    assert data['detail'] == "Keys in header don't match response specification. Difference: ['Location']"
+    assert data['detail'] == "Keys in header don't match response specification. Difference: Location"
     assert data['status'] == 500
 
 


### PR DESCRIPTION
See https://www.quantifiedcode.com/app/project/6ca6bc4af4224f4586a74658f551a64f?groups=code_patterns%3A4ACGxFj1

I replaced the old style `%` format with the new (? is 9 years still "new") style format and made the header comparison easier to read and understand, while avoiding needless conversions to `set`.