### PR TITLE
fix typo in README automatic routing section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -198,7 +198,7 @@ the endpoints in your specification:
        get:
           # Implied operationId: api.foo.get
        put:
-          # Implied operationId: api.foo.post
+          # Implied operationId: api.foo.put
        copy:
           # Implied operationId: api.foo.copy
        delete:


### PR DESCRIPTION
The automatic routing section of the README currently says the RestyResolver looks for `api.foo.post` for PUT requests. This PR just fixes that typo.

BTW, this is an awesome tool!