### PR TITLE
Refactor code to fix confusion with returned values

### DIFF
--- a/connexion/app.py
+++ b/connexion/app.py
@@ -87,7 +87,8 @@ class App(object):
         """
         if not isinstance(exception, werkzeug.exceptions.HTTPException):
             exception = werkzeug.exceptions.InternalServerError()
-        return problem(title=exception.name, detail=exception.description, status=exception.code)
+        response_container = problem(title=exception.name, detail=exception.description, status=exception.code)
+        return response_container.flask_response_object()
 
     def add_api(self, specification, base_path=None, arguments=None, auth_all_paths=None, swagger_json=None,
                 swagger_ui=None, swagger_path=None, swagger_url=None, validate_responses=False,

--- a/connexion/decorators/decorator.py
+++ b/connexion/decorators/decorator.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 
 import flask
@@ -8,33 +9,6 @@ logger = logging.getLogger('connexion.decorators.decorator')
 
 
 class BaseDecorator(object):
-
-    @staticmethod
-    def get_full_response(data):
-        """
-        Gets Data. Status Code and Headers for response.
-        If only body data is returned by the endpoint function, then the status code will be set to 200 and no headers
-        will be added.
-        If the returned object is a flask.Response then it will just pass the information needed to recreate it.
-
-        :type data: flask.Response | (object, int) | (object, int, dict) | object
-        :rtype: (object, int, dict)
-        """
-        url = flask.request.url
-        logger.debug('Getting data and status code', extra={'data': data, 'data_type': type(data), 'url': url})
-        status_code, headers = 200, {}
-        if is_flask_response(data):
-            data = data
-            status_code = data.status_code
-            headers = data.headers
-        elif isinstance(data, tuple) and len(data) == 3:
-            data, status_code, headers = data
-        elif isinstance(data, tuple) and len(data) == 2:
-            data, status_code = data
-        logger.debug('Got data and status code (%d)', status_code, extra={'data': data,
-                                                                          'data_type': type(data),
-                                                                          'url': url})
-        return data, status_code, headers
 
     def __call__(self, function):
         """
@@ -47,4 +21,150 @@ class BaseDecorator(object):
         """
         :rtype: str
         """
