### PR TITLE
host arg for app object (instead of hardcode 0.0.0.0 interface)

### DIFF
--- a/connexion/app.py
+++ b/connexion/app.py
@@ -250,7 +250,7 @@ class App(object):
         if host is not None:
             self.host = host
         elif self.host is None:
-            self.host = '0.0.0.0'
+            self.host = '::'
 
         if port is not None:
             self.port = port


### PR DESCRIPTION
Fixes broken ipv6 support (hardcoded 0.0.0.0 listen interface in app.py)



Changes proposed in this pull request:

 - Added host arg for App object, now we can redefine host to listen on
 - By default listen host='::' interface instead host='0.0.0.0'. App would think its in ipv6-only world, but you could access it thru ipv4 cause OS would map your ipv4 addr to ipv6 (see http://stackoverflow.com/a/21689979)

