### PR TITLE
Support app.add_api() with API-dictionary as an alternative to file path

### DIFF
--- a/connexion/api.py
+++ b/connexion/api.py
@@ -58,12 +58,12 @@ class Api(object):
     Single API that corresponds to a flask blueprint
     """
 
-    def __init__(self, swagger_yaml_path, base_url=None, arguments=None,
+    def __init__(self, specification, base_url=None, arguments=None,
                  swagger_json=None, swagger_ui=None, swagger_path=None, swagger_url=None,
                  validate_responses=False, strict_validation=False, resolver=None,
                  auth_all_paths=False, debug=False, resolver_error_handler=None):
         """
-        :type swagger_yaml_path: pathlib.Path
+        :type specification: pathlib.Path | dict
         :type base_url: str | None
         :type arguments: dict | None
         :type swagger_json: bool
@@ -81,8 +81,8 @@ class Api(object):
         """
         self.debug = debug
         self.resolver_error_handler = resolver_error_handler
-        logger.debug('Loading specification: %s', swagger_yaml_path,
-                     extra={'swagger_yaml': swagger_yaml_path,
+        logger.debug('Loading specification: %s', specification,
+                     extra={'swagger_yaml': specification,
                             'base_url': base_url,
                             'arguments': arguments,
                             'swagger_ui': swagger_ui,
@@ -90,11 +90,11 @@ class Api(object):
                             'swagger_url': swagger_url,
                             'auth_all_paths': auth_all_paths})
 
-        if isinstance(swagger_yaml_path, dict):
-            self.specification = swagger_yaml_path
+        if isinstance(specification, dict):
+            self.specification = specification
         else:
-            self.swagger_yaml_path = pathlib.Path(swagger_yaml_path)
-            self.load_spec_from_file(arguments, swagger_yaml_path)
+            self.specification = pathlib.Path(specification)
+            self.load_spec_from_file(arguments, specification)
 
         self.specification = compatibility_layer(self.specification)
         logger.debug('Read specification', extra={'spec': self.specification})
@@ -309,10 +309,10 @@ class Api(object):
         """
         return flask.send_from_directory(str(self.swagger_path), filename)
 
-    def load_spec_from_file(self, arguments, swagger_yaml_path):
+    def load_spec_from_file(self, arguments, specification):
         arguments = arguments or {}
 
-        with swagger_yaml_path.open(mode='rb') as swagger_yaml:
+        with specification.open(mode='rb') as swagger_yaml:
             contents = swagger_yaml.read()
             try:
                 swagger_template = contents.decode()

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -93,8 +93,8 @@ class Api(object):
         if isinstance(specification, dict):
             self.specification = specification
         else:
-            self.specification = pathlib.Path(specification)
-            self.load_spec_from_file(arguments, specification)
+            specification_path = pathlib.Path(specification)
+            self.specification = self.load_spec_from_file(arguments, specification_path)
 
         self.specification = compatibility_layer(self.specification)
         logger.debug('Read specification', extra={'spec': self.specification})
@@ -320,4 +320,4 @@ class Api(object):
                 swagger_template = contents.decode('utf-8', 'replace')
 
             swagger_string = jinja2.Template(swagger_template).render(**arguments)
-            self.specification = yaml.safe_load(swagger_string)  # type: dict
+            return yaml.safe_load(swagger_string)  # type: dict

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -84,14 +84,14 @@ class App(object):
             exception = werkzeug.exceptions.InternalServerError()
         return problem(title=exception.name, detail=exception.description, status=exception.code)
 