-        return '<BaseDecorator: {}>'
+        return '<BaseDecorator>'
+
+
+class BeginOfRequestLifecycleDecorator(BaseDecorator):
+    """Manages the lifecycle of the request internally in Connexion.
+
+    Transforms the operation handler response into a `ResponseContainer`
+    that can be manipulated by the series of decorators during the
+    lifecycle of the request.
+    """
+
+    def __init__(self, mimetype):
+        self.mimetype = mimetype
+
+    def get_response_container(self, operation_handler_result):
+        """Gets ResponseContainer instance for the operation handler
+        result. Status Code and Headers for response.  If only body
+        data is returned by the endpoint function, then the status
+        code will be set to 200 and no headers will be added.
+
+        If the returned object is a flask.Response then it will just
+        pass the information needed to recreate it.
+
+        :type operation_handler_result: flask.Response | (flask.Response, int) | (flask.Response, int, dict)
+        :rtype: ResponseContainer
+        """
+        url = flask.request.url
+        logger.debug('Getting data and status code',
+                     extra={
+                         'data': operation_handler_result,
+                         'data_type': type(operation_handler_result),
+                         'url': url
+                     })
+
+        response_container = None
+        if is_flask_response(operation_handler_result):
+            response_container = ResponseContainer(
+                self.mimetype, response=operation_handler_result)
+
+        elif isinstance(operation_handler_result, ResponseContainer):
+            response_container = operation_handler_result
+
+        elif isinstance(operation_handler_result, tuple) and len(
+                operation_handler_result) == 3:
+            data, status_code, headers = operation_handler_result
+            response_container = ResponseContainer(
+                self.mimetype, data=data, status_code=status_code, headers=headers)
+
+        elif isinstance(operation_handler_result, tuple) and len(
+                operation_handler_result) == 2:
+            data, status_code = operation_handler_result
+            response_container = ResponseContainer(
+                self.mimetype, data=data, status_code=status_code)
+        else:
+            response_container = ResponseContainer(
+                self.mimetype, data=operation_handler_result)
+
+        logger.debug('Got data and status code (%d)',
+                     response_container.status_code,
+                     extra={
+                         'data': operation_handler_result,
+                         'datatype': type(operation_handler_result),
+                         'url': url
+                     })
+
+        return response_container
+
+    def __call__(self, function):
+        """
+        :type function: types.FunctionType
+        :rtype: types.FunctionType
+        """
+        @functools.wraps(function)
+        def wrapper(*args, **kwargs):
+            operation_handler_result = function(*args, **kwargs)
+            return self.get_response_container(operation_handler_result)
+
+        return wrapper
+
+
+class EndOfRequestLifecycleDecorator(BaseDecorator):
+    """Manages the lifecycle of the request internally in Connexion.
+
+    Filter the ResponseContainer instance to return the corresponding
+    flask.Response object.
+    """
+
+    def __call__(self, function):
+        """
+        :type function: types.FunctionType
+        :rtype: types.FunctionType
+        """
+        @functools.wraps(function)
+        def wrapper(*args, **kwargs):
+            response_container = function(*args, **kwargs)
+            return response_container.flask_response_object()
+
+        return wrapper
+
+
+class ResponseContainer(object):
+    """Internal response object to be passed among Connexion
+    decorators that want to manipulate response data.
+    """
+
+    def __init__(self, mimetype, data=None, status_code=200, headers=None, response=None):
+        """
+        :type data: dict | None
+        :type status_code: int | None
+        :type headers: dict | None
+        :type response: flask.Response | None
+        """
+        self.mimetype = mimetype
+        self.data = data
+        self.status_code = status_code
+        self.headers = headers or {}
+
+        self._response = response
+        self.is_handler_response_object = bool(response)
+
+        if self._response:
+            self.data = self._response.data
+            self.status_code = self._response.status_code
+            self.headers = self._response.headers
+
+    def flask_response_object(self):
+        """
+        Builds an Flask response using the contained data,
+        status_code, and headers.
+
+        :rtype: flask.Response
+        """
+        if self._response:
+            # returns flask.Response as is
+            return self._response
+
+        self._response = flask.current_app.response_class(
+            self.data, mimetype=self.mimetype)  # type: flask.Response
+        self._response.status_code = self.status_code
+        self._response.headers.extend(self.headers)
+
+        return self._response
+
+    def __eq__(self, other):
+        if isinstance(other, ResponseContainer):
+            return all(getattr(self, attr) == getattr(other, attr)
+                       for attr in self.__dict__.keys())

--- a/connexion/decorators/decorator.py
+++ b/connexion/decorators/decorator.py
@@ -142,7 +142,7 @@ class ResponseContainer(object):
         self.is_handler_response_object = bool(response)
 
         if self._response:
-            self.data = self._response.data
+            self.data = self._response.get_data()
             self.status_code = self._response.status_code
             self.headers = self._response.headers
 
@@ -153,10 +153,6 @@ class ResponseContainer(object):
 
         :rtype: flask.Response
         """
-        if self._response:
-            # returns flask.Response as is
-            return self._response
-
         self._response = flask.current_app.response_class(
             self.data, mimetype=self.mimetype)  # type: flask.Response
         self._response.status_code = self.status_code

--- a/connexion/decorators/decorator.py
+++ b/connexion/decorators/decorator.py
@@ -122,8 +122,16 @@ class EndOfRequestLifecycleDecorator(BaseDecorator):
 
 
 class ResponseContainer(object):
-    """Internal response object to be passed among Connexion
+    """ Internal response object to be passed among Connexion
     decorators that want to manipulate response data.
+
+    Partially matches the flask.Response interface for easy access and
+    manipulation.
+
+    The methods ResponseContainer#get_data and ResponseContainer#set_data
+    are added here following the recommendation found in:
+
+    http://flask.pocoo.org/docs/0.11/api/#flask.Response.data
     """
 
     def __init__(self, mimetype, data=None, status_code=200, headers=None, response=None):
