### PR TITLE
Add CLI option to isort to output diff of proposed changes.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands=python setup.py flake8
 [testenv:isort-check]
 basepython=python3
 deps=isort
-commands=isort -ns __init__.py -rc -c {toxinidir}/connexion {toxinidir}/examples {toxinidir}/tests
+commands=isort -ns __init__.py -rc -c -df {toxinidir}/connexion {toxinidir}/examples {toxinidir}/tests
 
 [testenv:py35-flask0.10.1]
 deps=flask==0.10.1


### PR DESCRIPTION
It took me a while to dig down to the fact that my global Python3 interpreter has a different version from the tox one, which leads to all sorts of weird default isort behaviour.

With this extra flag, Travis will tell you precisely which imports isort would like to see changed.