### PR TITLE
Fixed response validation when a flask.response object is being returned by a service endpoint.

### DIFF
--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -21,6 +21,7 @@ from jsonschema import ValidationError
 from ..exceptions import (NonConformingResponseBody,
                           NonConformingResponseHeaders)
 from ..problem import problem
+from ..utils import is_flask_response
 from ..utils import produces_json
 from .decorator import BaseDecorator
 from .validation import ResponseBodyValidator
@@ -57,8 +58,11 @@ class ResponseValidator(BaseDecorator):
             try:
                 # For cases of custom encoders, we need to encode and decode to
                 # transform to the actual types that are going to be returned.
-                data = json.dumps(data)
-                data = json.loads(data)
+                if not is_flask_response(data):
+                    data = json.dumps(data)
+                    data = json.loads(data)
+                else:
+                    data = json.loads(data.get_data())
 
                 v.validate_schema(data)
             except ValidationError as e:

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -152,3 +152,14 @@ def test_maybe_blob_or_json(simple_app):
     text, number = unpack('!4sh', resp.data)
     assert text == b'cool'
     assert number == 8
+
+def test_flask_response(simple_app):
+    app_client = simple_app.app.test_client()
+
+    resp = app_client.get('/v1.0/flask-response')
+    assert resp.status_code == 200
+    assert resp.content_type == 'application/json'
+
+    response = json.loads(resp.data.decode())
+    assert response['message'] == 'Hello'
+

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -3,7 +3,7 @@
 import json
 
 from connexion import NoContent, problem, request
-from flask import redirect
+from flask import redirect, make_response
 
 
 class DummyClass(object):
@@ -351,3 +351,9 @@ def more_than_one_scope_defined():
 
 def test_args_kwargs(*args, **kwargs):
     return kwargs
+
+def get_flask_response():
+    response = make_response(json.dumps({'message':'Hello'}), 200)
+    response.mimetype = 'application/json'
+
+    return response

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -630,6 +630,22 @@ paths:
           schema:
             type: object
 
+  /flask-response:
+    get:
+      operationId: fakeapi.hello.get_flask_response
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                description: Test message
+            required:
+            - message
 
 definitions:
   new_stack:


### PR DESCRIPTION
I found that if connexion is set to validate **responses** and a service endpoint (or controller method) returns a flask.response object there is a TypeError exception being thrown from decorators/response.validate_response().

The reason is the current code tries to perform json.dumps() on a flask.response object which fails. It looks like only the case where an endpoint returns separate response body, http status and headers is handled in validation. 

My proposed fix is to check whether the response is a flask.response object and if is to perform json.dumps on its data property (via get_data() method, since flask documentation advises against using the flask.response.data directly).