### PR TITLE
Fixed a wrong example of README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,7 +190,7 @@ the endpoints in your specification:
           # Implied operationId: api.get
      /foo:
        get:
-          # Implied operationId: api.foo.search
+          # Implied operationId: api.foo.get
        post:
           # Implied operationId: api.foo.post
 


### PR DESCRIPTION
Because the document had a trifling mistake, I made modifications.
