### PR TITLE
Ensure that 204 and NoContent responses have the correct Content-Type

### DIFF
--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -106,13 +106,15 @@ class Jsonifier(BaseSerializer):
             if is_flask_response(data):
                 logger.debug('Endpoint returned a Flask Response', extra={'url': url, 'mimetype': data.mimetype})
                 return data
-            elif data is NoContent:
-                return '', status_code, headers
+
+            if data is NoContent:
+                data = ''
             elif status_code == 204:
                 logger.debug('Endpoint returned an empty response (204)', extra={'url': url, 'mimetype': self.mimetype})
-                return '', 204, headers
+                data = ''
+            else:
+                data = [json.dumps(data, indent=2), '\n']
 
-            data = [json.dumps(data, indent=2), '\n']
             response = flask.current_app.response_class(data, mimetype=self.mimetype)  # type: flask.Response
             response = self.process_headers(response, headers)
 

--- a/tests/api/test_headers.py
+++ b/tests/api/test_headers.py
@@ -35,6 +35,7 @@ def test_no_content_response_have_headers(simple_app):
     resp = app_client.get('/v1.0/test-204-with-headers')
     assert resp.status_code == 204
     assert 'X-Something' in resp.headers
+    assert resp.headers['Content-Type'] == 'application/json'
 
 
 def test_no_content_object_and_have_headers(simple_app):
@@ -42,3 +43,4 @@ def test_no_content_object_and_have_headers(simple_app):
     resp = app_client.get('/v1.0/test-204-with-headers-nocontent-obj')
     assert resp.status_code == 204
     assert 'X-Something' in resp.headers
+    assert resp.headers['Content-Type'] == 'application/json'


### PR DESCRIPTION
Fixes #321.


Changes proposed in this pull request:

 - Uses Flask's `make_response` to construct the response when returning 204 status codes or "no content" responses, which pulls in the correct `Content-Type` header

