### PR TITLE
Fix for when parameter spec is unordered.

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -11,9 +11,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
  language governing permissions and limitations under the License.
 """
 
+import collections
 import copy
 import functools
-import itertools
 import logging
 import sys
 
@@ -157,7 +157,9 @@ class ResponseBodyValidator(object):
 
 class ParameterValidator(object):
     def __init__(self, parameters):
-        self.parameters = {k: list(g) for k, g in itertools.groupby(parameters, key=lambda p: p['in'])}
+        self.parameters = collections.defaultdict(list)
+        for p in parameters:
+            self.parameters[p['in']].append(p)
 
     @staticmethod
     def validate_parameter(parameter_type, value, param):

--- a/tests/api/test_unordered_definition.py
+++ b/tests/api/test_unordered_definition.py
@@ -1,0 +1,9 @@
+import json
+
+
+def test_app(unordered_definition_app):
+    app_client = unordered_definition_app.app.test_client()
+    response = app_client.get('/v1.0/unordered-params/1?first=first&second=2')  # type: flask.Response
+    assert response.status_code == 400
+    response_data = json.loads(response.data.decode())
+    assert response_data['detail'] == 'Wrong type, expected \'integer\' for query parameter \'first\''

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,3 +108,8 @@ def secure_endpoint_app():
 @pytest.fixture(scope="session")
 def secure_api_app():
     return build_app_from_fixture('secure_api')
+
+
+@pytest.fixture(scope="session")
+def unordered_definition_app():
+    return build_app_from_fixture('unordered_definition')

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -337,3 +337,7 @@ def get_invalid_response():
 def get_custom_problem_response():
     return problem(402, "You need to pay", "Missing amount",
                    ext={'amount': 23.0})
+
+
+def unordered_params_response(first, path_param, second):
+    return dict(first=int(first), path_param=str(path_param), second=int(second))

--- a/tests/fixtures/unordered_definition/swagger.yaml
+++ b/tests/fixtures/unordered_definition/swagger.yaml
@@ -1,0 +1,30 @@
+swagger: "2.0"
+
+info:
+  title: "{{title}}"
+  version: "1.0"
+
+basePath: /v1.0
+
+paths:
+  /unordered-params/{path_param}:
+    get:
+      summary: Mixed parameters in swagger definition
+      operationId: fakeapi.hello.unordered_params_response
+      responses:
+        200:
+          description: OK
+      parameters:
+        - name: first
+          in: query
+          type: integer
+          description: First Param
+        - name: path_param
+          in: path
+          required: true
+          type: string
+          description: Path Param
+        - name: second
+          in: query
+          type: integer
+          description: Second Param


### PR DESCRIPTION
Fixes #219  .



Changes proposed in this pull request:

 - Parameter validation dictionary is built with a default dict instead of `groupby` from `itertools`.
 - Tests to verify that the validation now really works.