@@ -146,6 +154,18 @@ class ResponseContainer(object):
             self.status_code = self._response.status_code
             self.headers = self._response.headers
 
+    def get_data(self):
+        """ Get the current data to be used when creating the
+        flask.Response instance.
+        """
+        return self.data
+
+    def set_data(self, data):
+        """ Gets the data that is going to be used to create the
+        flask.Response instance.
+        """
+        self.data = data
+
     def flask_response_object(self):
         """
         Builds an Flask response using the contained data,
@@ -159,8 +179,3 @@ class ResponseContainer(object):
         self._response.headers.extend(self.headers)
 
         return self._response
-
-    def __eq__(self, other):
-        if isinstance(other, ResponseContainer):
-            return all(getattr(self, attr) == getattr(other, attr)
-                       for attr in self.__dict__.keys())

--- a/connexion/decorators/metrics.py
+++ b/connexion/decorators/metrics.py
@@ -36,7 +36,7 @@ class UWSGIMetricsCollector(object):
             start_time_s = time.time()
             try:
                 response = function(*args, **kwargs)
-                _, status_code, _ = BaseSerializer.get_full_response(response)
+                status_code = response.status_code
             finally:
                 end_time_s = time.time()
                 delta_s = end_time_s - start_time_s

--- a/connexion/decorators/metrics.py
+++ b/connexion/decorators/metrics.py
@@ -2,8 +2,6 @@ import functools
 import os
 import time
 
-from connexion.decorators.produces import BaseSerializer
-
 try:
     import uwsgi_metrics
     HAS_UWSGI_METRICS = True  # pragma: no cover

--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -71,6 +71,13 @@ class Produces(BaseSerializer):
 
 
 class Jsonifier(BaseSerializer):
+    @staticmethod
+    def dumps(data):
+        """ Central point where JSON serialization happens inside
+        Connexion.
+        """
+        return "{}\n".format(json.dumps(data, indent=2))
+
     def __call__(self, function):
         """
         :type function: types.FunctionType
@@ -102,11 +109,11 @@ class Jsonifier(BaseSerializer):
                 return response
 
             elif response.mimetype == 'application/problem+json' and isinstance(response.data, str):
-                # connexion.problem() is already a serialized JSON
+                # connexion.problem() already adds data as a serialized JSON
                 return response
 
-            # format JSON output
-            response.set_data("{}\n".format(json.dumps(response.data, indent=2)))
+            json_content = Jsonifier.dumps(response.get_data())
+            response.set_data(json_content)
             return response
 
         return wrapper

--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -92,13 +92,13 @@ class Jsonifier(BaseSerializer):
                 return response
 
             elif response.data is NoContent:
-                response.data = ''
+                response.set_data('')
                 return response
 
             elif response.status_code == 204:
                 logger.debug('Endpoint returned an empty response (204)',
                              extra={'url': url, 'mimetype': self.mimetype})
-                response.data = ''
+                response.set_data('')
                 return response
 
             elif response.mimetype == 'application/problem+json' and isinstance(response.data, str):
@@ -106,7 +106,7 @@ class Jsonifier(BaseSerializer):
                 return response
 
             # format JSON output
-            response.data = "{}\n".format(json.dumps(response.data, indent=2))
+            response.set_data("{}\n".format(json.dumps(response.data, indent=2)))
             return response
 
         return wrapper

--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -6,7 +6,6 @@ import logging
 import flask
 from flask import json
 
-from ..utils import is_flask_response
 from .decorator import BaseDecorator
 
 logger = logging.getLogger('connexion.decorators.produces')
