### PR TITLE
No json pretty printing

### DIFF
--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -125,7 +125,7 @@ class Jsonifier(BaseSerializer):
                 logger.debug('Endpoint returned an empty response (204)', extra={'url': url, 'mimetype': self.mimetype})
                 return '', 204, headers
 
-            data = [json.dumps(data, indent=2), '\n']
+            data = json.dumps(data)
             response = flask.current_app.response_class(data, mimetype=self.mimetype)  # type: flask.Response
             response = self.process_headers(response, headers)
 

--- a/connexion/problem.py
+++ b/connexion/problem.py
@@ -41,13 +41,13 @@ def problem(status, title, detail, type='about:blank', instance=None, headers=No
     :return: Json serialized error response
     :rtype: flask.Response
     """
-    problem_response = {'type': type, 'title': title, 'detail': detail, 'status': status, }
+    problem_response = {'type': type, 'title': title, 'detail': detail, 'status': status}
     if instance:
         problem_response['instance'] = instance
     if ext:
         problem_response.update(ext)
 
-    body = [json.dumps(problem_response, indent=2), '\n']
+    body = json.dumps(problem_response)
     response = flask.current_app.response_class(body, mimetype='application/problem+json',
                                                 status=status)  # type: flask.Response
     if headers:

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -109,13 +109,13 @@ def test_single_route(simple_app):
 def test_resolve_method(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/resolver-test/method')  # type: flask.Response
-    assert resp.data.decode() == '"DummyClass"\n'
+    assert resp.data.decode() == '"DummyClass"'
 
 
 def test_resolve_classmethod(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/resolver-test/classmethod')  # type: flask.Response
-    assert resp.data.decode() == '"DummyClass"\n'
+    assert resp.data.decode() == '"DummyClass"'
 
 
 def test_add_api_with_function_resolver_function_is_wrapped(simple_api_spec_dir):

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -74,7 +74,7 @@ def test_strict_extra_query_param(strict_app):
 def test_path_parameter_someint(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-int-path/123')  # type: flask.Response
-    assert resp.data.decode() == '"int"\n'
+    assert resp.data.decode() == '"int"'
 
     # non-integer values will not match Flask route
     resp = app_client.get('/v1.0/test-int-path/foo')  # type: flask.Response
@@ -84,7 +84,7 @@ def test_path_parameter_someint(simple_app):
 def test_path_parameter_somefloat(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-float-path/123.45')  # type: flask.Response
-    assert resp.data.decode() == '"float"\n'
+    assert resp.data.decode() == '"float"'
 
     # non-float values will not match Flask route
     resp = app_client.get('/v1.0/test-float-path/123,45')  # type: flask.Response


### PR DESCRIPTION
Changes proposed in this pull request:

 - Do not pretty print returned json payload

Personally I think it is not best practice to return pretty printed json. This only unnecessarily enlarges the payload to be returned and this increase can be significant. Pretty printing should be
handled by the client instead.