### PR TITLE
Validate parameter list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ allows you to write a Swagger specification, then maps the
 endpoints to your Python functions; this makes it unique, as many tools generate the specification based on your Python
 code. You can describe your REST API in as much detail as
 you want; then Connexion guarantees that it will work as
-you specified. 
+you specified.
 
 We built Connexion this way in order to:
 
@@ -65,7 +65,7 @@ With Connexion, you write the spec first. Connexion then calls your Python
 code, handling the mapping from the specification to the code. This
 incentivizes you to write the specification so that all of your
 developers can understand what your API does, even before you write a
-single line of code. 
+single line of code.
 
 If multiple teams depend on your APIs, you can use Connexion to easily send them the documentation of your API. This guarantees that your API will follow the specification that you wrote. This is a different process from that offered by frameworks such as Hug_, which generates a specification *after* you've written the code. Some disadvantages of generating specifications based on code is that they often end up lacking details or mix your documentation with the code logic of your application.
 
@@ -271,6 +271,18 @@ available type castings are:
 If you use the `array` type In the Swagger definition, you can define the
 `collectionFormat` so that it won't be recognized. Connexion currently
 supports collection formats "pipes" and "csv". The default format is "csv".
+
+Parameter validation
+^^^^^^^^^^^^^^^^^^^^
+
+Connexion can apply strict parameter validation for query and form data
+parameters.  When this is enabled, requests that include parameters not defined
+in the swagger spec return a 400 error.  You can enable it when adding the API
+to your application:
+
+.. code-block:: python
+
+    app.add_api('my_apy.yaml', strict_validation=True)
 
 API Versioning and basePath
 ---------------------------

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -62,7 +62,7 @@ class Api(object):
 
     def __init__(self, swagger_yaml_path, base_url=None, arguments=None,
                  swagger_json=None, swagger_ui=None, swagger_path=None, swagger_url=None,
-                 validate_responses=False, resolver=resolver.Resolver(),
+                 validate_responses=False, strict_validation=False, resolver=resolver.Resolver(),
                  auth_all_paths=False, debug=False):
         """
         :type swagger_yaml_path: pathlib.Path
@@ -72,6 +72,8 @@ class Api(object):
         :type swagger_ui: bool
         :type swagger_path: string | None
         :type swagger_url: string | None
+        :type validate_responses: bool
+        :type strict_validation: bool
         :type auth_all_paths: bool
         :type debug: bool
         :param resolver: Callable that maps operationID to a function
@@ -132,6 +134,9 @@ class Api(object):
         logger.debug('Validate Responses: %s', str(validate_responses))
         self.validate_responses = validate_responses
 
+        logger.debug('Strict Request Validation: %s', str(validate_responses))
+        self.strict_validation = strict_validation
+
         # Create blueprint and endpoints
         self.blueprint = self.create_blueprint()
 
@@ -173,6 +178,7 @@ class Api(object):
                               parameter_definitions=self.parameter_definitions,
                               response_definitions=self.response_definitions,
                               validate_responses=self.validate_responses,
+                              strict_validation=self.strict_validation,
                               resolver=self.resolver)
         operation_id = operation.operation_id
         logger.debug('... Adding %s -> %s', method.upper(), operation_id,

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -96,7 +96,7 @@ class App(object):
 
     def add_api(self, swagger_file, base_path=None, arguments=None, auth_all_paths=None, swagger_json=None,
                 swagger_ui=None, swagger_path=None, swagger_url=None, validate_responses=False,
-                resolver=Resolver()):
+                strict_validation=False, resolver=Resolver()):
         """
         Adds an API to the application based on a swagger file
 
@@ -118,6 +118,8 @@ class App(object):
         :type swagger_url: string | None
         :param validate_responses: True enables validation. Validation errors generate HTTP 500 responses.
         :type validate_responses: bool
+        :param strict_validation: True enables validation on invalid request parameters
+        :type strict_validation: bool
         :param resolver: Operation resolver.
         :type resolver: Resolver | types.FunctionType
         :rtype: Api
@@ -142,6 +144,7 @@ class App(object):
                   swagger_url=swagger_url,
                   resolver=resolver,
                   validate_responses=validate_responses,
+                  strict_validation=strict_validation,
                   auth_all_paths=auth_all_paths,
                   debug=self.debug)
         self.app.register_blueprint(api.blueprint)

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -169,10 +169,12 @@ class ResponseBodyValidator(object):
 
 
 class ParameterValidator(object):