@@ -40,20 +39,6 @@ class BaseSerializer(BaseDecorator):
         """
         self.mimetype = mimetype
 
-    @staticmethod
-    def process_headers(response, headers):
-        """
-        A convenience function for updating the Response headers with any additional headers
-        generated in the view. If more complex logic should be needed later then it can be handled here.
-
-        :type response: flask.Response
-        :type headers: dict
-        :rtype flask.Response
-        """
-        if headers:
-            response.headers.extend(headers)
-        return response
-
     def __repr__(self):
         """
         :rtype: str
@@ -71,16 +56,10 @@ class Produces(BaseSerializer):
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
             url = flask.request.url
-            data, status_code, headers = self.get_full_response(function(*args, **kwargs))
-            logger.debug('Returning %s', url, extra={'url': url, 'mimetype': self.mimetype})
-            if is_flask_response(data):
-                logger.debug('Endpoint returned a Flask Response', extra={'url': url, 'mimetype': data.mimetype})
-                return data
-
-            response = flask.current_app.response_class(data, mimetype=self.mimetype)  # type: flask.Response
-            response = self.process_headers(response, headers)
-
-            return response, status_code
+            response = function(*args, **kwargs)
+            logger.debug('Returning %s', url,
+                         extra={'url': url, 'mimetype': self.mimetype})
+            return response
 
         return wrapper
 
@@ -101,22 +80,34 @@ class Jsonifier(BaseSerializer):
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
             url = flask.request.url
-            logger.debug('Jsonifing %s', url, extra={'url': url, 'mimetype': self.mimetype})
-            data, status_code, headers = self.get_full_response(function(*args, **kwargs))
-            if is_flask_response(data):
-                logger.debug('Endpoint returned a Flask Response', extra={'url': url, 'mimetype': data.mimetype})
-                return data
-            elif data is NoContent:
-                return '', status_code, headers
-            elif status_code == 204:
-                logger.debug('Endpoint returned an empty response (204)', extra={'url': url, 'mimetype': self.mimetype})
-                return '', 204, headers
 
-            data = [json.dumps(data, indent=2), '\n']
-            response = flask.current_app.response_class(data, mimetype=self.mimetype)  # type: flask.Response
-            response = self.process_headers(response, headers)
+            logger.debug('Jsonifing %s', url,
+                         extra={'url': url, 'mimetype': self.mimetype})
 
