### PR TITLE
Fix Flask version to 0.10.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jsonschema>=2.5.1
-flask>=0.10.1
+flask==0.10.1
 PyYAML>=3.11
 requests>=2.9.1
 six>=1.7


### PR DESCRIPTION
Currently Connexion does not support latest version of Flask. It works for version 0.10.1


Changes proposed in this pull request:

 - Fixed Flask version.