### PR TITLE
Allow custom rendering of oAuth issues

### DIFF
--- a/tests/decorators/test_security.py
+++ b/tests/decorators/test_security.py
@@ -1,5 +1,7 @@
+from werkzeug.exceptions import Unauthorized
+
+import pytest
 from connexion.decorators.security import get_tokeninfo_url, verify_oauth
-from connexion.problem import problem
 from mock import MagicMock
 
 
@@ -30,5 +32,6 @@ def test_verify_oauth_invalid_auth_header(monkeypatch):
     app = MagicMock()
     monkeypatch.setattr('connexion.decorators.security.request', request)
     monkeypatch.setattr('flask.current_app', app)
-    resp = wrapped_func()
-    assert resp == problem(401, 'Unauthorized', 'Invalid authorization header')
+
+    with pytest.raises(Unauthorized):
+        wrapped_func()


### PR DESCRIPTION
Changes proposed in this pull request:

 - Raises an exception in the oAuth security provider instead of returning a flask response

This allows easier overriding of the oAuth security failures because you add your own error handler to customise the response (if you choose not to use the 'application/json+problem' return type):

```
def render_unauthorized(exception):
    return Response(response=json.dumps({'error_description': 'Test String', 'error': 'test_error'}), status=401, mimetype="application/json")

app = connexion.App(__name__, specification_dir='./../swagger/', debug=debug, swagger_ui=False)
app = app.add_error_handler(401, render_unauthorized)
```

The current messages will continue to be returned in a b/c way because the current default exception handlers find the exceptions now being thrown and format them in the same way as of present.