### PR TITLE
It's bad practice to derive custom exception classes from BaseException.

### DIFF
--- a/connexion/exceptions.py
+++ b/connexion/exceptions.py
@@ -12,7 +12,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 """
 
 
-class ConnexionException(BaseException):
+class ConnexionException(Exception):
     pass
 
 

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -127,4 +127,4 @@ def test_add_api_with_function_resolver_function_is_wrapped(simple_api_spec_dir)
 def test_default_query_param_does_not_match_defined_type(
         default_param_error_spec_dir):
     with pytest.raises(InvalidSpecification):
-        build_app_from_fixture(default_param_error_spec_dir, validate_responses=True)
+        build_app_from_fixture(default_param_error_spec_dir, validate_responses=True, debug=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,11 @@ def default_param_error_spec_dir():
 
 
 def build_app_from_fixture(api_spec_folder, **kwargs):
-    app = App(__name__, 5001, FIXTURES_FOLDER / api_spec_folder, debug=True)
+    debug = True
+    if 'debug' in kwargs:
+        debug = kwargs['debug']
+        del(kwargs['debug'])
+    app = App(__name__, 5001, FIXTURES_FOLDER / api_spec_folder, debug=debug)
     app.add_api('swagger.yaml', **kwargs)
     return app
 


### PR DESCRIPTION
Changes proposed in this pull request:

 - Derive from Exception rather than BaseException (see https://www.python.org/dev/peps/pep-0352/)
 - Change the expectation that `InvalidSpecification` is only raised outside debug mode.

Note: the latter change is in line with how exceptions are generally handled in connexion. It'd be easy enough to pass this particular error through anyway.