### PR TITLE
add --proxy option to serve data through a local proxy

### DIFF
--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -3,9 +3,9 @@ import sys
 from os import path
 
 import click
-import connexion
 from clickclick import AliasedGroup, fatal_error
 
+import connexion
 from connexion.mock import MockResolver
 from connexion.proxy import ProxyResolver
 

--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -3,9 +3,9 @@ import sys
 from os import path
 
 import click
+import connexion
 from clickclick import AliasedGroup, fatal_error
 
-import connexion
 from connexion.mock import MockResolver
 from connexion.proxy import ProxyResolver
 

--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -1,15 +1,5 @@
 from connexion.resolver import Resolution, Resolver, ResolverError
-
-
-def partial(func, **frozen):
-    """
-    Replacement for functools.partial as functools.partial does not work with inspect.py on Python 2.7
-    """
-    def wrapper(*args, **kwargs):
-        for k, v in frozen.items():
-            kwargs[k] = v
-        return func(*args, **kwargs)
-    return wrapper
+from .utils import partial
 
 
 class MockResolver(Resolver):

--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -1,4 +1,5 @@
 from connexion.resolver import Resolution, Resolver, ResolverError
+
 from .utils import partial
 
 

--- a/connexion/proxy.py
+++ b/connexion/proxy.py
@@ -2,7 +2,13 @@ from connexion.resolver import Resolution, Resolver
 from flask import Response, request
 import requests
 import json
-from urlparse import urljoin
+
+# urljoin for 2 and 3
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+
 from .utils import partial
 
 CHUNK_SIZE = 1024

--- a/connexion/proxy.py
+++ b/connexion/proxy.py
@@ -1,7 +1,10 @@
+import json
+
+import requests
 from connexion.resolver import Resolution, Resolver
 from flask import Response, request
-import requests
-import json
+
+from .utils import partial
 
 # urljoin for 2 and 3
 try:
@@ -9,7 +12,6 @@ try:
 except ImportError:
     from urlparse import urljoin
 
-from .utils import partial
 
 CHUNK_SIZE = 1024
 

--- a/connexion/proxy.py
+++ b/connexion/proxy.py
@@ -1,0 +1,70 @@
+from connexion.resolver import Resolution, Resolver
+from flask import Response, request
+import requests
+import json
+from urlparse import urljoin
+from .utils import partial
+
+CHUNK_SIZE = 1024
+
+
+def proxy(base_url="", path="", *_):
+    """
+    Proxy connections to the API
+    """
+    url = urljoin(base_url, path)
+    params = {}
+    args = dict(request.args.items())
+    params.update(args)
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": request.headers.get("Authorization", "")
+    }
+    response = requests.get(
+        url,
+        params=params,
+        headers=headers,
+        stream=True
+    )
+    if response.status_code != 200:
+        err = {"error": "There was an error in the API."}
+        try:
+            err.update(response.json())
+        except ValueError:
+            # No JSON could be decoded
+            pass  # no detail to add
+        return Response(response=json.dumps(err),
+                        status=response.status_code, mimetype='application/json')
+
+    def generate():
+        for chunk in response.iter_content(CHUNK_SIZE):
+            yield chunk
+
+    ret = Response(
+        response=generate(),
+        status=200,
+        mimetype='application/json'
+    )
+    return ret
+
+
+class ProxyResolver(Resolver):
+
+    def __init__(self, base_url, override={}):
+        self._operation_id_counter = 1
+        self.base_url = base_url
+        self.override = override
+
+    def resolve(self, operation):
+        """
+        Proxy operation resolver
+        :type operation: connexion.operation.Operation
+        """
+        operation_id = self.resolve_operation_id(operation)
+        if not operation_id:
+            # just generate an unique operation ID
+            operation_id = 'fake-{}'.format(self._operation_id_counter)
+            self._operation_id_counter += 1
+
+        func = partial(proxy, base_url=self.base_url, path=operation.path)
+        return Resolution(func, operation_id)

--- a/connexion/proxy.py
+++ b/connexion/proxy.py
@@ -1,8 +1,9 @@
 import json
 
 import requests
-from connexion.resolver import Resolution, Resolver
 from flask import Response, request
+
+from connexion.resolver import Resolution, Resolver
 
 from .utils import partial
 

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -17,6 +17,17 @@ PATH_PARAMETER_CONVERTERS = {
 }
 
 
+def partial(func, **frozen):
+    """
+    Replacement for functools.partial as functools.partial does not work with inspect.py on Python 2.7
+    """
+    def wrapper(*args, **kwargs):
+        for k, v in frozen.items():
+            kwargs[k] = v
+        return func(*args, **kwargs)
+    return wrapper
+
+
 def flaskify_endpoint(identifier, randomize=None):
     """
     Converts the provided identifier in a valid flask endpoint name

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -59,3 +59,13 @@ Your API specification file is not required to have any ``operationId``.
 .. code-block:: bash
 
     $ connexion run your_api.yaml --mock=all -v
+
+Running a proxy server
+---------------------
+
+You can run a simple server which returns data proxied from another server.
+Your API specification file is not required to have any ``operationId``.
+
+.. code-block:: bash
+
+    $ connexion run your_api.yaml --proxy https://example.com/ -v


### PR DESCRIPTION
Hi - I'm not sure if this is useful to you, but I've added a proxy option to my fork.
It has been useful bypassing CORS, as well as for building an API proxy/gateway.

Changes proposed in this pull request:
 - add ProxyResolver which is initialized with a remote server URL
 - add --proxy command line argument to pass in the base server url from the command line

Let me know what you think!


Best.

Daniel