### PR TITLE
Add ability to add random string to endpoint names

### DIFF
--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -45,9 +45,9 @@ def flaskify_endpoint(identifier, randomize=None):
     if randomize is None:
         return result
 
-    def generator(size=randomize, chars=string.ascii_uppercase + string.digits):
-        return ''.join(random.SystemRandom().choice(chars) for _ in range(size))
-    return result + '|' + generator()
+    chars = string.ascii_uppercase + string.digits
+    return result + '|' + ''.join(
+        random.SystemRandom().choice(chars) for _ in range(randomize))
 
 
 def convert_path_parameter(match, types):

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -28,14 +28,25 @@ PATH_PARAMETER_CONVERTERS = {
 }
 
 
-def flaskify_endpoint(identifier):
+def flaskify_endpoint(identifier, randomize=None):
     """
     Converts the provided identifier in a valid flask endpoint name
 
     :type identifier: str
+    :param randomize: If specified, add this many random characters (upper case
+        and digits) to the endpoint name, separated by a pipe character.
+    :type randomize: int | None
     :rtype: str
     """
-    return identifier.replace('.', '_')
+    result = identifier.replace('.', '_')
+    if randomize is None:
+      return result
+
+    import random
+    import string
+    def generator(size=randomize, chars=string.ascii_uppercase + string.digits):
+      return ''.join(random.SystemRandom().choice(chars) for _ in range(size))
+    return  result + '|' + generator()
 
 
 def convert_path_parameter(match, types):
@@ -47,7 +58,7 @@ def convert_path_parameter(match, types):
                                 name.replace('-', '_'))
 
 
-def flaskify_path(swagger_path, types=None):
+def flaskify_path(swagger_path, types=None, method=None):
     """
     Convert swagger path templates to flask path templates
 

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -58,7 +58,7 @@ def convert_path_parameter(match, types):
                                 name.replace('-', '_'))
 
 
-def flaskify_path(swagger_path, types=None, method=None):
+def flaskify_path(swagger_path, types=None):
     """
     Convert swagger path templates to flask path templates
 

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -40,13 +40,14 @@ def flaskify_endpoint(identifier, randomize=None):
     """
     result = identifier.replace('.', '_')
     if randomize is None:
-      return result
+        return result
 
     import random
     import string
+
     def generator(size=randomize, chars=string.ascii_uppercase + string.digits):
-      return ''.join(random.SystemRandom().choice(chars) for _ in range(size))
-    return  result + '|' + generator()
+        return ''.join(random.SystemRandom().choice(chars) for _ in range(size))
+    return result + '|' + generator()
 
 
 def convert_path_parameter(match, types):

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -13,10 +13,13 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 import functools
 import importlib
+import random
 import re
+import string
 
 import flask
 import werkzeug.wrappers
+
 
 PATH_PARAMETER = re.compile(r'\{([^}]*)\}')
 
@@ -41,9 +44,6 @@ def flaskify_endpoint(identifier, randomize=None):
     result = identifier.replace('.', '_')
     if randomize is None:
         return result
-
-    import random
-    import string
 
     def generator(size=randomize, chars=string.ascii_uppercase + string.digits):
         return ''.join(random.SystemRandom().choice(chars) for _ in range(size))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,6 +20,12 @@ def test_flaskify_endpoint():
     assert utils.flaskify_endpoint("module.function") == "module_function"
     assert utils.flaskify_endpoint("function") == "function"
 
+    name = 'module.function'
+    randlen = 6
+    res = utils.flaskify_endpoint(name, randlen)
+    assert res.startswith('module_function')
+    assert len(res) == len(name) + 1 + randlen
+
 
 def test_get_function_from_name():
     function = utils.get_function_from_name('math.ceil')


### PR DESCRIPTION
Swagger is clear on the fact that operationIds must be unique across a spec. That leads to connexion assuming that there is no reason for the same Python function to be mapped to multiple paths, and using the output of `flaskify_endpoint` for unique flask view names.

Now this is correct as connexion is currently implemented. I'm preparing another PR based on #274 that would no longer make this assumption always true.

Changes proposed in this pull request:

 - Add the ability to *optionally* add random characters to a flask view name
