### PR TITLE
Fix forgotten argument in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -393,7 +393,7 @@ Flask with uWSGI`_ (this is common):
 
 .. code-block:: python
 
-    app = connexion.App(specification_dir='swagger/')
+    app = connexion.App(__name__, specification_dir='swagger/')
     application = app.app # expose global WSGI application object
 
 Set up and run the installation code:


### PR DESCRIPTION
This change fixes the following error when trying the example:

```
Traceback (most recent call last):
  File ".../src/app.py", line 5, in <module>
    connexionApp = connexion.App(specification_dir='./swagger/')
TypeError: __init__() missing 1 required positional argument: 'import_name'
```