-            return response, status_code
+            response = function(*args, **kwargs)
+
+            if response.is_handler_response_object:
+                logger.debug('Endpoint returned a Flask Response',
+                             extra={'url': url, 'mimetype': self.mimetype})
+                return response
+
+            elif response.data is NoContent:
+                response.data = ''
+                return response
+
+            elif response.status_code == 204:
+                logger.debug('Endpoint returned an empty response (204)',
+                             extra={'url': url, 'mimetype': self.mimetype})
+                response.data = ''
+                return response
+
+            elif response.mimetype == 'application/problem+json' and isinstance(response.data, str):
+                # connexion.problem() is already a serialized JSON
+                return response
+
+            # format JSON output
+            response.data = "{}\n".format(json.dumps(response.data, indent=2))
+            return response
 
         return wrapper
 

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -87,15 +87,14 @@ class ResponseValidator(BaseDecorator):
         """
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
-            result = function(*args, **kwargs)
+            response = function(*args, **kwargs)
             try:
-                data, status_code, headers = self.get_full_response(result)
-                self.validate_response(data, status_code, headers)
+                self.validate_response(response.data, response.status_code, response.headers)
             except NonConformingResponseBody as e:
                 return problem(500, e.reason, e.message)
             except NonConformingResponseHeaders as e:
                 return problem(500, e.reason, e.message)
-            return result
+            return response
 
         return wrapper
 

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -89,7 +89,7 @@ class ResponseValidator(BaseDecorator):
         def wrapper(*args, **kwargs):
             response = function(*args, **kwargs)
             try:
-                self.validate_response(response.data, response.status_code, response.headers)
+                self.validate_response(response.get_data(), response.status_code, response.headers)
             except NonConformingResponseBody as e:
                 return problem(500, e.reason, e.message)
             except NonConformingResponseHeaders as e:

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -288,7 +288,6 @@ class ParameterValidator(object):
                 if error:
                     return problem(400, 'Bad Request', error)
 
-            response = function(*args, **kwargs)
-            return response
+            return function(*args, **kwargs)
 
         return wrapper

--- a/connexion/problem.py
+++ b/connexion/problem.py
@@ -1,5 +1,5 @@
 from .decorators.decorator import ResponseContainer
-from .decorators.produces import Jsonfier
+from .decorators.produces import Jsonifier
 
 
 def problem(status, title, detail, type='about:blank', instance=None, headers=None, ext=None):
@@ -41,7 +41,7 @@ def problem(status, title, detail, type='about:blank', instance=None, headers=No
     # return a problem payload in JSON format.
     return ResponseContainer(
         mimetype='application/problem+json',
-        data=Jsonfier.dumps(problem_response),
+        data=Jsonifier.dumps(problem_response),
         status_code=status,
         headers=headers
     )

--- a/connexion/problem.py
+++ b/connexion/problem.py
@@ -36,7 +36,7 @@ def problem(status, title, detail, type='about:blank', instance=None, headers=No
 
     # We serialize here because even if the default content type is
     # not set to JSON, which means that the
-    # `decorators.produces.Jsonfier` will not be added to the request
+    # `decorators.produces.Jsonifier` will not be added to the request
     # life-cycle (so we cannot rely on that serialization), we will
     # return a problem payload in JSON format.
     return ResponseContainer(

--- a/connexion/problem.py
+++ b/connexion/problem.py
@@ -1,6 +1,5 @@
-from flask import json
-
 from .decorators.decorator import ResponseContainer
+from .decorators.produces import Jsonfier
 
 
 def problem(status, title, detail, type='about:blank', instance=None, headers=None, ext=None):
@@ -35,9 +34,14 @@ def problem(status, title, detail, type='about:blank', instance=None, headers=No
     if ext:
         problem_response.update(ext)
 
+    # We serialize here because even if the default content type is
+    # not set to JSON, which means that the
+    # `decorators.produces.Jsonfier` will not be added to the request
+    # life-cycle (so we cannot rely on that serialization), we will
+    # return a problem payload in JSON format.
     return ResponseContainer(
         mimetype='application/problem+json',
-        data="{}\n".format(json.dumps(problem_response, indent=2)),
+        data=Jsonfier.dumps(problem_response),
         status_code=status,
         headers=headers
     )

--- a/connexion/problem.py
+++ b/connexion/problem.py
@@ -1,6 +1,6 @@
-import json
+from flask import json
 
-import flask
+from .decorators.decorator import ResponseContainer
 
 
 def problem(status, title, detail, type='about:blank', instance=None, headers=None, ext=None):
@@ -35,10 +35,9 @@ def problem(status, title, detail, type='about:blank', instance=None, headers=No
     if ext:
         problem_response.update(ext)
 
-    body = [json.dumps(problem_response, indent=2), '\n']
-    response = flask.current_app.response_class(body, mimetype='application/problem+json',
-                                                status=status)  # type: flask.Response
-    if headers:
-        response.headers.extend(headers)
-
-    return response
+    return ResponseContainer(
+        mimetype='application/problem+json',
+        data="{}\n".format(json.dumps(problem_response, indent=2)),
+        status_code=status,
+        headers=headers
+    )

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -1,6 +1,6 @@
 import jinja2
-import yaml
 import pytest
+import yaml
 from conftest import TEST_FOLDER, build_app_from_fixture
 from connexion.app import App
 from connexion.exceptions import InvalidSpecification

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -1,6 +1,7 @@
 import jinja2
-import pytest
 import yaml
+
+import pytest
 from conftest import TEST_FOLDER, build_app_from_fixture
 from connexion.app import App
 from connexion.exceptions import InvalidSpecification

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -173,3 +173,9 @@ def test_text_request(simple_app):
 
     resp = app_client.post('/v1.0/text-request', data='text')
     assert resp.status_code == 200
+
+
+def test_operation_handler_returns_flask_object(invalid_resp_allowed_app):
+    app_client = invalid_resp_allowed_app.app.test_client()
+    resp = app_client.get('/v1.0/get_non_conforming_response')
+    assert resp.status_code == 200

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def oauth_requests(monkeypatch):
         :type params: dict| None
         """
         params = params or {}
