### PR TITLE
#290 fix basePath with trailing slash

### DIFF
--- a/connexion/api.py
+++ b/connexion/api.py
@@ -46,6 +46,13 @@ def compatibility_layer(spec):
     return spec
 
 
+def canonical_base_url(base_path):
+    """
+    Make given "basePath" a canonical base URL which can be prepended to paths starting with "/".
+    """
+    return base_path.rstrip('/')
+
+
 class Api(object):
     """
     Single API that corresponds to a flask blueprint
@@ -104,9 +111,9 @@ class Api(object):
         # https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#fixed-fields
         # If base_url is not on provided then we try to read it from the swagger.yaml or use / by default
         if base_url is None:
-            self.base_url = self.specification.get('basePath', '')  # type: dict
+            self.base_url = canonical_base_url(self.specification.get('basePath', ''))
         else:
-            self.base_url = base_url
+            self.base_url = canonical_base_url(base_url)
             self.specification['basePath'] = base_url
 
         # A list of MIME types the APIs can produce. This is global to all APIs but can be overridden on specific

--- a/tests/fixtures/simple/basepath-slash.yaml
+++ b/tests/fixtures/simple/basepath-slash.yaml
@@ -1,0 +1,25 @@
+swagger: "2.0"
+
+info:
+  title: "Test basePath == /"
+  version: "1.0"
+
+basePath: /
+
+paths:
+  /greeting/{name}:
+    post:
+      summary: Generate greeting
+      description: Generates a greeting message.
+      operationId: fakeapi.hello.post_greeting
+      responses:
+        '200':
+          description: greeting response
+          schema:
+            type: object
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to greet.
+          required: true
+          type: string

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,7 @@
 import pathlib
 import tempfile
 
-from connexion.api import Api
+from connexion.api import Api, canonical_base_url
 from connexion.exceptions import InvalidSpecification, ResolverError
 from swagger_spec_validator.common import SwaggerValidationError
 from yaml import YAMLError
@@ -11,6 +11,13 @@ from yaml import YAMLError
 import pytest
 
 TEST_FOLDER = pathlib.Path(__file__).parent
+
+
+def test_canonical_base_url():
+    assert canonical_base_url('') == ''
+    assert canonical_base_url('/') == ''
+    assert canonical_base_url('/api') == '/api'
+    assert canonical_base_url('/api/') == '/api'
 
 
 def test_api():
@@ -22,6 +29,12 @@ def test_api():
     api2 = Api(TEST_FOLDER / "fixtures/simple/swagger.yaml")
     assert api2.blueprint.name == '/v1_0'
     assert api2.blueprint.url_prefix == '/v1.0'
+
+
+def test_api_basepath_slash():
+    api = Api(TEST_FOLDER / "fixtures/simple/basepath-slash.yaml", None, {})
+    assert api.blueprint.name == ''
+    assert api.blueprint.url_prefix == ''
 
 
 def test_template():


### PR DESCRIPTION
Fixes #290.

Strip trailing slashes from `basePath` to fix URL routing.