### PR TITLE
Fix tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ class PyTest(TestCommand):
         TestCommand.finalize_options(self)
         if self.cov_html:
             self.pytest_args.extend(['--cov-report', 'html'])
+        self.pytest_args.extend(['tests'])
 
     def run_tests(self):
         import pytest
@@ -53,12 +54,19 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
+def readme():
+    try:
+        return open('README.rst', encoding='utf-8').read()
+    except TypeError:
+        return open('README.rst').read()
+
+
 setup(
     name='connexion',
     packages=find_packages(),
     version=version,
     description='Connexion - API first applications with OpenAPI/Swagger and Flask',
-    long_description=open('README.rst').read(),
+    long_description=readme(),
     author='Zalando SE',
     url='https://github.com/zalando/connexion',
     keywords='openapi oai swagger rest api oauth flask microservice framework',


### PR DESCRIPTION
- Not specifying `tests` as the test directory will lead to pytest trying to run test code in dependencies installed in the project directory via `virtualenv`.
- `README.rst` is in utf-8 encoding; reading it fails on py34