-    def add_api(self, swagger_file, base_path=None, arguments=None, auth_all_paths=None, swagger_json=None,
+    def add_api(self, specification, base_path=None, arguments=None, auth_all_paths=None, swagger_json=None,
                 swagger_ui=None, swagger_path=None, swagger_url=None, validate_responses=False,
                 strict_validation=False, resolver=Resolver(), resolver_error=None):
         """
-        Adds an API to the application based on a swagger file
+        Adds an API to the application based on a swagger file or API dict
 
-        :param swagger_file: swagger file with the specification
-        :type swagger_file: pathlib.Path
+        :param specification: swagger file with the specification | specification dict
+        :type specification: pathlib.Path or dict
         :param base_path: base path where to add this api
         :type base_path: str | None
         :param arguments: api version specific arguments to replace on the specification
@@ -130,17 +130,17 @@ class App(object):
         swagger_path = swagger_path if swagger_path is not None else self.swagger_path
         swagger_url = swagger_url if swagger_url is not None else self.swagger_url
         auth_all_paths = auth_all_paths if auth_all_paths is not None else self.auth_all_paths
-        logger.debug('Adding API: %s', swagger_file)
+        logger.debug('Adding API: %s', specification)
         # TODO test if base_url starts with an / (if not none)
         arguments = arguments or dict()
         arguments = dict(self.arguments, **arguments)  # copy global arguments and update with api specfic
 
-        if isinstance(swagger_file, dict):
-            yaml_path = swagger_file
+        if isinstance(specification, dict):
+            specification = specification
         else:
-            yaml_path = self.specification_dir / swagger_file
+            specification = self.specification_dir / specification
 
-        api = Api(swagger_yaml_path=yaml_path,
+        api = Api(specification=specification,
                   base_url=base_path, arguments=arguments,
                   swagger_json=swagger_json,
                   swagger_ui=swagger_ui,

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -130,7 +130,6 @@ class App(object):
         swagger_path = swagger_path if swagger_path is not None else self.swagger_path
         swagger_url = swagger_url if swagger_url is not None else self.swagger_url
         auth_all_paths = auth_all_paths if auth_all_paths is not None else self.auth_all_paths
-        logger.debug('Adding API: %s', specification)
         # TODO test if base_url starts with an / (if not none)
         arguments = arguments or dict()
         arguments = dict(self.arguments, **arguments)  # copy global arguments and update with api specfic

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -134,7 +134,12 @@ class App(object):
         # TODO test if base_url starts with an / (if not none)
         arguments = arguments or dict()
         arguments = dict(self.arguments, **arguments)  # copy global arguments and update with api specfic
-        yaml_path = self.specification_dir / swagger_file
+
+        if isinstance(swagger_file, dict):
+            yaml_path = swagger_file
+        else:
+            yaml_path = self.specification_dir / swagger_file
+
         api = Api(swagger_yaml_path=yaml_path,
                   base_url=base_path, arguments=arguments,
                   swagger_json=swagger_json,

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -2,6 +2,8 @@ from connexion.app import App
 from connexion.exceptions import InvalidSpecification
 
 import pytest
+import jinja2
+import yaml
 from conftest import TEST_FOLDER, build_app_from_fixture
 
 
@@ -50,6 +52,28 @@ def test_no_swagger_json_app(simple_api_spec_dir):
     app_client = app.app.test_client()
     swagger_json = app_client.get('/v1.0/swagger.json')  # type: flask.Response
     assert swagger_json.status_code == 404
+
+
+def test_dic_as_yaml_path(simple_api_spec_dir):
+
+    swagger_yaml_path = simple_api_spec_dir / 'swagger.yaml'
+
+    with swagger_yaml_path.open(mode='rb') as swagger_yaml:
+        contents = swagger_yaml.read()
+        try:
+            swagger_template = contents.decode()
+        except UnicodeDecodeError:
+            swagger_template = contents.decode('utf-8', 'replace')
+
+        swagger_string = jinja2.Template(swagger_template).render({})
+        specification = yaml.safe_load(swagger_string)  # type: dict
+
+    app = App(__name__, 5001, simple_api_spec_dir, debug=True)
+    app.add_api(specification)
+
+    app_client = app.app.test_client()
+    swagger_json = app_client.get('/v1.0/swagger.json')  # type: flask.Response
+    assert swagger_json.status_code == 200
 
 
 def test_swagger_json_api(simple_api_spec_dir):

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -54,7 +54,7 @@ def test_no_swagger_json_app(simple_api_spec_dir):
     assert swagger_json.status_code == 404
 
 
-def test_dic_as_yaml_path(simple_api_spec_dir):
+def test_dict_as_yaml_path(simple_api_spec_dir):
 
     swagger_yaml_path = simple_api_spec_dir / 'swagger.yaml'
 

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -1,10 +1,9 @@
-from connexion.app import App
-from connexion.exceptions import InvalidSpecification
-
-import pytest
 import jinja2
+import pytest
 import yaml
 from conftest import TEST_FOLDER, build_app_from_fixture
+from connexion.app import App
+from connexion.exceptions import InvalidSpecification
 
 
 def test_app_with_relative_path(simple_api_spec_dir):

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -1,6 +1,6 @@
 import jinja2
-import pytest
 import yaml
+import pytest
 from conftest import TEST_FOLDER, build_app_from_fixture
 from connexion.app import App
 from connexion.exceptions import InvalidSpecification


### PR DESCRIPTION
Fixes #296 

Changes proposed in this pull request:
- Add support for an API-dictionary argument to app.add_api() as an alternative to a file path.
- test case creating app and using add_api() with an API-dictionary
- Currently the param is still called swagger_file, this and other params should probably change I am just not sure what to change it to.
