### PR TITLE
Parameter names are not sanitized

### DIFF
--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -73,6 +73,23 @@ encountered in the specification. It will also respect
 ``connexion.resolver.Resolver`` to implement your own ``operationId``
 (and function) resolution algorithm.
 
+Parameter Name Sanitation
+-------------------------
+
+The names of query and form parameters, as well as the name of the body
+parameter are sanitized by removing characters that are not allowed in Python
+symbols. I.e. all characters that are not letters, digits or the underscore are
+removed, and finally characters are removed from the front until a letter or an
+under-score is encountered. As an example:
+
+.. code-block:: python
+
+    >>> re.sub('^[^a-zA-Z_]+', '', re.sub('[^0-9a-zA-Z_]', '', '$top'))
+    'top'
+
+Without this sanitation it would e.g. be impossible to implement an
+[OData](http://www.odata.org) API.
+
 API Versioning and basePath
 ---------------------------
 

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -354,3 +354,14 @@ def more_than_one_scope_defined():
 
 def test_args_kwargs(*args, **kwargs):
     return kwargs
+
+def test_param_sanitization(query=None, form=None):
+    result = {}
+    if query:
+      result['query'] = query
+    if form:
+      result['form'] = form
+    return result
+
+def test_body_sanitization(body=None):
+    return body

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -646,6 +646,50 @@ paths:
         200:
           description: OK
 
+  /param-sanitization:
+    post:
+      operationId: fakeapi.hello.test_param_sanitization
+      consumes:
+      - multipart/form-data
+      produces:
+        - application/json
+      parameters:
+        - name: $query
+          description: Just a testing parameter with an invalid Python name
+          in: query
+          type: string
+        - name: $form
+          description: Just a testing parameter in the form data
+          in: formData
+          type: string
+      responses:
+        200:
+          description: Return parameters
+          schema:
+            type: object
+
+  /body-sanitization:
+    post:
+      operationId: fakeapi.hello.test_body_sanitization
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: $body
+          description: Just a testing parameter in the body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              body1:
+                type: string
+              body2:
+                type: string
+      responses:
+        200:
+          description: OK
 
 definitions:
   new_stack:


### PR DESCRIPTION
### Description

Parameters that are not valid Python names are not handled gracefully at the moment. E.g. OData query parameters (`$skip`, `$top`, `$filter`) are only passed to the controller if it uses `**kwargs`.

### Expected bahaviour

Parameter names should be sanitized by stripping invalid characters.

### Actual behaviour

If the controller does not have `**kwargs` there is no way for the parameters to be passed as arguments.

### Steps to reproduce

Create a `swagger.yaml` that declares a parameter with a name that is not a valid argument name in Python, such as `$top`.

### Additional info:

Output of the commands:

- `python --version`

    Python 2.7.12

- `pip show connexion | grep "^Version\:"`

    Version: 2016.0.dev1

- `git describe --always`

    1.0.88-234-g10a0c15