### PR TITLE
Replacing deprecated flask json calls + Content-Type validation

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -96,10 +96,7 @@ def parameter_to_arg(parameters, consumes, function):
 
         if all_json(consumes):
             try:
-                try:
-                    request_body = flask.request.get_json()
-                except AttributeError:
-                    request_body = flask.request.json
+                request_body = flask.request.get_json()
             except exceptions.BadRequest:
                 request_body = None
         else:

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -96,7 +96,10 @@ def parameter_to_arg(parameters, consumes, function):
 
         if all_json(consumes):
             try:
-                request_body = flask.request.json
+                try:
+                    request_body = flask.request.get_json()
+                except AttributeError:
+                    request_body = flask.request.json
             except exceptions.BadRequest:
                 request_body = None
         else:

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -109,6 +109,14 @@ class RequestBodyValidator(object):
                 except AttributeError:
                     data = flask.request.json
 
+                # flask does not process json if the Content-Type header is not equal to "application/json"
+                if data is None and len(flask.request.data) > 0 and not self.is_null_value_valid:
+                    return problem(415,
+                                   "Unsupported Media Type",
+                                   "Invalid Content-type ({content_type}), expected JSON data".format(
+                                       content_type=flask.request.headers["Content-Type"]
+                                   ))
+
                 logger.debug("%s validating schema...", flask.request.url)
                 error = self.validate_schema(data)
                 if error and not self.has_default:

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -104,10 +104,7 @@ class RequestBodyValidator(object):
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
             if all_json(self.consumes):
-                try:
-                    data = flask.request.get_json()
-                except AttributeError:
-                    data = flask.request.json
+                data = flask.request.get_json()
 
                 # flask does not process json if the Content-Type header is not equal to "application/json"
                 if data is None and len(flask.request.data) > 0 and not self.is_null_value_valid:

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -104,7 +104,10 @@ class RequestBodyValidator(object):
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
             if all_json(self.consumes):
-                data = flask.request.json
+                try:
+                    data = flask.request.get_json()
+                except AttributeError:
+                    data = flask.request.json
 
                 logger.debug("%s validating schema...", flask.request.url)
                 error = self.validate_schema(data)

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,10 +1,11 @@
 -e git+https://github.com/Julian/jsonschema.git#egg=jsonschema
 -e git+https://github.com/pallets/flask.git#egg=flask
 -e git+https://github.com/kennethreitz/requests#egg=requests
--e hg+https://bitbucket.org/gutworth/six#egg=six
 -e git+https://github.com/danielrichman/strict-rfc3339.git#egg=strict-rfc3339
--e git+https://github.com/digium/swagger-py.git#egg=swagger-spec-validator
+-e git+https://github.com/Yelp/swagger_spec_validator.git#egg=swagger-spec-validator
 -e git+https://github.com/zalando/python-clickclick.git#egg=clickclick
 -e hg+https://bitbucket.org/pitrou/pathlib#egg=pathlib
 # PyYAML is not that easy to build manually, it may fail.
 #-e svn+http://svn.pyyaml.org/pyyaml/trunk#egg=PyYAML
+# six is causing errors during the tests
+#-e git+https://github.com/benjaminp/six.git#egg=six

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -179,3 +179,23 @@ def test_operation_handler_returns_flask_object(invalid_resp_allowed_app):
     app_client = invalid_resp_allowed_app.app.test_client()
     resp = app_client.get('/v1.0/get_non_conforming_response')
     assert resp.status_code == 200
+
+
+def test_post_wrong_content_type(simple_app):
+    app_client = simple_app.app.test_client()
+    resp = app_client.post('/v1.0/post_wrong_content_type',
+                           content_type="application/weird+json",
+                           data=json.dumps({"some": "data"})
+                           )
+    assert resp.status_code == 200
+
+    resp = app_client.post('/v1.0/post_wrong_content_type',
+                           content_type="application/xml",
+                           data=json.dumps({"some": "data"})
+                           )
+    assert resp.status_code == 415
+
+    resp = app_client.post('/v1.0/post_wrong_content_type',
+                           data=json.dumps({"some": "data"})
+                           )
+    assert resp.status_code == 415

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -184,12 +184,6 @@ def test_operation_handler_returns_flask_object(invalid_resp_allowed_app):
 def test_post_wrong_content_type(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.post('/v1.0/post_wrong_content_type',
-                           content_type="application/weird+json",
-                           data=json.dumps({"some": "data"})
-                           )
-    assert resp.status_code == 200
-
-    resp = app_client.post('/v1.0/post_wrong_content_type',
                            content_type="application/xml",
                            data=json.dumps({"some": "data"})
                            )

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -379,3 +379,6 @@ def test_param_sanitization(query=None, form=None):
 
 def test_body_sanitization(body=None):
     return body
+
+def post_wrong_content_type():
+    return "NOT OK"

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -147,6 +147,8 @@ paths:
       responses:
         200:
           description: OK
+        215:
+          description: fucked
 
   /test-default-integer-body:
     post:
@@ -706,6 +708,28 @@ paths:
             properties:
               some:
                 type: string
+  /post_wrong_content_type:
+    post:
+      operationId: fakeapi.hello.post_wrong_content_type
+      consumes:
+      - application/json
+      parameters:
+        - name: $body
+          description: Just a testing parameter in the body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              body1:
+                type: string
+              body2:
+                type: string
+      responses:
+        200:
+          description: OK
+        215:
+          description: NOT-OK
 
 
 definitions:

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -147,8 +147,6 @@ paths:
       responses:
         200:
           description: OK
-        215:
-          description: fucked
 
   /test-default-integer-body:
     post:

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -266,6 +266,7 @@ paths:
         - name: someint
           in: path
           type: integer
+          required: true
       responses:
         200:
           description: OK
@@ -278,6 +279,7 @@ paths:
         - name: somefloat
           in: path
           type: number
+          required: true
       responses:
         200:
           description: OK


### PR DESCRIPTION
Hi, 

While debugging a vague error message ("None type is not of type object"). I came across some deprecated Flask code, so I changed it.

The reason i got the error message was because I had forgotten to set a content-type header to "application/json" in Postman. I thought it would be useful to improve the error message when this happens. 

Let met know what you think!

Changes proposed in this pull request:

 - refactoring flask.request.json calls to flask.request.get_json()
 - Improving error messages when an http request does contain data but lacks a proper content-type
