### PR TITLE
Add a --base-path option to the CLI

### DIFF
--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -71,6 +71,8 @@ def main():
 @click.option('--debug', '-d', help='Show debugging information.',
               is_flag=True, default=False)
 @click.option('--verbose', '-v', help='Show verbose information.', count=True)
+@click.option('--base-path', metavar='PATH',
+              help='Override the basePath in the API spec.')
 def run(spec_file,
         base_module_path,
         port,
@@ -84,7 +86,8 @@ def run(spec_file,
         validate_responses,
         strict_validation,
         debug,
-        verbose):
+        verbose,
+        base_path):
     """
     Runs a server compliant with a OpenAPI/Swagger 2.0 Specification file.
 
@@ -122,6 +125,7 @@ def run(spec_file,
                         debug=debug)
 
     app.add_api(spec_file_full_path,
+                base_path=base_path,
                 resolver_error=resolver_error,
                 validate_responses=validate_responses,
                 strict_validation=strict_validation)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -166,6 +166,18 @@ def test_run_in_verbose_mode(mock_app_run, expected_arguments, spec_file,
     mock_app_run.assert_called_with('connexion.cli', **expected_arguments)
 
 
+def test_run_using_option_base_path(mock_app_run, expected_arguments,
+                                    spec_file):
+    runner = CliRunner()
+    runner.invoke(main, ['run', spec_file, '--base-path', '/foo'],
+                  catch_exceptions=False)
+
+    expected_arguments = dict(base_path='/foo',
+                              resolver_error=None,
+                              validate_responses=False,
+                              strict_validation=False)
+    mock_app_run().add_api.assert_called_with(spec_file, **expected_arguments)
+
 
 def test_run_unimplemented_operations_and_stub(mock_app_run):
     runner = CliRunner()


### PR DESCRIPTION
Changes proposed in this pull request:

 - add a --base-path option to the CLI which overrides (or provides) the basePath from the spec

This allows deploying at different paths without editing the API spec.
