### PR TITLE
Fix array conversion during validation

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -74,7 +74,7 @@ def validate_type(param, value, parameter_type, parameter_name=None):
                 converted = make_type(part, param["items"]["type"])
             except (ValueError, TypeError):
                 converted = part
-        converted_parts.append(converted)
+            converted_parts.append(converted)
         return converted_parts
     else:
         try:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -22,7 +22,8 @@ def test_parameter_validator(monkeypatch):
     params = [{'name': 'p1', 'in': 'path', 'type': 'integer', 'required': True},
               {'name': 'h1', 'in': 'header', 'type': 'string', 'enum': ['a', 'b']},
               {'name': 'q1', 'in': 'query', 'type': 'integer', 'maximum': 3},
-              {'name': 'a1', 'in': 'query', 'type': 'array', 'items': {'type': 'integer', 'minimum': 0}}]
+              {'name': 'a1', 'in': 'query', 'type': 'array', 'minItems': 2, 'maxItems': 3,
+               'items': {'type': 'integer', 'minimum': 0}}]
     validator = ParameterValidator(params)
     handler = validator(orig_handler)
 
@@ -43,6 +44,10 @@ def test_parameter_validator(monkeypatch):
     assert handler(p1=1).startswith("'a' is not of type 'integer'")
     request.args = {'a1': "1,-1"}
     assert handler(p1=1).startswith("-1 is less than the minimum of 0")
+    request.args = {'a1': "1"}
+    assert handler(p1=1).startswith("[1] is too short")
+    request.args = {'a1': "1,2,3,4"}
+    assert handler(p1=1).startswith("[1, 2, 3, 4] is too long")
     del request.args['a1']
 
     request.headers = {'h1': 'a'}


### PR DESCRIPTION
I noticed this bug while testing a swagger.yaml that included `minItems` and `maxItems` properties on an `array` parameter.
It is quite obvious and self-explanatory.