-    def __init__(self, parameters):
+    def __init__(self, parameters, strict_validation=False):
         self.parameters = collections.defaultdict(list)
         for p in parameters:
             self.parameters[p['in']].append(p)
+
+        self.strict_validation = strict_validation
 
     @staticmethod
     def validate_parameter(parameter_type, value, param):
@@ -249,13 +251,14 @@ class ParameterValidator(object):
         def wrapper(*args, **kwargs):
             logger.debug("%s validating parameters...", flask.request.url)
 
-            error = self.validate_query_parameter_list()
-            if error:
-                return problem(400, 'Bad Request', error)
+            if self.strict_validation:
+                error = self.validate_query_parameter_list()
+                if error:
+                    return problem(400, 'Bad Request', error)
 
-            error = self.validate_formdata_parameter_list()
-            if error:
-                return problem(400, 'Bad Request', error)
+                error = self.validate_formdata_parameter_list()
+                if error:
+                    return problem(400, 'Bad Request', error)
 
             for param in self.parameters.get('query', []):
                 error = self.validate_query_parameter(param)

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -170,6 +170,10 @@ class ResponseBodyValidator(object):
 
 class ParameterValidator(object):
     def __init__(self, parameters, strict_validation=False):
+        """
+        :param parameters: List of request parameter dictionaries
+        :param strict_validation: Flag indicating if parametrs not in spec are allowed
+        """
         self.parameters = collections.defaultdict(list)
         for p in parameters:
             self.parameters[p['in']].append(p)

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -108,7 +108,7 @@ class Operation(SecureOperation):
     def __init__(self, method, path, operation, resolver, app_produces,
                  path_parameters=None, app_security=None, security_definitions=None,
                  definitions=None, parameter_definitions=None, response_definitions=None,
-                 validate_responses=False):
+                 validate_responses=False, strict_validation=False):
         """
         This class uses the OperationID identify the module and function that will handle the operation
 
@@ -144,6 +144,8 @@ class Operation(SecureOperation):
         :type response_definitions: dict
         :param validate_responses: True enables validation. Validation errors generate HTTP 500 responses.
         :type validate_responses: bool
+        :param strict_validation: True enables validation on invalid request parameters
+        :type strict_validation: bool
         """
 
         self.method = method
@@ -158,6 +160,7 @@ class Operation(SecureOperation):
             'responses': self.response_definitions
         }
         self.validate_responses = validate_responses
+        self.strict_validation = strict_validation
         self.operation = operation
 
         # todo support definition references