-        if url == "https://ouath.example/token_info":
+        if url == "https://oauth.example/token_info":
             token = params['access_token']
             if token in ["100", "has_myscope"]:
                 return FakeResponse(200, '{"uid": "test-user", "scope": ["myscope"]}')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,11 @@ def simple_app():
 
 
 @pytest.fixture(scope="session")
+def invalid_resp_allowed_app():
+    return build_app_from_fixture('simple', validate_responses=False)
+
+
+@pytest.fixture(scope="session")
 def strict_app():
     return build_app_from_fixture('simple', validate_responses=True, strict_validation=True)
 

--- a/tests/decorators/test_security.py
+++ b/tests/decorators/test_security.py
@@ -1,5 +1,6 @@
+import json
+
 from connexion.decorators.security import get_tokeninfo_url, verify_oauth
-from connexion.problem import problem
 from mock import MagicMock
 
 
@@ -30,5 +31,10 @@ def test_verify_oauth_invalid_auth_header(monkeypatch):
     app = MagicMock()
     monkeypatch.setattr('connexion.decorators.security.request', request)
     monkeypatch.setattr('flask.current_app', app)
+
     resp = wrapped_func()
-    assert resp == problem(401, 'Unauthorized', 'Invalid authorization header')
+
+    assert resp.status_code == 401
+    payload = json.loads(resp.get_data())
+    assert payload['title'] == 'Unauthorized'
+    assert payload['detail'] == 'Invalid authorization header'

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -339,6 +339,10 @@ def get_invalid_response():
     return {"simple": object()}
 
 
+def get_empty_dict():
+    return {}
+
+
 def get_custom_problem_response():
     return problem(403, "You need to pay", "Missing amount",
                    ext={'amount': 23.0})

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -359,13 +359,15 @@ def more_than_one_scope_defined():
 def test_args_kwargs(*args, **kwargs):
     return kwargs
 
+
 def test_param_sanitization(query=None, form=None):
     result = {}
     if query:
-      result['query'] = query
+        result['query'] = query
     if form:
-      result['form'] = form
+        result['form'] = form
     return result
+
 
 def test_body_sanitization(body=None):
     return body

--- a/tests/fixtures/problem/swagger.yaml
+++ b/tests/fixtures/problem/swagger.yaml
@@ -10,8 +10,8 @@ securityDefinitions:
     oauth:
         type: oauth2
         flow: password
-        tokenUrl: https://ouath.example/token
-        x-tokenInfoUrl: https://ouath.example/token_info
+        tokenUrl: https://oauth.example/token
+        x-tokenInfoUrl: https://oauth.example/token_info
         scopes:
             myscope: can do stuff
 

--- a/tests/fixtures/secure_api/swagger.yaml
+++ b/tests/fixtures/secure_api/swagger.yaml
@@ -10,8 +10,8 @@ securityDefinitions:
     oauth:
       type: oauth2
       flow: password
-      tokenUrl: https://ouath.example/token
-      x-tokenInfoUrl: https://ouath.example/token_info
+      tokenUrl: https://oauth.example/token
+      x-tokenInfoUrl: https://oauth.example/token_info
       scopes:
         myscope: can do stuff
 

--- a/tests/fixtures/secure_endpoint/swagger.yaml
+++ b/tests/fixtures/secure_endpoint/swagger.yaml
@@ -10,8 +10,8 @@ securityDefinitions:
     oauth:
         type: oauth2
         flow: password
