### PR TITLE
Adding custom validators

### DIFF
--- a/connexion/api.py
+++ b/connexion/api.py
@@ -141,7 +141,6 @@ class Api(object):
         if auth_all_paths:
             self.add_auth_on_not_found()
 
-
     def add_operation(self, method, path, swagger_operation, path_parameters):
         """
         Adds one operation to the api.

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -21,9 +21,8 @@ import flask
 import jinja2
 import six
 import werkzeug.exceptions
-from swagger_spec_validator.validator20 import validate_spec
-
 import yaml
+from swagger_spec_validator.validator20 import validate_spec
 
 from . import resolver, utils
 from .handlers import AuthErrorHandler

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -58,12 +58,14 @@ class Api(object):
     Single API that corresponds to a flask blueprint
     """
 
-    def __init__(self, swagger_yaml_path, base_url=None, arguments=None,
+    def __init__(self, swagger_yaml_path, validator_map, base_url=None, arguments=None,
                  swagger_json=None, swagger_ui=None, swagger_path=None, swagger_url=None,
                  validate_responses=False, resolver=resolver.Resolver(),
                  auth_all_paths=False, debug=False):
         """
         :type swagger_yaml_path: pathlib.Path
+        :param validator_map: map of validators
+        :type validator_map: dict
         :type base_url: str | None
         :type arguments: dict | None
         :type swagger_json: bool
@@ -75,6 +77,7 @@ class Api(object):
         :param resolver: Callable that maps operationID to a function
         """
         self.debug = debug
+        self.validator_map = validator_map
         self.swagger_yaml_path = pathlib.Path(swagger_yaml_path)
         logger.debug('Loading specification: %s', swagger_yaml_path,
                      extra={'swagger_yaml': swagger_yaml_path,
@@ -138,6 +141,7 @@ class Api(object):
         if auth_all_paths:
             self.add_auth_on_not_found()
 
+
     def add_operation(self, method, path, swagger_operation, path_parameters):
         """
         Adds one operation to the api.
@@ -166,7 +170,8 @@ class Api(object):
                               parameter_definitions=self.parameter_definitions,
                               response_definitions=self.response_definitions,
                               validate_responses=self.validate_responses,
-                              resolver=self.resolver)
+                              resolver=self.resolver,
+                              validator_map=self.validator_map)
         operation_id = operation.operation_id
         logger.debug('... Adding %s -> %s', method.upper(), operation_id,
                      extra=vars(operation))

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -21,8 +21,9 @@ import flask
 import jinja2
 import six
 import werkzeug.exceptions
-import yaml
 from swagger_spec_validator.validator20 import validate_spec
+
+import yaml
 
 from . import resolver, utils
 from .handlers import AuthErrorHandler

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -58,10 +58,10 @@ class Api(object):
     Single API that corresponds to a flask blueprint
     """
 
-    def __init__(self, swagger_yaml_path, validator_map, base_url=None, arguments=None,
+    def __init__(self, swagger_yaml_path, base_url=None, arguments=None,
                  swagger_json=None, swagger_ui=None, swagger_path=None, swagger_url=None,
                  validate_responses=False, resolver=resolver.Resolver(),
-                 auth_all_paths=False, debug=False):
+                 auth_all_paths=False, debug=False, validator_map={}):
         """
         :type swagger_yaml_path: pathlib.Path
         :param validator_map: map of validators

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -16,7 +16,6 @@ import pathlib
 
 import flask
 import werkzeug.exceptions
-
 from connexion.decorators.produces import JSONEncoder as ConnexionJSONEncoder
 from connexion.resolver import Resolver
 

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -20,17 +20,11 @@ from connexion.decorators.produces import JSONEncoder as ConnexionJSONEncoder
 from connexion.resolver import Resolver
 
 from .api import Api
-from .decorators.response import ResponseValidator
-from .decorators.validation import ParameterValidator, RequestBodyValidator
 from .problem import problem
 
 logger = logging.getLogger('connexion.app')
 
-VALIDATOR_MAP = {
-    'parameter': ParameterValidator,
-    'body': RequestBodyValidator,
-    'response': ResponseValidator,
-}
+
 
 
 class App(object):
@@ -94,8 +88,7 @@ class App(object):
         self.swagger_path = swagger_path
         self.swagger_url = swagger_url
         self.auth_all_paths = auth_all_paths
-        self.validator_map = dict(VALIDATOR_MAP)
-        self.validator_map.update(validator_map)
+        self.validator_map = validator_map
 
     @staticmethod
     def common_error_handler(exception):

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -25,8 +25,6 @@ from .problem import problem
 logger = logging.getLogger('connexion.app')
 
 
-
-
 class App(object):
     def __init__(self, import_name, port=None, specification_dir='',
                  server=None, arguments=None, auth_all_paths=False,

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -16,6 +16,7 @@ import pathlib
 
 import flask
 import werkzeug.exceptions
+
 from connexion.decorators.produces import JSONEncoder as ConnexionJSONEncoder
 from connexion.resolver import Resolver
 

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -24,8 +24,8 @@ from .decorators.produces import BaseSerializer, Jsonifier, Produces
 from .decorators.response import ResponseValidator
 from .decorators.security import (get_tokeninfo_url, security_passthrough,
                                   verify_oauth)
-from .decorators.validation import TypeValidationError, ParameterValidator, RequestBodyValidator
-
+from .decorators.validation import (ParameterValidator, RequestBodyValidator,
+                                    TypeValidationError)
 from .exceptions import InvalidSpecification
 from .utils import flaskify_endpoint, is_nullable, produces_json
 

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -1,7 +1,7 @@
+import pytest
 from connexion.app import App
 from connexion.exceptions import InvalidSpecification
 
-import pytest
 from conftest import TEST_FOLDER, build_app_from_fixture
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,8 @@ import json
 import logging
 import pathlib
 
-from connexion.app import App
-
 import pytest
+from connexion.app import App
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,8 @@
 import pathlib
 
+import pytest
 from connexion.api import Api
 from swagger_spec_validator.common import SwaggerValidationError
-
-import pytest
 
 TEST_FOLDER = pathlib.Path(__file__).parent
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1,12 +1,11 @@
 import pathlib
 import types
 
+import pytest
 from connexion.decorators.security import security_passthrough, verify_oauth
 from connexion.exceptions import InvalidSpecification
 from connexion.operation import Operation
 from connexion.resolver import Resolver
-
-import pytest
 
 TEST_FOLDER = pathlib.Path(__file__).parent
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,6 @@ import math
 
 import connexion.app
 import connexion.utils as utils
-
 import pytest
 
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,9 +2,8 @@ import json
 import logging
 import pathlib
 
-from connexion.app import App
-
 import pytest
+from connexion.app import App
 
 logging.basicConfig(level=logging.DEBUG)
 


### PR DESCRIPTION
Changes proposed in this pull request:

 - Support for custom validators

This example returns the complete list of validation errors instead of returning a single error:

    from connexion.decorators.validation import RequestBodyValidator
    from connexion.problem import problem
    from connexion.utils import is_null
    from jsonschema.validators import validator_for

    class CustomRequestBodyValidator(RequestBodyValidator):
        def validate_schema(self, data):
            if self.is_null_value_valid and is_null(data):
                return None

            cls = validator_for(self.schema)
            cls.check_schema(self.schema)
            errors = tuple(cls(self.schema).iter_errors(data))

            if errors:
                error_list = [ e.message for e in errors ]
                return problem(400, 'Bad Request', {'errors': error_list}, type='validation')

            return None

    if __name__ == '__main__':
        validator_map = {
            'body': CustomRequestBodyValidator,
        }
        app = connexion.App(__name__, ..., validator_map=validator_map)

