### PR TITLE
Allow jinja includes in swagger.yaml

### DIFF
--- a/connexion/api.py
+++ b/connexion/api.py
@@ -83,6 +83,7 @@ class Api(object):
         self.debug = debug
         self.resolver_error_handler = resolver_error_handler
         self.swagger_yaml_path = pathlib.Path(swagger_yaml_path)
+        self.jinja_environment = self.create_jinja_environment()
         logger.debug('Loading specification: %s', swagger_yaml_path,
                      extra={'swagger_yaml': swagger_yaml_path,
                             'base_url': base_url,
@@ -99,7 +100,7 @@ class Api(object):
             except UnicodeDecodeError:
                 swagger_template = contents.decode('utf-8', 'replace')
 
-            swagger_string = jinja2.Template(swagger_template).render(**arguments)
+            swagger_string = self.jinja_environment.from_string(swagger_template).render(**arguments)
             self.specification = yaml.safe_load(swagger_string)  # type: dict
 
         logger.debug('Read specification', extra={'spec': self.specification})
@@ -314,3 +315,9 @@ class Api(object):
         :type filename: str
         """
         return flask.send_from_directory(str(self.swagger_path), filename)
+
+    def create_jinja_environment(self):
+        path_string = str(self.swagger_yaml_path.parent.absolute())
+        return jinja2.Environment(
+            loader=jinja2.FileSystemLoader(path_string)
+        )

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -62,7 +62,8 @@ class Api(object):
     def __init__(self, swagger_yaml_path, base_url=None, arguments=None,
                  swagger_json=None, swagger_ui=None, swagger_path=None, swagger_url=None,
                  validate_responses=False, strict_validation=False, resolver=None,
-                 auth_all_paths=False, debug=False, resolver_error_handler=None):
+                 auth_all_paths=False, debug=False, resolver_error_handler=None,
+                 jinja_template_root=None):
         """
         :type swagger_yaml_path: pathlib.Path
         :type base_url: str | None
@@ -79,11 +80,14 @@ class Api(object):
         :param resolver_error_handler: If given, a callable that generates an
             Operation used for handling ResolveErrors
         :type resolver_error_handler: callable | None
+        :type jinja_template_root: pathlib.Path | None
         """
         self.debug = debug
         self.resolver_error_handler = resolver_error_handler
         self.swagger_yaml_path = pathlib.Path(swagger_yaml_path)
-        self.jinja_environment = self.create_jinja_environment()
+        self.jinja_environment = self.create_jinja_environment(
+            jinja_template_root or swagger_yaml_path.parent
+        )
         logger.debug('Loading specification: %s', swagger_yaml_path,
                      extra={'swagger_yaml': swagger_yaml_path,
                             'base_url': base_url,
@@ -316,8 +320,7 @@ class Api(object):
         """
         return flask.send_from_directory(str(self.swagger_path), filename)
 
-    def create_jinja_environment(self):
-        path_string = str(self.swagger_yaml_path.parent.absolute())
+    def create_jinja_environment(self, template_root):
         return jinja2.Environment(
-            loader=jinja2.FileSystemLoader(path_string)
+            loader=jinja2.FileSystemLoader(str(template_root.absolute()))
         )

--- a/connexion/api.py
+++ b/connexion/api.py
@@ -80,7 +80,7 @@ class Api(object):
         :param resolver_error_handler: If given, a callable that generates an
             Operation used for handling ResolveErrors
         :type resolver_error_handler: callable | None
-        :type jinja_template_root: pathlib.Path | None
+        :type jinja_template_root: pathlib.Path | list of pathlib.Path | None
         """
         self.debug = debug
         self.resolver_error_handler = resolver_error_handler
@@ -321,6 +321,13 @@ class Api(object):
         return flask.send_from_directory(str(self.swagger_path), filename)
 
     def create_jinja_environment(self, template_root):
+        if isinstance(template_root, pathlib.Path):
+            template_root = [template_root]
+
+        # Ensure all paths are strings as jinja2.FileSystemLoader cannot
+        # understand `Path`s
+        template_root = [str(path.resolve()) for path in template_root]
+
         return jinja2.Environment(
-            loader=jinja2.FileSystemLoader(str(template_root.absolute()))
+            loader=jinja2.FileSystemLoader(template_root)
         )

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -88,7 +88,7 @@ class App(object):
 
     def add_api(self, swagger_file, base_path=None, arguments=None, auth_all_paths=None, swagger_json=None,
                 swagger_ui=None, swagger_path=None, swagger_url=None, validate_responses=False,
-                strict_validation=False, resolver=Resolver(), resolver_error=None):
+                strict_validation=False, resolver=Resolver(), resolver_error=None, jinja_template_root=None):
         """
         Adds an API to the application based on a swagger file
 
@@ -117,6 +117,10 @@ class App(object):
         :param resolver_error: If specified, turns ResolverError into error
             responses with the given status code.
         :type resolver_error: int | None
+        :parem jinja_template_root: The location to search for Jinja include
+            templates. If not specified then the parent folder of the swagger
+            yaml path is used.
+        :type jinja_template_root: pathlib.Path | None
         :rtype: Api
         """
         # Turn the resolver_error code into a handler object
@@ -148,7 +152,9 @@ class App(object):
                   validate_responses=validate_responses,
                   strict_validation=strict_validation,
                   auth_all_paths=auth_all_paths,
-                  debug=self.debug)
+                  debug=self.debug,
+                  jinja_template_root=jinja_template_root
+                  )
         self.app.register_blueprint(api.blueprint)
         return api
 

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -72,8 +72,8 @@ https://gist.github.com/rafaelcaricio/6e67286a522f747405a7299e6843cd93
 Splitting up your swagger.yaml
 ------------------------------
 
-Connexion does not yet support the `$ref` syntax from Swagger which allows you
-to split up one big zswagger.yaml` into multiple smaller ones. There is a
+Connexion [does not support](https://github.com/zalando/connexion/issues/254) the `$ref` syntax from Swagger which allows you
+to split up one big swagger.yaml` into multiple smaller ones. There is a
 workaround which can be done using Jinja templating though.
 
 
@@ -94,10 +94,10 @@ workaround which can be done using Jinja templating though.
         type: string
         format: money
 
+
 This appraoch won't work if you are including block which should be indented.
 In those cases you have to include the file using a macro, which will let you
 indent it in the main Swagger file.
-
 
 
 .. code-block:: yaml
@@ -116,5 +116,7 @@ indent it in the main Swagger file.
       title:
         {{ include_("title.yaml")|indent(4, true) }}
 
-If you want to add support for Swagger `$ref` syntax then check out
-https://github.com/zalando/connexion/issues/254.
+The Jinja template search path defaults to the directoy which includes the
+swagger.yaml file. You can specify a different search path with the
+`jinja_template_root` parameter.
+

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -67,3 +67,54 @@ Connexion application. Keep in mind that the format checkers should be
 defined and registered before you run your application server. A full
 example can be found at
 https://gist.github.com/rafaelcaricio/6e67286a522f747405a7299e6843cd93
+
+
+Splitting up your swagger.yaml
+------------------------------
+
+Connexion does not yet support the `$ref` syntax from Swagger which allows you
+to split up one big zswagger.yaml` into multiple smaller ones. There is a
+workaround which can be done using Jinja templating though.
+
+
+.. code-block:: yaml
+
+    # swagger.yaml
+    type: object
+    {% include "properties.yaml" %}
+
+
+.. code-block:: yaml
+
+    # properties.yaml
+    properties:
+      title:
+        type: string
+      price_label:
+        type: string
+        format: money
+
+This appraoch won't work if you are including block which should be indented.
+In those cases you have to include the file using a macro, which will let you
+indent it in the main Swagger file.
+
+
+
+.. code-block:: yaml
+
+    # swagger.yaml
+    # This doesn't work
+    type: object
+    properties:
+      title:
+        {% include "title.yaml" %}
+
+    # This will work
+    {% macro include_(x) %}{% include x %}{% endmacro %}
+    type: object
+    properties:
+      title:
+        {{ include_("title.yaml")|indent(4, true) }}
+
+If you want to add support for Swagger `$ref` syntax then check out
+https://github.com/zalando/connexion/issues/254.

--- a/tests/fixtures/simple/include.yaml
+++ b/tests/fixtures/simple/include.yaml
@@ -1,0 +1,1 @@
+{% include "basepath-slash.yaml" %}

--- a/tests/fixtures/simple/include_from_path.yaml
+++ b/tests/fixtures/simple/include_from_path.yaml
@@ -1,0 +1,1 @@
+{% include "fixtures/simple/basepath-slash.yaml" %}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -51,6 +51,12 @@ def test_include():
     assert api.blueprint.url_prefix == ''
 
 
+def test_include_from_path():
+    api = Api(TEST_FOLDER / "fixtures/simple/include_from_path.yaml", None, {}, jinja_template_root=TEST_FOLDER)
+    assert api.blueprint.name == ''
+    assert api.blueprint.url_prefix == ''
+
+
 def test_invalid_operation_does_stop_application_to_setup():
     with pytest.raises(ImportError):
         Api(TEST_FOLDER / "fixtures/op_error_api/swagger.yaml", "/api/v1.0",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -57,6 +57,12 @@ def test_include_from_path():
     assert api.blueprint.url_prefix == ''
 
 
+def test_include_from_multiple_paths():
+    api = Api(TEST_FOLDER / "fixtures/simple/include_from_path.yaml", None, {}, jinja_template_root=[TEST_FOLDER])
+    assert api.blueprint.name == ''
+    assert api.blueprint.url_prefix == ''
+
+
 def test_invalid_operation_does_stop_application_to_setup():
     with pytest.raises(ImportError):
         Api(TEST_FOLDER / "fixtures/op_error_api/swagger.yaml", "/api/v1.0",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,6 +45,12 @@ def test_template():
     assert api2.specification['info']['title'] == 'other test'
 
 
+def test_include():
+    api = Api(TEST_FOLDER / "fixtures/simple/include.yaml", None, {})
+    assert api.blueprint.name == ''
+    assert api.blueprint.url_prefix == ''
+
+
 def test_invalid_operation_does_stop_application_to_setup():
     with pytest.raises(ImportError):
         Api(TEST_FOLDER / "fixtures/op_error_api/swagger.yaml", "/api/v1.0",
@@ -132,3 +138,4 @@ def test_validation_error_on_completely_invalid_swagger_spec():
             f.write('[1]\n'.encode())
             f.flush()
             Api(pathlib.Path(f.name), "/api/v1.0")
+


### PR DESCRIPTION
This PR implements the Jinja template loading mechanism specified in #254, which will let us split up our swagger.yaml into smaller files and include them at runtime.

Changes proposed in this pull request:
- Allow swagger.yaml to specify Jinja `{% include %}` blocks