-        tokenUrl: https://ouath.example/token
-        x-tokenInfoUrl: https://ouath.example/token_info
+        tokenUrl: https://oauth.example/token
+        x-tokenInfoUrl: https://oauth.example/token_info
         scopes:
             myscope: can do stuff
             otherscope: another scope

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -691,6 +691,21 @@ paths:
         200:
           description: OK
 
+  /get_non_conforming_response:
+    get:
+      operationId: fakeapi.hello.get_empty_dict
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            required:
+              - some
+            properties:
+              some:
+                type: string
+
+
 definitions:
   new_stack:
     type: object

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,5 @@
 from connexion.decorators.metrics import UWSGIMetricsCollector
+import connexion
 from mock import MagicMock
 
 
@@ -6,7 +7,7 @@ def test_timer(monkeypatch):
     wrapper = UWSGIMetricsCollector('/foo/bar/<param>', 'get')
 
     def operation():
-        return None, 418, None
+        return connexion.problem(418, '', '')
 
     op = wrapper(operation)
     metrics = MagicMock()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,5 +1,5 @@
-from connexion.decorators.metrics import UWSGIMetricsCollector
 import connexion
+from connexion.decorators.metrics import UWSGIMetricsCollector
 from mock import MagicMock
 
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -226,7 +226,7 @@ OPERATION10 = {'description': 'Adds a new stack to be created by lizzy and retur
 
 SECURITY_DEFINITIONS = {'oauth': {'type': 'oauth2',
                                   'flow': 'password',
-                                  'x-tokenInfoUrl': 'https://ouath.example/token_info',
+                                  'x-tokenInfoUrl': 'https://oauth.example/token_info',
                                   'scopes': {'myscope': 'can do stuff'}}}
 
 SECURITY_DEFINITIONS_WO_INFO = {'oauth': {'type': 'oauth2',
@@ -250,7 +250,7 @@ def test_operation():
     # security decorator should be a partial with verify_oauth as the function and token url and scopes as arguments.
     # See https://docs.python.org/2/library/functools.html#partial-objects
     assert operation.security_decorator.func is verify_oauth
-    assert operation.security_decorator.args == ('https://ouath.example/token_info', set(['uid']))
+    assert operation.security_decorator.args == ('https://oauth.example/token_info', set(['uid']))
 
     assert operation.method == 'GET'
     assert operation.produces == ['application/json']
@@ -280,7 +280,7 @@ def test_operation_array():
     # security decorator should be a partial with verify_oauth as the function and token url and scopes as arguments.
     # See https://docs.python.org/2/library/functools.html#partial-objects
     assert operation.security_decorator.func is verify_oauth
-    assert operation.security_decorator.args == ('https://ouath.example/token_info', set(['uid']))
+    assert operation.security_decorator.args == ('https://oauth.example/token_info', set(['uid']))
 
     assert operation.method == 'GET'
     assert operation.produces == ['application/json']
@@ -310,7 +310,7 @@ def test_operation_composed_definition():
     # security decorator should be a partial with verify_oauth as the function and token url and scopes as arguments.
     # See https://docs.python.org/2/library/functools.html#partial-objects
     assert operation.security_decorator.func is verify_oauth
-    assert operation.security_decorator.args == ('https://ouath.example/token_info', set(['uid']))
+    assert operation.security_decorator.args == ('https://oauth.example/token_info', set(['uid']))
 
     assert operation.method == 'GET'
     assert operation.produces == ['application/json']

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -11,7 +11,14 @@ def test_parameter_validator(monkeypatch):
     request.headers = {}
     request.params = {}
     app = MagicMock(name='app')
-    app.response_class = lambda a, mimetype, status: json.loads(''.join(a))['detail']
+
+    def _response_class(data, mimetype):
+        response = MagicMock(name='response')
+        response.detail = json.loads(''.join(data))['detail']
+        response.headers = MagicMock()
+        return response
+
+    app.response_class = _response_class
     monkeypatch.setattr('flask.request', request)
     monkeypatch.setattr('flask.current_app', app)
 
@@ -26,31 +33,31 @@ def test_parameter_validator(monkeypatch):
     validator = ParameterValidator(params)
     handler = validator(orig_handler)
 
-    assert handler() == "Missing path parameter 'p1'"
+    assert handler().flask_response_object().detail == "Missing path parameter 'p1'"
     assert handler(p1='123') == 'OK'
-    assert handler(p1='') == "Wrong type, expected 'integer' for path parameter 'p1'"
-    assert handler(p1='foo') == "Wrong type, expected 'integer' for path parameter 'p1'"
-    assert handler(p1='1.2') == "Wrong type, expected 'integer' for path parameter 'p1'"
+    assert handler(p1='').flask_response_object().detail == "Wrong type, expected 'integer' for path parameter 'p1'"
+    assert handler(p1='foo').flask_response_object().detail == "Wrong type, expected 'integer' for path parameter 'p1'"
+    assert handler(p1='1.2').flask_response_object().detail == "Wrong type, expected 'integer' for path parameter 'p1'"
 
     request.args = {'q1': '4'}
-    assert handler(p1=1).startswith('4 is greater than the maximum of 3')
+    assert handler(p1=1).flask_response_object().detail.startswith('4 is greater than the maximum of 3')
     request.args = {'q1': '3'}
     assert handler(p1=1) == 'OK'
 
     request.args = {'a1': "1,2"}
     assert handler(p1=1) == "OK"
     request.args = {'a1': "1,a"}
-    assert handler(p1=1).startswith("'a' is not of type 'integer'")
+    assert handler(p1=1).flask_response_object().detail.startswith("'a' is not of type 'integer'")
     request.args = {'a1': "1,-1"}
-    assert handler(p1=1).startswith("-1 is less than the minimum of 0")
+    assert handler(p1=1).flask_response_object().detail.startswith("-1 is less than the minimum of 0")
     request.args = {'a1': "1"}
-    assert handler(p1=1).startswith("[1] is too short")
+    assert handler(p1=1).flask_response_object().detail.startswith("[1] is too short")
     request.args = {'a1': "1,2,3,4"}
-    assert handler(p1=1).startswith("[1, 2, 3, 4] is too long")
+    assert handler(p1=1).flask_response_object().detail.startswith("[1, 2, 3, 4] is too long")
     del request.args['a1']
 
     request.headers = {'h1': 'a'}
     assert handler(p1='123') == 'OK'
 
     request.headers = {'h1': 'x'}
-    assert handler(p1='123').startswith("'x' is not one of ['a', 'b']")
+    assert handler(p1='123').flask_response_object().detail.startswith("'x' is not one of ['a', 'b']")

--- a/tests/util.py
+++ b/tests/util.py
@@ -38,7 +38,7 @@ def oauth_requests(monkeypatch):
         :type params: dict| None
         """
         params = params or {}
-        if url == "https://ouath.example/token_info":
+        if url == "https://oauth.example/token_info":
             token = params['access_token']
             if token == "100":
                 return FakeResponse(200, '{"uid": "test-user", "scope": ["myscope"]}')


### PR DESCRIPTION
Fixes #356,  related to #285

I finally found time to make this change of how Connexion code internally works. I was very bothered by the `get_full_response` method returning multiple values and we were getting lost a lot to sort out those returned values, reusing positions, etc. This caused the #356 and generated #285. It is an old bug that is fixed by this PR. Also this PR makes it easier to maintain the Connexion codebase as we move forward.

Changes proposed in this pull request:

 - We rely on `ResponseContainer` as a wrapper to whatever the operation handler function returns.
 - The `ResponseContainer` object is responsible to manage the data that the operation handler function provided.
 - The `ResponseContainer` object is what all internal Connexion decorators interact with and not with the pure values returned by the operation handler function.
- In the end of the Connexion's internal lifecycle of the request, we return a `flask.Response` instance with the data after all the decorators process it with their respective functionalities (validating response, validating parameters, serialization, etc).

/ping @dpopov76