### PR TITLE
Support the flask url variable converter "path"

### DIFF
--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -326,7 +326,8 @@ class Operation(SecureOperation):
             yield param
 
     def get_path_parameter_types(self):
-        return {p['name']: p.get('type') for p in self.parameters if p['in'] == 'path'}
+        return {p['name']: 'path' if p.get('type') == 'string' and p.get('format') == 'path' else p.get('type')
+                for p in self.parameters if p['in'] == 'path'}
 
     @property
     def body_schema(self):

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -13,7 +13,8 @@ PATH_PARAMETER = re.compile(r'\{([^}]*)\}')
 # see http://flask.pocoo.org/docs/0.10/api/#url-route-registrations
 PATH_PARAMETER_CONVERTERS = {
     'integer': 'int',
-    'number': 'float'
+    'number': 'float',
+    'path': 'path'
 }
 
 

--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -90,6 +90,30 @@ under-score is encountered. As an example:
 Without this sanitation it would e.g. be impossible to implement an
 [OData](http://www.odata.org) API.
 
+Parameter Variable Converters
+-----------------------------
+
+Connexion supports Flask's ``int``, ``float``, and ``path`` route parameter
+`variable converters
+<http://flask.pocoo.org/docs/0.12/quickstart/#variable-rules>`_.
+Specify a route parameter's type as ``integer`` or ``number`` or its type as
+``string`` and its format as ``path`` to use these converters. For example:
+
+.. code-block:: yaml
+
+  paths:
+    /greeting/{name}:
+      # ...
+      parameters:
+        - name: name
+          in: path
+          required: true
+          type: string
+          format: path
+
+will create an equivalent Flask route ``/greeting/<path:name>``, allowing
+requests to include forward slashes in the ``name`` url variable.
+
 API Versioning and basePath
 ---------------------------
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -452,3 +452,15 @@ def test_default():
     Operation(method='POST', path='endpoint', path_parameters=[], operation=op, app_produces=['application/json'],
               app_consumes=['application/json'], app_security=[], security_definitions={},
               definitions=DEFINITIONS, parameter_definitions={}, resolver=Resolver())
+
+
+def test_get_path_parameter_types():
+    op = OPERATION1.copy()
+    op['parameters'] = [{'in': 'path', 'type': 'int', 'name': 'int_path'},
+                        {'in': 'path', 'type': 'string', 'name': 'string_path'},
+                        {'in': 'path', 'type': 'string', 'format': 'path', 'name': 'path_path'}]
+
+    operation = Operation(method='GET', path='endpoint', path_parameters=[], operation=op,
+                          app_produces=['application/json'], app_consumes=['application/json'], resolver=Resolver())
+
+    assert {'int_path': 'int', 'string_path': 'string', 'path_path': 'path'} == operation.get_path_parameter_types()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@ def test_flaskify_path():
     assert utils.flaskify_path("foo_bar/{a-b}/{c_d}") == "foo_bar/<a_b>/<c_d>"
     assert utils.flaskify_path("foo/{a}/{b}", {'a': 'integer'}) == "foo/<int:a>/<b>"
     assert utils.flaskify_path("foo/{a}/{b}", {'a': 'number'}) == "foo/<float:a>/<b>"
+    assert utils.flaskify_path("foo/{a}/{b}", {'a': 'path'}) == "foo/<path:a>/<b>"
 
 
 def test_flaskify_endpoint():


### PR DESCRIPTION
The Flask variable converter "path" allows url variables to include forward slashes in their values. This PR adds support for that feature if the Swagger specification indicates that a route parameter's format is "path". 

Example:

    parameters:
      - name: name
        in: path
        required: true
        format: path
        type: string

will add a route parameter `<path:name>`.

Excerpt from the Swagger specification:

> the format property is an open string-valued property, and can have any value to support documentation needs. Formats such as "email", "uuid", etc., can be used even though they are not defined by this specification. 