### PR TITLE
Don't send back entire API schema to clients after validation failures

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -127,8 +127,8 @@ class RequestBodyValidator(object):
             validate(data, self.schema, format_checker=draft4_format_checker)
         except ValidationError as exception:
             logger.error("{url} validation error: {error}".format(url=flask.request.url,
-                                                                  error=exception))
-            return problem(400, 'Bad Request', str(exception))
+                                                                  error=exception.message))
+            return problem(400, 'Bad Request', str(exception.message))
 
         return None
 


### PR DESCRIPTION
Fixes #234  .

Changes proposed in this pull request:

 - For request body validations, instead of sending back the entire API schema, Connexion will only send back the error message (eg: "'value' is a required property"
 - For response validations, Connexion will continue to log the entire API schema via the `logger.error` call, as it did before.
