### PR TITLE
Run an API spec, no boilerplate needed

### DIFF
--- a/connexion/api.py
+++ b/connexion/api.py
@@ -23,7 +23,8 @@ import werkzeug.exceptions
 import yaml
 from swagger_spec_validator.validator20 import validate_spec
 
-from . import resolver, utils
+from . import utils
+from .resolver import Resolver
 from .handlers import AuthErrorHandler
 from .operation import Operation
 
@@ -62,7 +63,7 @@ class Api(object):
 
     def __init__(self, swagger_yaml_path, base_url=None, arguments=None,
                  swagger_json=None, swagger_ui=None, swagger_path=None, swagger_url=None,
-                 validate_responses=False, strict_validation=False, resolver=resolver.Resolver(),
+                 validate_responses=False, strict_validation=False, resolver=None,
                  auth_all_paths=False, debug=False):
         """
         :type swagger_yaml_path: pathlib.Path
@@ -129,7 +130,7 @@ class Api(object):
         self.swagger_path = swagger_path or SWAGGER_UI_PATH
         self.swagger_url = swagger_url or SWAGGER_UI_URL
 
-        self.resolver = resolver
+        self.resolver = resolver or Resolver()
 
         logger.debug('Validate Responses: %s', str(validate_responses))
         self.validate_responses = validate_responses

--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -13,26 +13,17 @@ main = AliasedGroup(context_settings=dict(help_option_names=[
     '-h', '--help']))
 
 
-def _operation_not_implemented():
-    return problem(
-        title='Not Implemented Yet',
-        detail='The requested functionality is not implemented yet.',
-        status=400)
-
-
 def validate_wsgi_server_requirements(ctx, param, value):
     if value == 'gevent':
         try:
-            import gevent.wsgi  # NOQA
+            import gevent  # NOQA
         except:
             fatal_error('gevent library is not installed')
     elif value == 'tornado':
         try:
-            import tornado.wsgi  # NOQA
-            import tornado.httpserver  # NOQA
-            import tornado.ioloop  # NOQA
+            import tornado  # NOQA
         except:
-            fatal_error('tornado library not installed')
+            fatal_error('tornado library is not installed')
 
 
 @main.command()
@@ -91,7 +82,10 @@ def run(spec_file,
 
     resolver = None
     if stub:
-        resolver = StubResolver(_operation_not_implemented)
+        resolver = StubResolver(lambda: problem(
+            title='Not Implemented Yet',
+            detail='The requested functionality is not implemented yet.',
+            status=400))
 
     app = App(__name__)
     app.add_api(path.abspath(spec_file), resolver=resolver)

--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -34,22 +34,28 @@ def validate_wsgi_server_requirements(ctx, param, value):
               type=click.Choice(['flask', 'gevent', 'tornado']),
               callback=validate_wsgi_server_requirements,
               help='Which WSGI server container to use.')
-@click.option('--stub', '-s',
+@click.option('--stub',
               help='Returns status code 400, and `Not Implemented Yet` payload, for '
               'the endpoints which handlers are not found.',
               is_flag=True, default=False)
 @click.option('--hide-spec',
               help='Hides the API spec in JSON format which is by default available at `/swagger.json`.',
-              is_flag=True, default=True)
+              is_flag=True, default=False)
 @click.option('--hide-console-ui',
               help='Hides the the API console UI which is by default available at `/ui`.',
-              is_flag=True, default=True)
+              is_flag=True, default=False)
 @click.option('--console-ui-url', metavar='URL',
               help='Personalize what URL path the API console UI will be mounted.')
 @click.option('--console-ui-from', metavar='PATH',
               help='Path to a customized API console UI dashboard.')
 @click.option('--auth-all-paths',
               help='Enable authentication to paths not defined in the spec.',
+              is_flag=True, default=False)
+@click.option('--validate-responses',
+              help='Enable validation of response values from operation handlers.',
+              is_flag=True, default=False)
+@click.option('--strict-validation',
+              help='Enable strict validation of request payloads.',
               is_flag=True, default=False)
 @click.option('--debug', '-d', help='Show debugging information.',
               is_flag=True, default=False)
@@ -63,6 +69,8 @@ def run(spec_file,
         console_ui_url,
         console_ui_from,
         auth_all_paths,
+        validate_responses,
+        strict_validation,
         debug):
     """
     Runs a server compliant with a OpenAPI/Swagger 2.0 Specification file.
