### PR TITLE
[WIP] Re-organize configs

### DIFF
--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -6,6 +6,7 @@ import click
 from clickclick import AliasedGroup, fatal_error
 
 import connexion
+from connexion.config import Config
 from connexion.mock import MockResolver
 
 logger = logging.getLogger('connexion.cli')
@@ -71,7 +72,7 @@ def main():
               help='Enable validation of response values from operation handlers.',
               is_flag=True, default=False)
 @click.option('--strict-validation',
-              help='Enable strict validation of request payloads.',
+              help='Enable strict validation of endpoint parameters.',
               is_flag=True, default=False)
 @click.option('--debug', '-d', help='Show debugging information.',
               is_flag=True, default=False)
@@ -147,6 +148,14 @@ def run(spec_file,
             host=host,
             server=wsgi_server,
             debug=debug)
+
+
+@main.command()
+def default_config():
+    """
+    Prints the default configuration file for Connexion based applications.
+    """
+    click.echo(Config.get_config_text())
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -150,7 +150,7 @@ def run(spec_file,
             debug=debug)
 
 
-@main.command()
+@main.command('default-config')
 def default_config():
     """
     Prints the default configuration file for Connexion based applications.

--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -43,6 +43,7 @@ def main():
 @main.command()
 @click.argument('spec_file')
 @click.argument('base_module_path', required=False)
+@click.option('--config', '-c', metavar='PATH', help='Use configuration file to run.')
 @click.option('--port', '-p', default=5000, type=int, help='Port to listen.')
 @click.option('--host', '-H', type=str, help='Host interface to bind on.')
 @click.option('--wsgi-server', '-w', default='flask',
@@ -81,6 +82,7 @@ def main():
               help='Override the basePath in the API spec.')
 def run(spec_file,
         base_module_path,
+        config,
         port,
         host,
         wsgi_server,

--- a/connexion/config.py
+++ b/connexion/config.py
@@ -22,7 +22,12 @@ Config.define('PORT', 5000,
               'The port to listen to when server is running.',
               SERVER_CONFIG_SECTION)
 
-Config.define('DEBUG', False,
+Config.define('WSGI_SERVER_CONTAINER', 'flask',
+              'Which WSGI server container to use. '
+              'Options are: "flask", "gevent", and "tornado".',
+              SERVER_CONFIG_SECTION)
+
+Config.define('CONNEXION_DEBUG', False,
               'Whether to execute the application in debug mode.',
               SERVER_CONFIG_SECTION)
 
@@ -47,6 +52,21 @@ Config.define('MAKE_SPEC_AVAILABLE', True,
               'Whether to make available the OpenAPI sepecification under '
               'CONSOLE_UI_PATH/swagger.json path.',
               API_CONFIG_SECTION)
+
+Config.define('JSON_ENCODER', 'connexion.decorators.produces.JSONEncoder',
+              'Defines which encoder to use when serializing objects to JSON.',
+              API_CONFIG_SECTION)
+
+Config.define('STUB_NOT_IMPLEMENTED_ENDPOINTS', False,
+              'Returns status code 501, and "Not Implemented Yet" payload, for '
+              'the endpoints which handlers are not found.',
+              API_CONFIG_SECTION)
+
+Config.define('MOCK_API', None,
+              'Returns example data for all endpoints or for which handlers'
+              ' are not found. Options are: None, "all" or "notimplemented".',
+              API_CONFIG_SECTION)
+
 
 CONSOLE_UI_SECTION = 'API Console UI configurations'
 
@@ -77,9 +97,14 @@ def _print_doc_table():
     for group in config.class_groups:
         keys = config.class_group_items[group]
         for key in keys:
-            desc = '{} Defaults to: "{}"'.format(
-                config.class_descriptions[key], config.class_defaults[key])
+            default_value = config.class_defaults[key]
+            if isinstance(default_value, str):
+                default_value = '"{}"'.format(default_value)
+
+            desc = '{} Defaults to: {}'.format(
+                config.class_descriptions[key], default_value)
             desc = fill(desc, width=column_width).replace('\n', newline_spacing)
+
             print('``{}``{}{}'.format(key, ' ' * (column_width - len(key) - 3), desc))
     print(header)
 

--- a/connexion/config.py
+++ b/connexion/config.py
@@ -27,7 +27,7 @@ Config.define('WSGI_SERVER_CONTAINER', 'flask',
               'Options are: "flask", "gevent", and "tornado".',
               SERVER_CONFIG_SECTION)
 
-Config.define('CONNEXION_DEBUG', False,
+Config.define('DEBUG', False,
               'Whether to execute the application in debug mode.',
               SERVER_CONFIG_SECTION)
 

--- a/connexion/config.py
+++ b/connexion/config.py
@@ -4,7 +4,7 @@ from derpconf.config import Config
 BASE_API_SECTION = 'Basic API configurations'
 
 Config.define('SPECIFICATION_FILE', None,
-              'OpenAPI specification file path',
+              'OpenAPI specification file path.',
               BASE_API_SECTION)
 
 Config.define('SPECIFICATION_DIR', '',
@@ -61,3 +61,20 @@ Config.define('CONSOLE_UI_AVAILABLE', True,
 Config.define('CONSOLE_UI_PATH', '/ui',
               'Path to mount the OpenAPI console.',
               CONSOLE_UI_SECTION)
+
+
+if __name__ == '__main__':
+    from textwrap import fill
+    config = Config()
+    column_width = 41
+    header = '=' * column_width
+    header = '{} {}'.format(header, header)
+    newline_spacing = '\n' + (' ' * (column_width + 1))
+    print(header)
+    for group in config.class_groups:
+        keys = config.class_group_items[group]
+        for key in keys:
+            print('``{}``{}{}'.format(key, ' ' * (column_width - len(key) - 3),
+                                      fill(config.class_descriptions[key],
+                                           width=column_width).replace('\n', newline_spacing)))
+    print(header)

--- a/connexion/config.py
+++ b/connexion/config.py
@@ -63,7 +63,10 @@ Config.define('CONSOLE_UI_PATH', '/ui',
               CONSOLE_UI_SECTION)
 
 
-if __name__ == '__main__':
+def _print_doc_table():
+    """ Prints the table to be used in the `docs/configuration.rst`
+    documentation file.
+    """
     from textwrap import fill
     config = Config()
     column_width = 41
@@ -79,3 +82,6 @@ if __name__ == '__main__':
             desc = fill(desc, width=column_width).replace('\n', newline_spacing)
             print('``{}``{}{}'.format(key, ' ' * (column_width - len(key) - 3), desc))
     print(header)
+
+if __name__ == '__main__':
+    _print_doc_table()

--- a/connexion/config.py
+++ b/connexion/config.py
@@ -1,0 +1,63 @@
+from derpconf.config import Config
+
+
+BASE_API_SECTION = 'Basic API configurations'
+
+Config.define('SPECIFICATION_FILE', None,
+              'OpenAPI specification file path',
+              BASE_API_SECTION)
+
+Config.define('SPECIFICATION_DIR', '',
+              'Directory to use as bases to look for OpenAPI specification files.',
+              BASE_API_SECTION)
+
+
+SERVER_CONFIG_SECTION = 'Application Server configurations'
+
+Config.define('HOST', '0.0.0.0',
+              'The host interface to bind on when server is running.',
+              SERVER_CONFIG_SECTION)
+
+Config.define('PORT', 5000,
+              'The port to listen to when server is running.',
+              SERVER_CONFIG_SECTION)
+
+Config.define('DEBUG', False,
+              'Whether to execute the application in debug mode.',
+              SERVER_CONFIG_SECTION)
+
+
+API_CONFIG_SECTION = 'API configurations'
+
+Config.define('AUTHENTICATE_NOT_FOUND_URLS', False,
+              'Whether to authenticate paths not defined in the API specification.',
+              API_CONFIG_SECTION)
+
+Config.define('VALIDATE_RESPONSES', False,
+              'Whether to validate the operation handler responses against '
+              'the API specification or not.',
+              API_CONFIG_SECTION)
+
+Config.define('STRICT_PARAMETERS_VALIDATION', False,
+              'Whether to allow or not additional parameters in querystring '
+              'and formData than the defineds in the API specification.',
+              API_CONFIG_SECTION)
+
+Config.define('MAKE_SPEC_AVAILABLE', True,
+              'Whether to make available the OpenAPI sepecification under '
+              'CONSOLE_UI_PATH/swagger.json path.',
+              API_CONFIG_SECTION)
+
+CONSOLE_UI_SECTION = 'API Console UI configurations'
+
+Config.define('CONSOLE_UI_AVAILABLE', True,
+              'Whether to make the OpenAPI console available under '
+              'CONSOLE_UI_PATH config path. Notice that this '
+              'overrides the MAKE_SPEC_AVAILABLE configuration since '
+              'the specification is required to be available to show '
+              'the console UI.',
+              CONSOLE_UI_SECTION)
+
+Config.define('CONSOLE_UI_PATH', '/ui',
+              'Path to mount the OpenAPI console.',
+              CONSOLE_UI_SECTION)

--- a/connexion/config.py
+++ b/connexion/config.py
@@ -74,7 +74,8 @@ if __name__ == '__main__':
     for group in config.class_groups:
         keys = config.class_group_items[group]
         for key in keys:
+            desc = '{} Defaults to: {}'.format(
+                config.class_descriptions[key], config.class_defaults[key])
             print('``{}``{}{}'.format(key, ' ' * (column_width - len(key) - 3),
-                                      fill(config.class_descriptions[key],
-                                           width=column_width).replace('\n', newline_spacing)))
+                                      fill(desc, width=column_width).replace('\n', newline_spacing)))
     print(header)

--- a/connexion/config.py
+++ b/connexion/config.py
@@ -76,6 +76,6 @@ if __name__ == '__main__':
         for key in keys:
             desc = '{} Defaults to: "{}"'.format(
                 config.class_descriptions[key], config.class_defaults[key])
-            print('``{}``{}{}'.format(key, ' ' * (column_width - len(key) - 3),
-                                      fill(desc, width=column_width).replace('\n', newline_spacing)))
+            desc = fill(desc, width=column_width).replace('\n', newline_spacing)
+            print('``{}``{}{}'.format(key, ' ' * (column_width - len(key) - 3), desc))
     print(header)

--- a/connexion/config.py
+++ b/connexion/config.py
@@ -74,7 +74,7 @@ if __name__ == '__main__':
     for group in config.class_groups:
         keys = config.class_group_items[group]
         for key in keys:
-            desc = '{} Defaults to: {}'.format(
+            desc = '{} Defaults to: "{}"'.format(
                 config.class_descriptions[key], config.class_defaults[key])
             print('``{}``{}{}'.format(key, ' ' * (column_width - len(key) - 3),
                                       fill(desc, width=column_width).replace('\n', newline_spacing)))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -248,7 +248,9 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     ('index', 'Connexion', u'Connexion Documentation',
-     u'Zalando SE', 'Connexion', 'One line description of project.',
+     u'Zalando SE', 'Connexion',
+     'Swagger/OpenAPI First framework for Python on top of Flask'
+     ' with automatic endpoint validation and OAuth2 support',
      'Miscellaneous'),
 ]
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -59,7 +59,7 @@ The following configuration values are used internally by Connexion:
 ``WSGI_SERVER_CONTAINER``                 Which WSGI server container to use.
                                           Options are: "flask", "gevent", and
                                           "tornado". Defaults to: "flask"
-``CONNEXION_DEBUG``                       Whether to execute the application in
+``DEBUG``                                 Whether to execute the application in
                                           debug mode. Defaults to: False
 ``AUTHENTICATE_NOT_FOUND_URLS``           Whether to authenticate paths not defined
                                           in the API specification. Defaults to:
@@ -98,6 +98,26 @@ The following configuration values are used internally by Connexion:
                                           Defaults to: "/ui"
 ========================================= =========================================
 
+
+Using Environment Variables for Configurations
+----------------------------------------------
+
+Connexion automatically look for configurations in the environment
+variables of the running system. For that you have to set the
+environment variable in the format ``CONNEXION_{{CONFIG_NAME}}``. For
+example, to set the port that Connexion should use to run the
+application you should set the environment variable
+``CONNEXION_PORT`` to 8080.
+
+.. code-block:: bash
+
+    $ export CONNEXION_PORT=8080
+    $ connexion run swagger.yaml -v
+    INFO:werkzeug: * Running on http://0.0.0.0:8080/ (Press CTRL+C to quit)
+
+
+Using File for Configurations
+-----------------------------
 
 You can generate a base configuration file using the Connexion CLI:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -44,7 +44,6 @@ Builtin Configuration Values
 
 The following configuration values are used internally by Connexion::
 
-.. tabularcolumns:: |p{6.5cm}|p{8.5cm}|
 
 ========================================= =========================================
 ``SPECIFICATION_FILE``                    OpenAPI specification file path.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -26,17 +26,17 @@ dictionary and can be modifified just like any dictionary::
     app = connexion.App(__name__)
     app.config['SPECIFICATION_FILE'] = './swagger.yaml'
 
+
 The configurations are also possible to come from environment
 variables. The lookup order of configurations is:
 
- - Set directly in the ``connexion.App#config`` configuration
-   attribute;
- - Set while calling ``connexion.App`` or ``connexion.App.add_api``
-   directly;
- - Included in a configuration file passed to ``connexion.App`` or
-   ``connexion.App.add_api``;
- - An environment variable with same name of the configuration
-   setting;
+- Set directly in the ``connexion.App#config`` configuration
+  attribute;
+- Set while calling ``connexion.App`` or ``connexion.App.add_api``
+  directly;
+- Included in a configuration file passed to ``connexion.App`` or
+  ``connexion.App.add_api``;
+- An environment variable with same name of the configuration setting;
 
 
 Builtin Configuration Values

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -42,8 +42,9 @@ variables. The lookup order of configurations is:
 Builtin Configuration Values
 ----------------------------
 
-The following configuration values are used internally by Connexion::
+The following configuration values are used internally by Connexion:
 
+.. tabularcolumns:: |p{6.5cm}|p{8.5cm}|
 
 ========================================= =========================================
 ``SPECIFICATION_FILE``                    OpenAPI specification file path.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -34,9 +34,10 @@ variables. The lookup order of configurations is:
   attribute;
 - Set while calling ``connexion.App`` or ``connexion.App.add_api``
   directly;
+- An environment variable with same name of the configuration prefixed
+  by ``CONNEXION_``;
 - Included in a configuration file passed to ``connexion.App`` or
   ``connexion.App.add_api``;
-- An environment variable with same name of the configuration setting;
 
 
 Builtin Configuration Values

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -48,40 +48,56 @@ The following configuration values are used internally by Connexion:
 
 ========================================= =========================================
 ``SPECIFICATION_FILE``                    OpenAPI specification file path. Defaults
-                                          to: "None"
+                                          to: None
 ``SPECIFICATION_DIR``                     Directory to use as bases to look for
                                           OpenAPI specification files. Defaults to:
                                           ""
 ``HOST``                                  The host interface to bind on when server
                                           is running. Defaults to: "0.0.0.0"
 ``PORT``                                  The port to listen to when server is
-                                          running. Defaults to: "5000"
-``DEBUG``                                 Whether to execute the application in
-                                          debug mode. Defaults to: "False"
+                                          running. Defaults to: 5000
+``WSGI_SERVER_CONTAINER``                 Which WSGI server container to use.
+                                          Options are: "flask", "gevent", and
+                                          "tornado". Defaults to: "flask"
+``CONNEXION_DEBUG``                       Whether to execute the application in
+                                          debug mode. Defaults to: False
 ``AUTHENTICATE_NOT_FOUND_URLS``           Whether to authenticate paths not defined
                                           in the API specification. Defaults to:
-                                          "False"
+                                          False
 ``VALIDATE_RESPONSES``                    Whether to validate the operation handler
                                           responses against the API specification
-                                          or not. Defaults to: "False"
+                                          or not. Defaults to: False
 ``STRICT_PARAMETERS_VALIDATION``          Whether to allow or not additional
                                           parameters in querystring and formData
                                           than the defineds in the API
-                                          specification. Defaults to: "False"
+                                          specification. Defaults to: False
 ``MAKE_SPEC_AVAILABLE``                   Whether to make available the OpenAPI
                                           sepecification under
                                           CONSOLE_UI_PATH/swagger.json path.
-                                          Defaults to: "True"
+                                          Defaults to: True
+``JSON_ENCODER``                          Defines which encoder to use when
+                                          serializing objects to JSON. Defaults to:
+                                          "connexion.decorators.produces.JSONEncode
+                                          r"
+``STUB_NOT_IMPLEMENTED_ENDPOINTS``        Returns status code 501, and "Not
+                                          Implemented Yet" payload, for the
+                                          endpoints which handlers are not found.
+                                          Defaults to: False
+``MOCK_API``                              Returns example data for all endpoints or
+                                          for which handlers are not found. Options
+                                          are: None, "all" or "notimplemented".
+                                          Defaults to: None
 ``CONSOLE_UI_AVAILABLE``                  Whether to make the OpenAPI console
                                           available under CONSOLE_UI_PATH config
                                           path. Notice that this overrides the
                                           MAKE_SPEC_AVAILABLE configuration since
                                           the specification is required to be
                                           available to show the console UI.
-                                          Defaults to: "True"
+                                          Defaults to: True
 ``CONSOLE_UI_PATH``                       Path to mount the OpenAPI console.
                                           Defaults to: "/ui"
 ========================================= =========================================
+
 
 You can generate a base configuration file using the Connexion CLI:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,0 +1,76 @@
+Configuration Handling
+======================
+
+.. versionadded:: 1.0.130
+
+Connexion supports a series of configurations that define how the
+application should run or behave.
+
+The way configuration in Connexion is designed tries to be fiel to how
+Flask configurations work. We levarage the Flask support to
+configurations adding the possibility to use configuration file or
+environment variables for Connexion specific settings. That way we
+enable you to use Connexion in conjunction with other
+extensions. Futhermore, the development cycle of Connexion
+applications is as close as possible to using Flask direcly.
+
+
+Configuration Basics
+====================
+
+We provide the `connexion.App.config` which is a subclass of a
+dictionary and can be modifified just like any dictionary::
+
+.. code-block:: python
+
+    app = connexion.App(__name__)
+    app.config['SPECIFICATION_FILE'] = './swagger.yaml'
+
+The configurations are also possible to come from environment
+variables. The lookup order of configurations is:
+
+ - Set directly in the ``connexion.App#config`` configuration
+   attribute;
+ - Set while calling ``connexion.App`` or ``connexion.App.add_api``
+   directly;
+ - Included in a configuration file passed to ``connexion.App`` or
+   ``connexion.App.add_api``;
+ - An environment variable with same name of the configuration
+   setting;
+
+
+Builtin Configuration Values
+----------------------------
+
+The following configuration values are used internally by Connexion::
+
+========================================= =========================================
+``SPECIFICATION_FILE``                    OpenAPI specification file path.
+``SPECIFICATION_DIR``                     Directory to use as bases to look for
+                                          OpenAPI specification files.
+``HOST``                                  The host interface to bind on when server
+                                          is running.
+``PORT``                                  The port to listen to when server is
+                                          running.
+``DEBUG``                                 Whether to execute the application in
+                                          debug mode.
+``AUTHENTICATE_NOT_FOUND_URLS``           Whether to authenticate paths not defined
+                                          in the API specification.
+``VALIDATE_RESPONSES``                    Whether to validate the operation handler
+                                          responses against the API specification
+                                          or not.
+``STRICT_PARAMETERS_VALIDATION``          Whether to allow or not additional
+                                          parameters in querystring and formData
+                                          than the defineds in the API
+                                          specification.
+``MAKE_SPEC_AVAILABLE``                   Whether to make available the OpenAPI
+                                          sepecification under
+                                          CONSOLE_UI_PATH/swagger.json path.
+``CONSOLE_UI_AVAILABLE``                  Whether to make the OpenAPI console
+                                          available under CONSOLE_UI_PATH config
+                                          path. Notice that this overrides the
+                                          MAKE_SPEC_AVAILABLE configuration since
+                                          the specification is required to be
+                                          available to show the console UI.
+``CONSOLE_UI_PATH``                       Path to mount the OpenAPI console.
+========================================= =========================================

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -82,3 +82,9 @@ The following configuration values are used internally by Connexion:
 ``CONSOLE_UI_PATH``                       Path to mount the OpenAPI console.
                                           Defaults to: "/ui"
 ========================================= =========================================
+
+You can generate a base configuration file using the Connexion CLI:
+
+.. code-block:: bash
+
+    $ connexion default-config > myapp.conf

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -19,7 +19,7 @@ Configuration Basics
 ====================
 
 We provide the `connexion.App.config` which is a subclass of a
-dictionary and can be modifified just like any dictionary::
+dictionary and can be modifified just like any dictionary:
 
 .. code-block:: python
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -48,36 +48,37 @@ The following configuration values are used internally by Connexion:
 
 ========================================= =========================================
 ``SPECIFICATION_FILE``                    OpenAPI specification file path. Defaults
-                                          to: None
+                                          to: "None"
 ``SPECIFICATION_DIR``                     Directory to use as bases to look for
                                           OpenAPI specification files. Defaults to:
+                                          ""
 ``HOST``                                  The host interface to bind on when server
-                                          is running. Defaults to: 0.0.0.0
+                                          is running. Defaults to: "0.0.0.0"
 ``PORT``                                  The port to listen to when server is
-                                          running. Defaults to: 5000
+                                          running. Defaults to: "5000"
 ``DEBUG``                                 Whether to execute the application in
-                                          debug mode. Defaults to: False
+                                          debug mode. Defaults to: "False"
 ``AUTHENTICATE_NOT_FOUND_URLS``           Whether to authenticate paths not defined
                                           in the API specification. Defaults to:
-                                          False
+                                          "False"
 ``VALIDATE_RESPONSES``                    Whether to validate the operation handler
                                           responses against the API specification
-                                          or not. Defaults to: False
+                                          or not. Defaults to: "False"
 ``STRICT_PARAMETERS_VALIDATION``          Whether to allow or not additional
                                           parameters in querystring and formData
                                           than the defineds in the API
-                                          specification. Defaults to: False
+                                          specification. Defaults to: "False"
 ``MAKE_SPEC_AVAILABLE``                   Whether to make available the OpenAPI
                                           sepecification under
                                           CONSOLE_UI_PATH/swagger.json path.
-                                          Defaults to: True
+                                          Defaults to: "True"
 ``CONSOLE_UI_AVAILABLE``                  Whether to make the OpenAPI console
                                           available under CONSOLE_UI_PATH config
                                           path. Notice that this overrides the
                                           MAKE_SPEC_AVAILABLE configuration since
                                           the specification is required to be
                                           available to show the console UI.
-                                          Defaults to: True
+                                          Defaults to: "True"
 ``CONSOLE_UI_PATH``                       Path to mount the OpenAPI console.
-                                          Defaults to: /ui
+                                          Defaults to: "/ui"
 ========================================= =========================================

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -44,6 +44,8 @@ Builtin Configuration Values
 
 The following configuration values are used internally by Connexion::
 
+.. tabularcolumns:: |p{6.5cm}|p{8.5cm}|
+
 ========================================= =========================================
 ``SPECIFICATION_FILE``                    OpenAPI specification file path.
 ``SPECIFICATION_DIR``                     Directory to use as bases to look for

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -47,32 +47,37 @@ The following configuration values are used internally by Connexion:
 .. tabularcolumns:: |p{6.5cm}|p{8.5cm}|
 
 ========================================= =========================================
-``SPECIFICATION_FILE``                    OpenAPI specification file path.
+``SPECIFICATION_FILE``                    OpenAPI specification file path. Defaults
+                                          to: None
 ``SPECIFICATION_DIR``                     Directory to use as bases to look for
-                                          OpenAPI specification files.
+                                          OpenAPI specification files. Defaults to:
 ``HOST``                                  The host interface to bind on when server
-                                          is running.
+                                          is running. Defaults to: 0.0.0.0
 ``PORT``                                  The port to listen to when server is
-                                          running.
+                                          running. Defaults to: 5000
 ``DEBUG``                                 Whether to execute the application in
-                                          debug mode.
+                                          debug mode. Defaults to: False
 ``AUTHENTICATE_NOT_FOUND_URLS``           Whether to authenticate paths not defined
-                                          in the API specification.
+                                          in the API specification. Defaults to:
+                                          False
 ``VALIDATE_RESPONSES``                    Whether to validate the operation handler
                                           responses against the API specification
-                                          or not.
+                                          or not. Defaults to: False
 ``STRICT_PARAMETERS_VALIDATION``          Whether to allow or not additional
                                           parameters in querystring and formData
                                           than the defineds in the API
-                                          specification.
+                                          specification. Defaults to: False
 ``MAKE_SPEC_AVAILABLE``                   Whether to make available the OpenAPI
                                           sepecification under
                                           CONSOLE_UI_PATH/swagger.json path.
+                                          Defaults to: True
 ``CONSOLE_UI_AVAILABLE``                  Whether to make the OpenAPI console
                                           available under CONSOLE_UI_PATH config
                                           path. Notice that this overrides the
                                           MAKE_SPEC_AVAILABLE configuration since
                                           the specification is required to be
                                           available to show the console UI.
+                                          Defaults to: True
 ``CONSOLE_UI_PATH``                       Path to mount the OpenAPI console.
+                                          Defaults to: /ui
 ========================================= =========================================

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ install_requires = [
     'six>=1.9',
     'strict-rfc3339>=0.6',
     'swagger-spec-validator>=2.0.2',
+    'derpconf>=0.8.1'
 ]
 
 if py_major_minor_version < (3, 4):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -84,7 +84,7 @@ def test_run_no_options_all_default(mock_app_run, expected_arguments, spec_file)
 
 
 def test_run_using_option_hide_spec(mock_app_run, expected_arguments,
-                                           spec_file):
+                                    spec_file):
     runner = CliRunner()
     runner.invoke(main, ['run', spec_file, '--hide-spec'],
                   catch_exceptions=False)
@@ -94,7 +94,7 @@ def test_run_using_option_hide_spec(mock_app_run, expected_arguments,
 
 
 def test_run_using_option_hide_console_ui(mock_app_run, expected_arguments,
-                                                 spec_file):
+                                          spec_file):
     runner = CliRunner()
     runner.invoke(main, ['run', spec_file, '--hide-console-ui'],
                   catch_exceptions=False)
@@ -104,7 +104,7 @@ def test_run_using_option_hide_console_ui(mock_app_run, expected_arguments,
 
 
 def test_run_using_option_console_ui_from(mock_app_run, expected_arguments,
-                                           spec_file):
+                                          spec_file):
     user_path = '/some/path/here'
     runner = CliRunner()
     runner.invoke(main, ['run', spec_file, '--console-ui-from', user_path],
@@ -115,7 +115,7 @@ def test_run_using_option_console_ui_from(mock_app_run, expected_arguments,
 
 
 def test_run_using_option_console_ui_url(mock_app_run, expected_arguments,
-                                           spec_file):
+                                         spec_file):
     user_url = '/console_ui_test'
     runner = CliRunner()
     runner.invoke(main, ['run', spec_file, '--console-ui-url', user_url],
@@ -126,7 +126,7 @@ def test_run_using_option_console_ui_url(mock_app_run, expected_arguments,
 
 
 def test_run_using_option_auth_all_paths(mock_app_run, expected_arguments,
-                                                 spec_file):
+                                         spec_file):
     runner = CliRunner()
     runner.invoke(main, ['run', spec_file, '--auth-all-paths'],
                   catch_exceptions=False)
@@ -151,7 +151,7 @@ def test_run_in_debug_mode(mock_app_run, expected_arguments, spec_file,
 
 
 def test_run_in_very_verbose_mode(mock_app_run, expected_arguments, spec_file,
-                           monkeypatch):
+                                  monkeypatch):
     logging_config = MagicMock(name='connexion.cli.logging.basicConfig')
     monkeypatch.setattr('connexion.cli.logging.basicConfig',
                         logging_config)
@@ -166,7 +166,7 @@ def test_run_in_very_verbose_mode(mock_app_run, expected_arguments, spec_file,
 
 
 def test_run_in_verbose_mode(mock_app_run, expected_arguments, spec_file,
-                           monkeypatch):
+                             monkeypatch):
     logging_config = MagicMock(name='connexion.cli.logging.basicConfig')
     monkeypatch.setattr('connexion.cli.logging.basicConfig',
                         logging_config)


### PR DESCRIPTION
Fixes #283 

**PLEASE DO NOT MERGE, THIS IS A WORKING IN PROGRESS.**

Proposal to remove dependency on parameters to `connexion.App` and `connexion.App#add_api` methods.

Changes proposed in this pull request:

 - Possibility to use configuration files.
 - Read configurations automatically from environment variables (for that the environment variable has to be in the format `CONNEXION_{{config_variable_name}}`).
 - All the load and validations are deferred to when the method `connexion.App#run` is called. So we can do properly configuration resolution.
