### PR TITLE
Stricter requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-jsonschema>=2.5.1
-flask>=0.10.1
-PyYAML>=3.11
-requests>=2.9.1
-six>=1.7
-strict-rfc3339>=0.6
-swagger_spec_validator>=2.0.2
+jsonschema>=2.5.1,<3
+flask>=0.10.1,<0.12
+PyYAML>=3.11,<4
+requests>=2.9.1,<3
+six>=1.7,<2
+strict-rfc3339>=0.6,<0.7
+swagger_spec_validator>=2.0.2,<3
+jinja2>=2.8,<3
+werkzeug>=0.11.10,<0.12


### PR DESCRIPTION
Fixes #246: avoid being exposed to API changes in dependencies.

- provide upper bounds on dependencies
- remove `strict-rfc3339` dependency - doesn't seem to be required
- explicitly specify `jinja2` and `werkzeug` dependencies
- I haven't added dependencies for optional imports `gevent`, `tornado`, `uwsgi_metrics`