### PR TITLE
Fix isort checks

### DIFF
--- a/connexion/api.py
+++ b/connexion/api.py
@@ -7,6 +7,7 @@ import flask
 import jinja2
 import six
 import werkzeug.exceptions
+
 import yaml
 from swagger_spec_validator.validator20 import validate_spec
 

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -3,6 +3,7 @@ import pathlib
 
 import flask
 import werkzeug.exceptions
+
 from connexion.decorators.produces import JSONEncoder as ConnexionJSONEncoder
 from connexion.resolver import Resolver
 

--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -3,6 +3,7 @@ import sys
 from os import path
 
 import click
+
 import connexion
 from clickclick import AliasedGroup, fatal_error
 from connexion.mock import MockResolver

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -1,8 +1,7 @@
-from connexion.app import App
-from connexion.exceptions import InvalidSpecification
-
 import pytest
 from conftest import TEST_FOLDER, build_app_from_fixture
+from connexion.app import App
+from connexion.exceptions import InvalidSpecification
 
 
 def test_app_with_relative_path(simple_api_spec_dir):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,8 @@ import json
 import logging
 import pathlib
 
-from connexion.app import App
-
 import pytest
+from connexion.app import App
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/tests/decorators/test_security.py
+++ b/tests/decorators/test_security.py
@@ -1,6 +1,5 @@
 from connexion.decorators.security import get_tokeninfo_url, verify_oauth
 from connexion.problem import problem
-
 from mock import MagicMock
 
 

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
-from connexion import NoContent, problem, request
 from flask import redirect
+
+from connexion import NoContent, problem, request
 
 
 class DummyClass(object):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,12 +3,12 @@
 import pathlib
 import tempfile
 
-from connexion.api import Api, canonical_base_url
-from connexion.exceptions import InvalidSpecification, ResolverError
 from swagger_spec_validator.common import SwaggerValidationError
 from yaml import YAMLError
 
 import pytest
+from connexion.api import Api, canonical_base_url
+from connexion.exceptions import InvalidSpecification, ResolverError
 
 TEST_FOLDER = pathlib.Path(__file__).parent
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,12 @@
 import logging
 
-import connexion
 from click.testing import CliRunner
-from connexion.cli import main
-from connexion.exceptions import ResolverError
 
+import connexion
 import pytest
 from conftest import FIXTURES_FOLDER
+from connexion.cli import main
+from connexion.exceptions import ResolverError
 from mock import MagicMock
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,5 +1,4 @@
 from connexion.decorators.metrics import UWSGIMetricsCollector
-
 from mock import MagicMock
 
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1,12 +1,11 @@
 import pathlib
 import types
 
+import pytest
 from connexion.decorators.security import security_passthrough, verify_oauth
 from connexion.exceptions import InvalidSpecification
 from connexion.operation import Operation
 from connexion.resolver import Resolver
-
-import pytest
 
 TEST_FOLDER = pathlib.Path(__file__).parent
 

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1,6 +1,6 @@
-from connexion.decorators.parameter import inspect_function_arguments
-
 import decorator
+
+from connexion.decorators.parameter import inspect_function_arguments
 
 
 @decorator.decorator

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,9 +1,8 @@
 import connexion.app
+import pytest
 from connexion.exceptions import ResolverError
 from connexion.operation import Operation
 from connexion.resolver import Resolver, RestyResolver
-
-import pytest
 
 PARAMETER_DEFINITIONS = {'myparam': {'in': 'path', 'type': 'integer'}}
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,6 @@ import math
 
 import connexion.app
 import connexion.utils as utils
-
 import pytest
 from mock import MagicMock
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,7 +1,6 @@
 import json
 
 from connexion.decorators.validation import ParameterValidator
-
 # we are using "mock" module here for Py 2.7 support
 from mock import MagicMock
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,9 +2,8 @@ import json
 import logging
 import pathlib
 
-from connexion.app import App
-
 import pytest
+from connexion.app import App
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,13 @@ max-line-length=120
 exclude=connexion/__init__.py
 
 [tox]
-envlist=pypy,py27,py34,py35,py35-flask0.10.1,isort-check,flake8
+envlist=pypy,py27,py34,py35,py35-flask0.10.1,isort-check,isort-check-examples,isort-check-tests,flake8
 
 [tox:travis]
 pypy=pypy
 2.7=py27
 3.4=py34
-3.5=py35,isort-check,flake8
+3.5=py35,isort-check,isort-check-examples,isort-check-tests,flake8
 
 [testenv]
 commands=python setup.py test
@@ -21,7 +21,20 @@ commands=python setup.py flake8
 [testenv:isort-check]
 basepython=python3
 deps=isort
-commands=isort -ns __init__.py -rc -c -df {toxinidir}/connexion {toxinidir}/examples {toxinidir}/tests
+changedir={toxinidir}/connexion
+commands=isort -ns __init__.py -rc -c -df .
+
+[testenv:isort-check-examples]
+basepython=python3
+deps=isort
+changedir={toxinidir}/examples
+commands=isort -ns __init__.py -o connexion -rc -c -df .
+
+[testenv:isort-check-tests]
+basepython=python3
+deps=isort
+changedir={toxinidir}/tests
+commands=isort -ns __init__.py -p connexion -rc -c -df .
 
 [testenv:py35-flask0.10.1]
 deps=flask==0.10.1


### PR DESCRIPTION
Fixes the isort checks within tox

The idea is that within `connexion`, `connexion` is a first party, within `examples` it's a third party and within `tests` it's a first party as well. It's probably hard to get it working within an editor.

Changes proposed in this pull request:

 - separate the isort checks per folder
 - apply the proposed changes by isort on the existing code
 
Cheers,