### PR TITLE
Receiving --host or -H option via CLI and writing test cases.

### DIFF
--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -42,6 +42,7 @@ def main():
 @click.argument('spec_file')
 @click.argument('base_module_path', required=False)
 @click.option('--port', '-p', default=5000, type=int, help='Port to listen.')
+@click.option('--host', '-H', default=None, type=str, help='Host to listen.')
 @click.option('--wsgi-server', '-w', default='flask',
               type=click.Choice(['flask', 'gevent', 'tornado']),
               callback=validate_wsgi_server_requirements,
@@ -79,6 +80,7 @@ def main():
 def run(spec_file,
         base_module_path,
         port,
+        host,
         wsgi_server,
         stub,
         mock,
@@ -141,6 +143,7 @@ def run(spec_file,
                 **api_extra_args)
 
     app.run(port=port,
+            host=host,
             server=wsgi_server,
             debug=debug)
 

--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -42,7 +42,7 @@ def main():
 @click.argument('spec_file')
 @click.argument('base_module_path', required=False)
 @click.option('--port', '-p', default=5000, type=int, help='Port to listen.')
-@click.option('--host', '-H', default=None, type=str, help='Host to listen.')
+@click.option('--host', '-H', type=str, help='Host interface to bind on.')
 @click.option('--wsgi-server', '-w', default='flask',
               type=click.Choice(['flask', 'gevent', 'tornado']),
               callback=validate_wsgi_server_requirements,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,6 +59,20 @@ def test_run_simple_spec(mock_app_run, spec_file):
     app_instance = mock_app_run()
     app_instance.run.assert_called_with(
         port=default_port,
+        host=None,
+        server=None,
+        debug=False)
+
+
+def test_run_spec_with_host(mock_app_run, spec_file):
+    default_port = 5000
+    runner = CliRunner()
+    runner.invoke(main, ['run', spec_file, '--host', 'custom.host'], catch_exceptions=False)
+
+    app_instance = mock_app_run()
+    app_instance.run.assert_called_with(
+        port=default_port,
+        host='custom.host',
         server=None,
         debug=False)
 


### PR DESCRIPTION
Fixes #304.

Changes proposed in this pull request:

 - receive `--host` or `-H` option which defaults to None
 - make use of host parameters introduced in  #298 
 - test cases where users specify a host and cases when they don’t

We’re using `-H` instead of `-h` in order not to be confused with help arguments.
Fabric also uses `-H` as host parameter.