@@ -89,4 +97,14 @@ def run(spec_file,
 
     app = App(__name__)
     app.add_api(path.abspath(spec_file), resolver=resolver)
-    app.run(port=port, server=wsgi_server)
+    app.run(
+        port=port,
+        server=wsgi_server,
+        swagger_json=hide_spec or None,
+        swagger_ui=hide_console_ui or None,
+        swagger_path=console_ui_from or None,
+        swagger_url=console_ui_url or None,
+        strict_validation=strict_validation,
+        validate_responses=validate_responses,
+        auth_all_paths=auth_all_paths,
+        debug=debug)

--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -1,0 +1,56 @@
+import logging
+import sys
+from os import path
+
+import click
+from connexion import App
+
+from clickclick import AliasedGroup
+
+main = AliasedGroup(context_settings=dict(help_option_names=[
+    '-h', '--help']))
+
+
+@main.command()
+@click.argument('spec_file')
+@click.argument('base_path', required=False)
+@click.option('--port', '-p', default=5000, type=int, help='Port to listen.')
+@click.option('--server', '-s', default='gevent',
+              type=click.Choice(['gevent', 'tornado']),
+              help='Which WSGI server to use.')
+@click.option('--hide-spec',
+              help='Hides the API spec in JSON format which is by default available at `/swagger.json`.',
+              is_flag=True, default=True)
+@click.option('--hide-swagger-ui',
+              help='Hides the the Swagger UI which is by default available at `/ui`.',
+              is_flag=True, default=True)
+@click.option('--swagger-ui-url', metavar='URL',
+              help='Personalize what URL path the Swagger UI will be mounted.')
+@click.option('--swagger-ui-from', metavar='PATH',
+              help='Path to a customized Swagger UI dashboard.')
+@click.option('--auth-all-paths',
+              help='Enable authentication to paths not defined in the spec.',
+              is_flag=True, default=False)
+@click.option('--debug', '-d', help='Show debugging information.',
+              is_flag=True, default=False)
+def run(spec_file, base_path, port, server, debug):
+    """
+    Runs a server using the passed OpenAPI/Swagger 2.0 Specification file.
+
+    Possible arguments:
+
+    - SPEC_FILE: specification file of the API to run.
+
+    - BASE_PATH (optional): filesystem path from where to import the API handlers.
+    """
+    logging_level = logging.ERROR
+    if debug:
+        logging_level = logging.DEBUG
+    logging.basicConfig(level=logging_level)
+
+    sys.path.insert(1, path.abspath(base_path or '.'))
+
+    app = App(__name__)
+    app.add_api(path.abspath(spec_file))
+    click.echo('Running at http://localhost:{}/...'.format(port))
+    app.run(port=port, server=server)

--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -3,45 +3,84 @@ import sys
 from os import path
 
 import click
-from connexion import App
+from connexion import App, problem
+from connexion.resolver import StubResolver
 
-from clickclick import AliasedGroup
+from clickclick import AliasedGroup, fatal_error
+
 
 main = AliasedGroup(context_settings=dict(help_option_names=[
     '-h', '--help']))
+
+
+def _operation_not_implemented():
+    return problem(
+        title='Not Implemented Yet',
+        detail='The requested functionality is not implemented yet.',
+        status=400)
+
+
+def validate_wsgi_server_requirements(ctx, param, value):
+    if value == 'gevent':
+        try:
+            import gevent.wsgi  # NOQA
+        except:
+            fatal_error('gevent library is not installed')
+    elif value == 'tornado':
+        try:
+            import tornado.wsgi  # NOQA
+            import tornado.httpserver  # NOQA
+            import tornado.ioloop  # NOQA
+        except:
+            fatal_error('tornado library not installed')
 
 
 @main.command()
 @click.argument('spec_file')
 @click.argument('base_path', required=False)
 @click.option('--port', '-p', default=5000, type=int, help='Port to listen.')
-@click.option('--server', '-s', default='gevent',
-              type=click.Choice(['gevent', 'tornado']),
-              help='Which WSGI server to use.')
+@click.option('--wsgi-server', '-w', default='flask',
+              type=click.Choice(['flask', 'gevent', 'tornado']),
+              callback=validate_wsgi_server_requirements,
+              help='Which WSGI server container to use.')
+@click.option('--stub', '-s',
+              help='Returns status code 400, and `Not Implemented Yet` payload, for '
+              'the endpoints which handlers are not found.',
+              is_flag=True, default=False)
 @click.option('--hide-spec',
               help='Hides the API spec in JSON format which is by default available at `/swagger.json`.',
               is_flag=True, default=True)
-@click.option('--hide-swagger-ui',
-              help='Hides the the Swagger UI which is by default available at `/ui`.',
+@click.option('--hide-console-ui',
+              help='Hides the the API console UI which is by default available at `/ui`.',
               is_flag=True, default=True)
-@click.option('--swagger-ui-url', metavar='URL',
-              help='Personalize what URL path the Swagger UI will be mounted.')
-@click.option('--swagger-ui-from', metavar='PATH',
-              help='Path to a customized Swagger UI dashboard.')
+@click.option('--console-ui-url', metavar='URL',
+              help='Personalize what URL path the API console UI will be mounted.')
+@click.option('--console-ui-from', metavar='PATH',
+              help='Path to a customized API console UI dashboard.')
 @click.option('--auth-all-paths',
               help='Enable authentication to paths not defined in the spec.',
               is_flag=True, default=False)
 @click.option('--debug', '-d', help='Show debugging information.',
               is_flag=True, default=False)
-def run(spec_file, base_path, port, server, debug):
+def run(spec_file,
+        base_path,
+        port,
+        wsgi_server,
+        stub,
+        hide_spec,
+        hide_console_ui,
+        console_ui_url,
+        console_ui_from,
+        auth_all_paths,
+        debug):
     """
-    Runs a server using the passed OpenAPI/Swagger 2.0 Specification file.
+    Runs a server compliant with a OpenAPI/Swagger 2.0 Specification file.
 
-    Possible arguments:
+    Arguments:
 
-    - SPEC_FILE: specification file of the API to run.
+    - SPEC_FILE: specification file that describes the server endpoints.
 
-    - BASE_PATH (optional): filesystem path from where to import the API handlers.
+    - BASE_PATH (optional): filesystem path where the API endpoints handlers are going to be imported from.
     """
     logging_level = logging.ERROR
     if debug:
@@ -50,7 +89,10 @@ def run(spec_file, base_path, port, server, debug):
 
     sys.path.insert(1, path.abspath(base_path or '.'))
 
+    resolver = None
+    if stub:
+        resolver = StubResolver(_operation_not_implemented)
+
     app = App(__name__)
-    app.add_api(path.abspath(spec_file))
-    click.echo('Running at http://localhost:{}/...'.format(port))
-    app.run(port=port, server=server)
+    app.add_api(path.abspath(spec_file), resolver=resolver)
+    app.run(port=port, server=wsgi_server)

--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -146,5 +146,5 @@ class StubResolver(Resolver):
         """
         try:
             super(StubResolver, self).resolve_function_from_operation_id(operation_id)
-        except ImportError:
+        except (ImportError, AttributeError):
             return self.stub_function

--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -133,3 +133,18 @@ class RestyResolver(Resolver):
             return self.collection_endpoint_name if is_collection_endpoint else method.lower()
 
         return get_controller_name() + '.' + get_function_name()
+
+
+class StubResolver(Resolver):
+    def __init__(self, stub_function, **kwargs):
+        self.stub_function = stub_function
+        super(StubResolver, self).__init__(**kwargs)
+
+    def resolve_function_from_operation_id(self, operation_id):
+        """
+        In case a function for the operation is not found a stub function is returned.
+        """
+        try:
+            super(StubResolver, self).resolve_function_from_operation_id(operation_id)
+        except ImportError:
+            return self.stub_function

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -119,8 +119,11 @@ def get_function_from_name(function_name):
             module = importlib.import_module(module_name)
         except ImportError as import_error:
             last_import_error = import_error
-            module_name, attr_path1 = module_name.rsplit('.', 1)
-            attr_path = '{0}.{1}'.format(attr_path1, attr_path)
+            if '.' in module_name:
+                module_name, attr_path1 = module_name.rsplit('.', 1)
+                attr_path = '{0}.{1}'.format(attr_path1, attr_path)
+            else:
+                raise
     try:
         function = deep_getattr(module, attr_path)
     except AttributeError:

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -20,7 +20,6 @@ import string
 import flask
 import werkzeug.wrappers
 
-
 PATH_PARAMETER = re.compile(r'\{([^}]*)\}')
 
 # map Swagger type to flask path converter

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests>=2.9.1
 six>=1.7
 strict-rfc3339>=0.6
 swagger_spec_validator>=2.0.2
+clickclick>=1.1

--- a/setup.py
+++ b/setup.py
@@ -88,5 +88,6 @@ setup(
         'Topic :: Software Development :: Libraries :: Application Frameworks'
     ],
     include_package_data=True,  # needed to include swagger-ui (see MANIFEST.in)
-
+    entry_points={'console_scripts': ['connexion = connexion.cli:main',
+                                      'cnx = connexion.cli:main']}
 )

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -287,5 +287,3 @@ def test_args_kwargs(simple_app):
     resp = app_client.get('/v1.0/query-params-as-kwargs?foo=a&bar=b')
     assert resp.status_code == 200
     assert json.loads(resp.data.decode()) == {'foo': 'a'}
-
-

--- a/tests/fixtures/missing_implementation/swagger.yaml
+++ b/tests/fixtures/missing_implementation/swagger.yaml
@@ -1,0 +1,16 @@
+swagger: "2.0"
+
+info:
+  title: "Testing API"
+  version: "1.0"
+
+basePath: "/testing"
+
+paths:
+  /operation-not-implemented:
+    get:
+      summary: Operation function does not exist.
+      operationId: api.this_function_does_not_exist
+      responses:
+        200:
+          description: OK

--- a/tests/fixtures/module_does_not_exist/swagger.yaml
+++ b/tests/fixtures/module_does_not_exist/swagger.yaml
@@ -1,0 +1,16 @@
+swagger: "2.0"
+
+info:
+  title: "Not Exist API"
+  version: "1.0"
+
+basePath: '/na'
+
+paths:
+  /module-not-implemented:
+    get:
+      summary: Operation function does not exist.
+      operationId: m.module_does_not_exist
+      responses:
+        200:
+          description: OK

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,7 +34,17 @@ def test_run_simple_spec(mock_app_run, spec_file):
     runner = CliRunner()
     runner.invoke(main, ['run', spec_file], catch_exceptions=False)
 
-    mock_app_run.run.assert_called_with(port=default_port, server=None)
+    mock_app_run.run.assert_called_with(
+        port=default_port,
+        server=None,
+        strict_validation=False,
+        swagger_json=None,
+        swagger_path=None,
+        swagger_ui=None,
+        swagger_url=None,
+        auth_all_paths=False,
+        validate_responses=False,
+        debug=False)
 
 
 def test_run_in_debug_mode(mock_app_run, spec_file, monkeypatch):
@@ -61,8 +71,8 @@ def test_run_unimplemented_operations_and_stub(mock_app_run):
     spec_file = str(FIXTURES_FOLDER / 'module_does_not_exist/swagger.yaml')
     with pytest.raises(ImportError):
         runner.invoke(main, ['run', spec_file], catch_exceptions=False)
-    # yet can be run with -s (stub) option
-    result = runner.invoke(main, ['run', spec_file, '-s'], catch_exceptions=False)
+    # yet can be run with --stub option
+    result = runner.invoke(main, ['run', spec_file, '--stub'], catch_exceptions=False)
     assert result.exit_code == 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,11 @@
 import logging
 
 from click.testing import CliRunner
-from connexion import App, __version__
-from connexion.cli import main
 
 import pytest
 from conftest import FIXTURES_FOLDER
+from connexion import App
+from connexion.cli import main
 from mock import MagicMock
 
 
@@ -27,14 +27,10 @@ def test_run_missing_spec():
 def test_run_simple_spec(mock_app_run):
     spec_file = str(FIXTURES_FOLDER / 'simple/swagger.yaml')
     default_port = 5000
-    default_server = 'gevent'
     runner = CliRunner()
-    result = runner.invoke(main,
-                           ['run', spec_file],
-                           catch_exceptions=False)
+    runner.invoke(main, ['run', spec_file], catch_exceptions=False)
 
-    mock_app_run.run.assert_called_with(port=default_port, server=default_server)
-    assert 'Running at' in result.output
+    mock_app_run.run.assert_called_with(port=default_port, server=None)
 
 
 def test_run_in_debug_mode(mock_app_run, monkeypatch):
@@ -45,8 +41,6 @@ def test_run_in_debug_mode(mock_app_run, monkeypatch):
                         logging_config)
 
     runner = CliRunner()
-    result = runner.invoke(main,
-                           ['run', spec_file, '-d'],
-                           catch_exceptions=False)
+    runner.invoke(main, ['run', spec_file, '-d'], catch_exceptions=False)
 
     logging_config.assert_called_with(level=logging.DEBUG)


### PR DESCRIPTION
Currently creating or developing an API with Connexion means that you need to Copy&Paste® a little boilerplate (small, but still) code.

```
import connexion

app = connexion.App(__name__, specification_dir='swagger/')
app.add_api('my_api.yaml')
app.run(port=8080)
```

Plus would be nice to configure some logging, more Copy&Paste®.

```
import logging
logging.basicConfig(level=logging.DEBUG)
```

Then would be nice to have a command line to run the project. Let me Copy&Paste® this little CLI tool boilerplate code structure.

```
import click
@click.command()
def run():
    ...
```

**Alternatively**, we could provide this minimal set of common practices of creating apps using Connexion bundled already within the installation of Connexion itself. To create a Microservice using Connexion, developers would only need to worry about the OpenAPI specification and the actual business logic/Python code. Then run the server using:

```
$ connexion run my_api.yaml
```
or
```
$ cnx run my_api.yaml -p 8080 --debug
```

Other use case is when during the development we want to run the server with partially implemented endpoints. Just run it:

```
$ cnx run my_unfinished_api.yaml --stub
```

Endpoints not implemented yet will return an error message saying that the operation is not yet implemented.

Those changes will make Connexion sail smoothly and providing fast satisfactory results will definitely improve the success of Connexion.

***Important to notice***
This is not a breaking change and all other functionality continues to work the same.

Changes proposed in this pull request:

 - Adds a the class `StubResolver` to provide a easy way to stub not implemented or not found operations;
 - Adds a command line tool for running specifications (`connexion` or `cnx`).

I hope you will like it! ❤️ 