### PR TITLE
Problem as exceptions should convert properly to problem responses

### DIFF
--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -66,3 +66,9 @@ def test_errors(problem_app):
     problem_body = json.loads(custom_problem.data.decode('utf-8'))
     assert 'amount' in problem_body
     assert problem_body['amount'] == 23.
+
+    problem_as_exception = app_client.get('/v1.0/problem_exception_with_extra_args')
+    assert problem_as_exception.status_code == 400
+    problem_as_exception_body = json.loads(problem_as_exception.data.decode('utf-8'))
+    assert 'age' in problem_as_exception_body
+    assert problem_as_exception_body['age'] == 30

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -2,7 +2,7 @@
 
 from flask import redirect
 
-from connexion import NoContent, problem, request
+from connexion import NoContent, ProblemException, problem, request
 
 
 class DummyClass(object):
@@ -13,7 +13,7 @@ class DummyClass(object):
     def test_method(self):
         return self.__class__.__name__
 
-class_instance = DummyClass()
+class_instance = DummyClass()  # noqa
 
 
 def get():
@@ -346,6 +346,14 @@ def get_empty_dict():
 def get_custom_problem_response():
     return problem(403, "You need to pay", "Missing amount",
                    ext={'amount': 23.0})
+
+
+def throw_problem_exception():
+    raise ProblemException(
+        title="As Exception",
+        detail="Something wrong or not!",
+        ext={'age': 30}
+    )
 
 
 def unordered_params_response(first, path_param, second):

--- a/tests/fixtures/problem/swagger.yaml
+++ b/tests/fixtures/problem/swagger.yaml
@@ -91,3 +91,13 @@ paths:
       responses:
         200:
           description: Custom problem response
+
+  /problem_exception_with_extra_args:
+    get:
+      description: Using problem as exception
+      operationId: fakeapi.hello.throw_problem_exception
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Problem exception


### PR DESCRIPTION
The `ProblemException` is an internal behaviour of Connexion and shouldn't mix with the Flask responses. Furthermore, the previous implementation of the `ProblemException` introduced in #368 could not be converted directly to problem responses. This PR fixed this.