### PR TITLE
Using Requirements Builder for Tox setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6-dev"
 install:
   - pip install tox tox-travis coveralls
 script:

--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -3,9 +3,9 @@ import sys
 from os import path
 
 import click
+from clickclick import AliasedGroup, fatal_error
 
 import connexion
-from clickclick import AliasedGroup, fatal_error
 from connexion.mock import MockResolver
 
 logger = logging.getLogger('connexion.cli')

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,0 +1,10 @@
+-e git+https://github.com/Julian/jsonschema.git#egg=jsonschema
+-e git+https://github.com/pallets/flask.git#egg=flask
+-e git+https://github.com/kennethreitz/requests#egg=requests
+-e hg+https://bitbucket.org/gutworth/six#egg=six
+-e git+https://github.com/danielrichman/strict-rfc3339.git#egg=strict-rfc3339
+-e git+https://github.com/digium/swagger-py.git#egg=swagger-spec-validator
+-e git+https://github.com/zalando/python-clickclick.git#egg=clickclick
+-e hg+https://bitbucket.org/pitrou/pathlib#egg=pathlib
+# PyYAML is not that easy to build manually, it may fail.
+#-e svn+http://svn.pyyaml.org/pyyaml/trunk#egg=PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-jsonschema>=2.5.1
-flask>=0.10.1
-PyYAML>=3.11
-requests>=2.9.1
-six>=1.7
-strict-rfc3339>=0.6
-swagger_spec_validator>=2.0.2
-clickclick>=1.2

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 import platform
 import sys
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
 
 __location__ = os.path.join(os.getcwd(), os.path.dirname(inspect.getfile(inspect.currentframe())))
@@ -23,12 +23,26 @@ version = read_version('connexion')
 py_major_minor_version = tuple(int(v.rstrip('+')) for v in platform.python_version_tuple()[:2])
 
 
-def get_install_requirements(path):
-    content = open(os.path.join(__location__, path)).read()
-    requires = [req for req in content.split('\\n') if req != '']
-    if py_major_minor_version < (3, 4):
-        requires.append('pathlib')
-    return requires
+install_requires = [
+    'clickclick>=1.2',
+    'flask>=0.10.1',
+    'jsonschema>=2.5.1',
+    'PyYAML>=3.11',
+    'requests>=2.9.1',
+    'six>=1.9',
+    'strict-rfc3339>=0.6',
+    'swagger-spec-validator>=2.0.2',
+]
+
+if py_major_minor_version < (3, 4):
+    install_requires.append('pathlib>=1.0.1')
+
+tests_require = [
+    'decorator',
+    'mock',
+    'pytest',
+    'pytest-cov'
+]
 
 
 class PyTest(TestCommand):
@@ -72,8 +86,9 @@ setup(
     keywords='openapi oai swagger rest api oauth flask microservice framework',
     license='Apache License Version 2.0',
     setup_requires=['flake8'],
-    install_requires=get_install_requirements('requirements.txt'),
-    tests_require=['pytest-cov', 'pytest', 'mock', 'decorator'],
+    install_requires=install_requires,
+    tests_require=tests_require,
+    extras_require={'tests': tests_require},
     cmdclass={'test': PyTest},
     test_suite='tests',
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,15 @@ max-line-length=120
 exclude=connexion/__init__.py
 
 [tox]
-envlist=pypy,py27,py34,py35,py35-flask0.10.1,isort-check,isort-check-examples,isort-check-tests,flake8
+envlist =
+    {pypy}-{min,pypi,dev}
+    {py27}-{min,pypi,dev}
+    {py34}-{min,pypi,dev}
+    {py35}-{min,pypi,dev}
+    isort-check
+    isort-check-examples
+    isort-check-tests
+    flake8
 
 [tox:travis]
 pypy=pypy
@@ -12,7 +20,17 @@ pypy=pypy
 3.5=py35,isort-check,isort-check-examples,isort-check-tests,flake8
 
 [testenv]
-commands=python setup.py test
+setenv=PYTHONPATH = {toxinidir}:{toxinidir}
+deps=pytest
+commands=
+    pip install Requirements-Builder
+    min: requirements-builder --level=min -o {toxworkdir}/requirements-min.txt setup.py
+    min: pip install -r {toxworkdir}/requirements-min.txt
+    pypi: requirements-builder --level=pypi -o {toxworkdir}/requirements-pypi.txt setup.py
+    pypi: pip install -r {toxworkdir}/requirements-pypi.txt
+    dev: requirements-builder --level=dev --req=requirements-devel.txt -o {toxworkdir}/requirements-dev.txt setup.py
+    dev: pip install -r {toxworkdir}/requirements-dev.txt
+    python setup.py test
 
 [testenv:flake8]
 deps=flake8
@@ -35,6 +53,3 @@ basepython=python3
 deps=isort
 changedir={toxinidir}/tests
 commands=isort -ns __init__.py -p connexion -rc -c -df .
-
-[testenv:py35-flask0.10.1]
-deps=flask==0.10.1


### PR DESCRIPTION
Fixes minimal version for `six` .

**Changes proposed in this pull request:**

[Requirements Builder](https://pypi.python.org/pypi/requirements-builder) provides a way to run tests against all interesting
versions of the requirements: minimal, latest as well as development
(from git, hg, svn).

It requires to move the requirements into the setup.py and to provide a
minimal version. requirements-devel aims at helping you working

* It detected a conflict with six version which had to be bumped up;
* building PyYAML from Subversion fails so it's commented in the
  requirement-devel.txt file.

A cool blog post on how to keep some balance between setup.py and
requirements.txt file:
https://caremad.io/posts/2013/07/setup-vs-requirement/

**PS:** the build fails because of the `isort` test which I didn't touch.