@@ -384,7 +387,7 @@ class Operation(SecureOperation):
         :rtype: types.FunctionType
         """
         if self.parameters:
-            yield ParameterValidator(self.parameters)
+            yield ParameterValidator(self.parameters, strict_validation=self.strict_validation)
         if self.body_schema:
             yield RequestBodyValidator(self.body_schema,
                                        is_nullable(self.body_definition))

--- a/docs/request.rst
+++ b/docs/request.rst
@@ -93,6 +93,19 @@ supports collection formats "pipes" and "csv". The default format is "csv".
 .. _jsonschema: https://pypi.python.org/pypi/jsonschema
 .. _`Swagger/OpenAPI specification`: https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/2.0.md#fixed-fields-7
 
+Parameter validation
+^^^^^^^^^^^^^^^^^^^^
+
+Connexion can apply strict parameter validation for query and form data
+parameters.  When this is enabled, requests that include parameters not defined
+in the swagger spec return a 400 error.  You can enable it when adding the API
+to your application:
+
+.. code-block:: python
+
+    app.add_api('my_apy.yaml', strict_validation=True)
+
+
 Nullable parameters
 ^^^^^^^^^^^^^^^^^^^
 

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -127,4 +127,4 @@ def test_add_api_with_function_resolver_function_is_wrapped(simple_api_spec_dir)
 def test_default_query_param_does_not_match_defined_type(
         default_param_error_spec_dir):
     with pytest.raises(InvalidSpecification):
-        build_app_from_fixture(default_param_error_spec_dir)
+        build_app_from_fixture(default_param_error_spec_dir, validate_responses=True)

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -53,6 +53,15 @@ def test_array_query_param(simple_app):
     assert array_response == ["1;2;3"]
 
 
+def test_extra_query_param(simple_app):
+    app_client = simple_app.app.test_client()
+    headers = {'Content-type': 'application/json'}
+    url = '/v1.0/test_parameter_validation?extra_parameter=true'
+    resp = app_client.get(url, headers=headers)
+    assert resp.status_code == 400
+    response = json.loads(resp.data.decode())
+    assert response['detail'] == "Extra query parameter(s) extra_parameter not in spec"
+
 def test_path_parameter_someint(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-int-path/123')  # type: flask.Response
@@ -116,6 +125,14 @@ def test_formdata_missing_param(simple_app):
     resp = app_client.post('/v1.0/test-formData-missing-param',
                            data={'missing_formData': 'test'})
     assert resp.status_code == 200
+
+def test_formdata_extra_param(simple_app):
+    app_client = simple_app.app.test_client()
+    resp = app_client.post('/v1.0/test-formData-param',
+                           data={'extra_formData': 'test'})
+    assert resp.status_code == 400
+    response = json.loads(resp.data.decode())
+    assert response['detail'] == "Extra formData parameter(s) extra_formData not in spec"
 
 
 def test_formdata_file_upload(simple_app):

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -58,9 +58,18 @@ def test_extra_query_param(simple_app):
     headers = {'Content-type': 'application/json'}
     url = '/v1.0/test_parameter_validation?extra_parameter=true'
     resp = app_client.get(url, headers=headers)
+    assert resp.status_code == 200
+
+
+def test_strict_extra_query_param(strict_app):
+    app_client = strict_app.app.test_client()
+    headers = {'Content-type': 'application/json'}
+    url = '/v1.0/test_parameter_validation?extra_parameter=true'
+    resp = app_client.get(url, headers=headers)
     assert resp.status_code == 400
     response = json.loads(resp.data.decode())
     assert response['detail'] == "Extra query parameter(s) extra_parameter not in spec"
+
 
 def test_path_parameter_someint(simple_app):
     app_client = simple_app.app.test_client()
@@ -126,10 +135,20 @@ def test_formdata_missing_param(simple_app):
                            data={'missing_formData': 'test'})
     assert resp.status_code == 200
 
+
 def test_formdata_extra_param(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.post('/v1.0/test-formData-param',
-                           data={'extra_formData': 'test'})
+                           data={'formData': 'test',
+                                 'extra_formData': 'test'})
+    assert resp.status_code == 200
+
+
+def test_strict_formdata_extra_param(strict_app):
+    app_client = strict_app.app.test_client()
+    resp = app_client.post('/v1.0/test-formData-param',
+                           data={'formData': 'test',
+                                 'extra_formData': 'test'})
     assert resp.status_code == 400
     response = json.loads(resp.data.decode())
     assert response['detail'] == "Extra formData parameter(s) extra_formData not in spec"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,30 +81,35 @@ def default_param_error_spec_dir():
     return FIXTURES_FOLDER / 'default_param_error'
 
 
-def build_app_from_fixture(api_spec_folder):
+def build_app_from_fixture(api_spec_folder, **kwargs):
     app = App(__name__, 5001, FIXTURES_FOLDER / api_spec_folder, debug=True)
-    app.add_api('swagger.yaml', validate_responses=True)
+    app.add_api('swagger.yaml', **kwargs)
     return app
 
 
 @pytest.fixture(scope="session")
 def simple_app():
-    return build_app_from_fixture('simple')
+    return build_app_from_fixture('simple', validate_responses=True)
+
+
+@pytest.fixture(scope="session")
+def strict_app():
+    return build_app_from_fixture('simple', validate_responses=True, strict_validation=True)
 
 
 @pytest.fixture(scope="session")
 def problem_app():
-    return build_app_from_fixture('problem')
+    return build_app_from_fixture('problem', validate_responses=True)
 
 
 @pytest.fixture(scope="session")
 def schema_app():
-    return build_app_from_fixture('different_schemas')
+    return build_app_from_fixture('different_schemas', validate_responses=True)
 
 
 @pytest.fixture(scope="session")
 def secure_endpoint_app():
-    return build_app_from_fixture('secure_endpoint')
+    return build_app_from_fixture('secure_endpoint', validate_responses=True)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Fixes #223 .



Changes proposed in this pull request:

 - Add logic to validate that the query and formData parameters passed on the request are valid parameters in the swagger spec
 - Add a strict_validation flag to `add_api()` and `Api` to enable this validation.
