### PR TITLE
fix flake8 formatting of SQLAlchemy example

### DIFF
--- a/examples/sqlalchemy/app.py
+++ b/examples/sqlalchemy/app.py
@@ -9,11 +9,13 @@ import orm
 
 db_session = None
 
+
 def get_pets(limit, animal_type=None):
     q = db_session.query(orm.Pet)
     if animal_type:
         q = q.filter(orm.Pet.animal_type == animal_type)
-    return [ p.dump() for p in q][:limit]
+    return [p.dump() for p in q][:limit]
+
 
 def get_pet(pet_id):
     pet = db_session.query(orm.Pet).filter(orm.Pet.id == pet_id).one_or_none()
@@ -50,6 +52,7 @@ app = connexion.App(__name__)
 app.add_api('swagger.yaml')
 
 application = app.app
+
 
 @application.teardown_appcontext
 def shutdown_session(exception=None):

--- a/examples/sqlalchemy/orm.py
+++ b/examples/sqlalchemy/orm.py
@@ -11,25 +11,22 @@ class Pet(Base):
     name = Column(String(100))
     animal_type = Column(String(20))
     created = Column(DateTime())
-    
-    def update(self, id=None, name=None, animal_type=None, tags=None, 
-            created=None):
+
+    def update(self, id=None, name=None, animal_type=None, tags=None, created=None):
         if name is not None:
             self.name = name
         if animal_type is not None:
             self.animal_type = animal_type
         if created is not None:
             self.created = created
-        
+
     def dump(self):
-        return dict([(k,v) for k,v in vars(self).items() 
-                if not k.startswith('_')])
+        return dict([(k, v) for k, v in vars(self).items() if not k.startswith('_')])
 
 
 def init_db(uri):
     engine = create_engine(uri, convert_unicode=True)
-    db_session = scoped_session(sessionmaker(autocommit=False, autoflush=False,
-            bind=engine))
+    db_session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
     Base.query = db_session.query_property()
     Base.metadata.create_all(bind=engine)
     return db_session


### PR DESCRIPTION
Tiny code formatting changes (flake8) in SQLAlchemy example provided by @nmusatti.

Using our flake8 settings (defined in `tox.ini`) with max-line-length=120.