### PR TITLE
Support flask 0.11

### DIFF
--- a/connexion/app.py
+++ b/connexion/app.py
@@ -71,7 +71,7 @@ class App(object):
         logger.debug('Specification directory: %s', self.specification_dir)
 
         logger.debug('Setting error handlers')
-        for error_code in range(400, 600):  # All http status from 400 to 599 are errors
+        for error_code in werkzeug.exceptions.default_exceptions:
             self.add_error_handler(error_code, self.common_error_handler)
 
         self.port = port
@@ -153,7 +153,7 @@ class App(object):
         :type error_code: int
         :type function: types.FunctionType
         """
-        self.app.error_handler_spec[None][error_code] = function
+        self.app.register_error_handler(error_code, function)
 
     def add_url_rule(self, rule, endpoint=None, view_func=None, **options):
         """

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -62,7 +62,7 @@ def test_errors(problem_app):
     assert problematic_json.status_code == 500
 
     custom_problem = app_client.get('/v1.0/customized_problem_response')
-    assert custom_problem.status_code == 402
+    assert custom_problem.status_code == 403
     problem_body = json.loads(custom_problem.data.decode('utf-8'))
     assert 'amount' in problem_body
     assert problem_body['amount'] == 23.

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -335,7 +335,7 @@ def get_invalid_response():
 
 
 def get_custom_problem_response():
-    return problem(402, "You need to pay", "Missing amount",
+    return problem(403, "You need to pay", "Missing amount",
                    ext={'amount': 23.0})
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ max-line-length=120
 exclude=connexion/__init__.py
 
 [tox]
-envlist=pypy,py27,py34,py35,isort-check,flake8
+envlist=pypy,py27,py34,py35,py35-flask0.10.1,isort-check,flake8
 
 [tox:travis]
 pypy=pypy
@@ -22,3 +22,6 @@ commands=python setup.py flake8
 basepython=python3
 deps=isort
 commands=isort -ns __init__.py -rc -c {toxinidir}/connexion {toxinidir}/examples {toxinidir}/tests
+
+[testenv:py35-flask0.10.1]
+deps=flask==0.10.1


### PR DESCRIPTION
Fixes #239
Replaces #237

Simple change makes Connexion compatible with Flask 0.11

Since the Flask 0.11 the supported error handlers are the ones that have specific exception in [werkzeug](https://github.com/pallets/werkzeug). The HTTP error code 402 is not supported by Werkzeug so we cannot use it in tests.

Changes proposed in this pull request:

 - Calls properly the `add_error_handler` funcion from Flask App
 - Fix tests
