### PR TITLE
pass encoding=utf-8 keyword argument to flask.json.dumps

### DIFF
--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -2,9 +2,9 @@
 import datetime
 import functools
 import logging
-import six
 
 import flask
+import six
 from flask import json
 
 from .decorator import BaseDecorator

--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -76,7 +76,7 @@ class Jsonifier(BaseSerializer):
         """ Central point where JSON serialization happens inside
         Connexion.
         """
-        return "{}\n".format(json.dumps(data, indent=2))
+        return "{}\n".format(json.dumps(data, indent=2, encoding="utf-8"))
 
     def __call__(self, function):
         """

--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -77,7 +77,7 @@ class Jsonifier(BaseSerializer):
         """ Central point where JSON serialization happens inside
         Connexion.
         """
-        if six.PY2 == True:
+        if six.PY2:
             json_content = json.dumps(data, indent=2, encoding="utf-8")
         else:
             json_content = json.dumps(data, indent=2)

--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -78,11 +78,11 @@ class Jsonifier(BaseSerializer):
         Connexion.
         """
         if six.PY2 == True:
-            encoding = "utf-8"
+            json_content = json.dumps(data, indent=2, encoding="utf-8")
         else:
-            encoding = None
+            json_content = json.dumps(data, indent=2)
 
-        return "{}\n".format(json.dumps(data, indent=2, encoding=encoding))
+        return "{}\n".format(json_content)
 
     def __call__(self, function):
         """

--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -2,6 +2,7 @@
 import datetime
 import functools
 import logging
+import six
 
 import flask
 from flask import json
@@ -76,7 +77,12 @@ class Jsonifier(BaseSerializer):
         """ Central point where JSON serialization happens inside
         Connexion.
         """
-        return "{}\n".format(json.dumps(data, indent=2, encoding="utf-8"))
+        if six.PY2 == True:
+            encoding = "utf-8"
+        else:
+            encoding = None
+
+        return "{}\n".format(json.dumps(data, indent=2, encoding=encoding))
 
     def __call__(self, function):
         """

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -133,13 +133,13 @@ def test_single_route(simple_app):
 def test_resolve_method(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/resolver-test/method')  # type: flask.Response
-    assert resp.data.decode() == '"DummyClass"\n'
+    assert resp.data.decode('utf-8') == '"DummyClass"\n'
 
 
 def test_resolve_classmethod(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/resolver-test/classmethod')  # type: flask.Response
-    assert resp.data.decode() == '"DummyClass"\n'
+    assert resp.data.decode('utf-8') == '"DummyClass"\n'
 
 
 def test_add_api_with_function_resolver_function_is_wrapped(simple_api_spec_dir):

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -133,13 +133,13 @@ def test_single_route(simple_app):
 def test_resolve_method(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/resolver-test/method')  # type: flask.Response
-    assert resp.data.decode('utf-8') == '"DummyClass"\n'
+    assert resp.data.decode('utf-8', 'replace') == '"DummyClass"\n'
 
 
 def test_resolve_classmethod(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/resolver-test/classmethod')  # type: flask.Response
-    assert resp.data.decode('utf-8') == '"DummyClass"\n'
+    assert resp.data.decode('utf-8', 'replace') == '"DummyClass"\n'
 
 
 def test_add_api_with_function_resolver_function_is_wrapped(simple_api_spec_dir):

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -7,7 +7,7 @@ def test_errors(problem_app):
     greeting404 = app_client.get('/v1.0/greeting')  # type: flask.Response
     assert greeting404.content_type == 'application/problem+json'
     assert greeting404.status_code == 404
-    error404 = json.loads(greeting404.data.decode('utf-8'))
+    error404 = json.loads(greeting404.data.decode('utf-8', 'replace'))
     assert error404['type'] == 'about:blank'
     assert error404['title'] == 'Not Found'
     assert error404['detail'] == 'The requested URL was not found on the server.  ' \
@@ -18,7 +18,7 @@ def test_errors(problem_app):
     get_greeting = app_client.get('/v1.0/greeting/jsantos')  # type: flask.Response
     assert get_greeting.content_type == 'application/problem+json'
     assert get_greeting.status_code == 405
-    error405 = json.loads(get_greeting.data.decode('utf-8'))
+    error405 = json.loads(get_greeting.data.decode('utf-8', 'replace'))
     assert error405['type'] == 'about:blank'
     assert error405['title'] == 'Method Not Allowed'
     assert error405['detail'] == 'The method is not allowed for the requested URL.'
@@ -28,7 +28,7 @@ def test_errors(problem_app):
     get500 = app_client.get('/v1.0/except')  # type: flask.Response
     assert get500.content_type == 'application/problem+json'
     assert get500.status_code == 500
-    error500 = json.loads(get500.data.decode('utf-8'))
+    error500 = json.loads(get500.data.decode('utf-8', 'replace'))
     assert error500['type'] == 'about:blank'
     assert error500['title'] == 'Internal Server Error'
     assert error500['detail'] == 'The server encountered an internal error and was unable to complete your request.  ' \
@@ -40,7 +40,7 @@ def test_errors(problem_app):
     assert get_problem.content_type == 'application/problem+json'
     assert get_problem.status_code == 418
     assert get_problem.headers['x-Test-Header'] == 'In Test'
-    error_problem = json.loads(get_problem.data.decode('utf-8'))
+    error_problem = json.loads(get_problem.data.decode('utf-8', 'replace'))
     assert error_problem['type'] == 'http://www.example.com/error'
     assert error_problem['title'] == 'Some Error'
     assert error_problem['detail'] == 'Something went wrong somewhere'
@@ -50,7 +50,7 @@ def test_errors(problem_app):
     get_problem2 = app_client.get('/v1.0/other_problem')  # type: flask.Response
     assert get_problem2.content_type == 'application/problem+json'
     assert get_problem2.status_code == 418
-    error_problem2 = json.loads(get_problem2.data.decode('utf-8'))
+    error_problem2 = json.loads(get_problem2.data.decode('utf-8', 'replace'))
     assert error_problem2['type'] == 'about:blank'
     assert error_problem2['title'] == 'Some Error'
     assert error_problem2['detail'] == 'Something went wrong somewhere'
@@ -63,12 +63,12 @@ def test_errors(problem_app):
 
     custom_problem = app_client.get('/v1.0/customized_problem_response')
     assert custom_problem.status_code == 403
-    problem_body = json.loads(custom_problem.data.decode('utf-8'))
+    problem_body = json.loads(custom_problem.data.decode('utf-8', 'replace'))
     assert 'amount' in problem_body
     assert problem_body['amount'] == 23.
 
     problem_as_exception = app_client.get('/v1.0/problem_exception_with_extra_args')
     assert problem_as_exception.status_code == 400
-    problem_as_exception_body = json.loads(problem_as_exception.data.decode('utf-8'))
+    problem_as_exception_body = json.loads(problem_as_exception.data.decode('utf-8', 'replace'))
     assert 'age' in problem_as_exception_body
     assert problem_as_exception_body['age'] == 30

--- a/tests/api/test_headers.py
+++ b/tests/api/test_headers.py
@@ -23,7 +23,7 @@ def test_header_not_returned(simple_app):
     response = app_client.post('/v1.0/goodday/noheader', data={})  # type: flask.Response
     assert response.status_code == 500  # view_func has not returned what was promised in spec
     assert response.content_type == 'application/problem+json'
-    data = json.loads(response.data.decode('utf-8'))
+    data = json.loads(response.data.decode('utf-8', 'replace'))
     assert data['type'] == 'about:blank'
     assert data['title'] == 'Response headers do not conform to specification'
     assert data['detail'] == "Keys in header don't match response specification. Difference: Location"

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -40,15 +40,15 @@ def test_array_query_param(simple_app):
     headers = {'Content-type': 'application/json'}
     url = '/v1.0/test_array_csv_query_param?items=one,two,three'
     response = app_client.get(url, headers=headers)
-    array_response = json.loads(response.data.decode('utf-8'))  # type: [str]
+    array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [str]
     assert array_response == ['one', 'two', 'three']
     url = '/v1.0/test_array_pipes_query_param?items=1|2|3'
     response = app_client.get(url, headers=headers)
-    array_response = json.loads(response.data.decode('utf-8'))  # type: [int]
+    array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [int]
     assert array_response == [1, 2, 3]
     url = '/v1.0/test_array_unsupported_query_param?items=1;2;3'
     response = app_client.get(url, headers=headers)
-    array_response = json.loads(response.data.decode('utf-8'))  # [str] unsupported collectionFormat
+    array_response = json.loads(response.data.decode('utf-8', 'replace'))  # [str] unsupported collectionFormat
     assert array_response == ["1;2;3"]
 
 
@@ -66,14 +66,14 @@ def test_strict_extra_query_param(strict_app):
     url = '/v1.0/test_parameter_validation?extra_parameter=true'
     resp = app_client.get(url, headers=headers)
     assert resp.status_code == 400
-    response = json.loads(resp.data.decode('utf-8'))
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response['detail'] == "Extra query parameter(s) extra_parameter not in spec"
 
 
 def test_path_parameter_someint(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-int-path/123')  # type: flask.Response
-    assert resp.data.decode('utf-8') == '"int"\n'
+    assert resp.data.decode('utf-8', 'replace') == '"int"\n'
 
     # non-integer values will not match Flask route
     resp = app_client.get('/v1.0/test-int-path/foo')  # type: flask.Response
@@ -83,7 +83,7 @@ def test_path_parameter_someint(simple_app):
 def test_path_parameter_somefloat(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-float-path/123.45')  # type: flask.Response
-    assert resp.data.decode('utf-8') == '"float"\n'
+    assert resp.data.decode('utf-8' , 'replace') == '"float"\n'
 
     # non-float values will not match Flask route
     resp = app_client.get('/v1.0/test-float-path/123,45')  # type: flask.Response
@@ -94,7 +94,7 @@ def test_default_param(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-default-query-parameter')
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode('utf-8'))
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response['app_name'] == 'connexion'
 
 
@@ -102,12 +102,12 @@ def test_falsy_param(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-falsy-param', query_string={'falsy': 0})
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode('utf-8'))
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response == 0
 
     resp = app_client.get('/v1.0/test-falsy-param')
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode('utf-8'))
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response == 1
 
 
@@ -116,7 +116,7 @@ def test_formdata_param(simple_app):
     resp = app_client.post('/v1.0/test-formData-param',
                            data={'formData': 'test'})
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode('utf-8'))
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response == 'test'
 
 
@@ -124,7 +124,7 @@ def test_formdata_bad_request(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.post('/v1.0/test-formData-param')
     assert resp.status_code == 400
-    response = json.loads(resp.data.decode('utf-8'))
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response['detail'] == "Missing formdata parameter 'formData'"
 
 
@@ -149,7 +149,7 @@ def test_strict_formdata_extra_param(strict_app):
                            data={'formData': 'test',
                                  'extra_formData': 'test'})
     assert resp.status_code == 400
-    response = json.loads(resp.data.decode('utf-8'))
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response['detail'] == "Extra formData parameter(s) extra_formData not in spec"
 
 
@@ -158,7 +158,7 @@ def test_formdata_file_upload(simple_app):
     resp = app_client.post('/v1.0/test-formData-file-upload',
                            data={'formData': (BytesIO(b'file contents'), 'filename.txt')})
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode('utf-8'))
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response == {'filename.txt': 'file contents'}
 
 
@@ -166,7 +166,7 @@ def test_formdata_file_upload_bad_request(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.post('/v1.0/test-formData-file-upload')
     assert resp.status_code == 400
-    response = json.loads(resp.data.decode('utf-8'))
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response['detail'] == "Missing formdata parameter 'formData'"
 
 
@@ -184,7 +184,7 @@ def test_bool_as_default_param(simple_app):
 
     resp = app_client.get('/v1.0/test-bool-param', query_string={'thruthiness': True})
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode('utf-8'))
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response is True
 
 
@@ -192,12 +192,12 @@ def test_bool_param(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-bool-param', query_string={'thruthiness': True})
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode('utf-8'))
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response is True
 
     resp = app_client.get('/v1.0/test-bool-param', query_string={'thruthiness': False})
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode('utf-8'))
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response is False
 
 
@@ -205,13 +205,13 @@ def test_bool_array_param(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-bool-array-param?thruthiness=true,true,true')
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode('utf-8'))
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response is True
 
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-bool-array-param?thruthiness=true,true,false')
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode('utf-8'))
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response is False
 
     app_client = simple_app.app.test_client()
@@ -236,7 +236,7 @@ def test_parameters_defined_in_path_level(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/parameters-in-root-path?title=nice-get')
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode('utf-8')) == ["nice-get"]
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == ["nice-get"]
 
     resp = app_client.get('/v1.0/parameters-in-root-path')
     assert resp.status_code == 400
@@ -245,59 +245,59 @@ def test_parameters_defined_in_path_level(simple_app):
 def test_array_in_path(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-array-in-path/one_item')
-    assert json.loads(resp.data.decode('utf-8')) == ["one_item"]
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == ["one_item"]
 
     resp = app_client.get('/v1.0/test-array-in-path/one_item,another_item')
-    assert json.loads(resp.data.decode('utf-8')) == ["one_item", "another_item"]
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == ["one_item", "another_item"]
 
 
 def test_nullable_parameter(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/nullable-parameters?time_start=null')
-    assert json.loads(resp.data.decode('utf-8')) == 'it was None'
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == 'it was None'
 
     resp = app_client.get('/v1.0/nullable-parameters?time_start=None')
-    assert json.loads(resp.data.decode('utf-8')) == 'it was None'
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == 'it was None'
 
     time_start = 1010
     resp = app_client.get(
         '/v1.0/nullable-parameters?time_start={}'.format(time_start))
-    assert json.loads(resp.data.decode('utf-8')) == time_start
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == time_start
 
     resp = app_client.post('/v1.0/nullable-parameters', data={"post_param": 'None'})
-    assert json.loads(resp.data.decode('utf-8')) == 'it was None'
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == 'it was None'
 
     resp = app_client.post('/v1.0/nullable-parameters', data={"post_param": 'null'})
-    assert json.loads(resp.data.decode('utf-8')) == 'it was None'
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == 'it was None'
 
     resp = app_client.put('/v1.0/nullable-parameters', data="null")
-    assert json.loads(resp.data.decode('utf-8')) == 'it was None'
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == 'it was None'
 
     resp = app_client.put('/v1.0/nullable-parameters', data="None")
-    assert json.loads(resp.data.decode('utf-8')) == 'it was None'
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == 'it was None'
 
 
 def test_args_kwargs(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/query-params-as-kwargs')
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode('utf-8')) == {}
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == {}
 
     resp = app_client.get('/v1.0/query-params-as-kwargs?foo=a&bar=b')
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode('utf-8')) == {'foo': 'a'}
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == {'foo': 'a'}
 
 
 def test_param_sanitization(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.post('/v1.0/param-sanitization')
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode('utf-8')) == {}
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == {}
 
     resp = app_client.post('/v1.0/param-sanitization?$query=queryString',
             data={'$form': 'formString'})
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode('utf-8')) == {
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == {
             'query': 'queryString',
             'form': 'formString',
             }
@@ -308,4 +308,4 @@ def test_param_sanitization(simple_app):
         data=json.dumps(body),
         headers={'Content-Type': 'application/json'})
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode('utf-8')) == body
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == body

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -40,15 +40,15 @@ def test_array_query_param(simple_app):
     headers = {'Content-type': 'application/json'}
     url = '/v1.0/test_array_csv_query_param?items=one,two,three'
     response = app_client.get(url, headers=headers)
-    array_response = json.loads(response.data.decode())  # type: [str]
+    array_response = json.loads(response.data.decode('utf-8'))  # type: [str]
     assert array_response == ['one', 'two', 'three']
     url = '/v1.0/test_array_pipes_query_param?items=1|2|3'
     response = app_client.get(url, headers=headers)
-    array_response = json.loads(response.data.decode())  # type: [int]
+    array_response = json.loads(response.data.decode('utf-8'))  # type: [int]
     assert array_response == [1, 2, 3]
     url = '/v1.0/test_array_unsupported_query_param?items=1;2;3'
     response = app_client.get(url, headers=headers)
-    array_response = json.loads(response.data.decode())  # [str] unsupported collectionFormat
+    array_response = json.loads(response.data.decode('utf-8'))  # [str] unsupported collectionFormat
     assert array_response == ["1;2;3"]
 
 
@@ -66,14 +66,14 @@ def test_strict_extra_query_param(strict_app):
     url = '/v1.0/test_parameter_validation?extra_parameter=true'
     resp = app_client.get(url, headers=headers)
     assert resp.status_code == 400
-    response = json.loads(resp.data.decode())
+    response = json.loads(resp.data.decode('utf-8'))
     assert response['detail'] == "Extra query parameter(s) extra_parameter not in spec"
 
 
 def test_path_parameter_someint(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-int-path/123')  # type: flask.Response
-    assert resp.data.decode() == '"int"\n'
+    assert resp.data.decode('utf-8') == '"int"\n'
 
     # non-integer values will not match Flask route
     resp = app_client.get('/v1.0/test-int-path/foo')  # type: flask.Response
@@ -83,7 +83,7 @@ def test_path_parameter_someint(simple_app):
 def test_path_parameter_somefloat(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-float-path/123.45')  # type: flask.Response
-    assert resp.data.decode() == '"float"\n'
+    assert resp.data.decode('utf-8') == '"float"\n'
 
     # non-float values will not match Flask route
     resp = app_client.get('/v1.0/test-float-path/123,45')  # type: flask.Response
@@ -94,7 +94,7 @@ def test_default_param(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-default-query-parameter')
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode())
+    response = json.loads(resp.data.decode('utf-8'))
     assert response['app_name'] == 'connexion'
 
 
@@ -102,12 +102,12 @@ def test_falsy_param(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-falsy-param', query_string={'falsy': 0})
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode())
+    response = json.loads(resp.data.decode('utf-8'))
     assert response == 0
 
     resp = app_client.get('/v1.0/test-falsy-param')
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode())
+    response = json.loads(resp.data.decode('utf-8'))
     assert response == 1
 
 
@@ -116,7 +116,7 @@ def test_formdata_param(simple_app):
     resp = app_client.post('/v1.0/test-formData-param',
                            data={'formData': 'test'})
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode())
+    response = json.loads(resp.data.decode('utf-8'))
     assert response == 'test'
 
 
@@ -124,7 +124,7 @@ def test_formdata_bad_request(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.post('/v1.0/test-formData-param')
     assert resp.status_code == 400
-    response = json.loads(resp.data.decode())
+    response = json.loads(resp.data.decode('utf-8'))
     assert response['detail'] == "Missing formdata parameter 'formData'"
 
 
@@ -149,7 +149,7 @@ def test_strict_formdata_extra_param(strict_app):
                            data={'formData': 'test',
                                  'extra_formData': 'test'})
     assert resp.status_code == 400
-    response = json.loads(resp.data.decode())
+    response = json.loads(resp.data.decode('utf-8'))
     assert response['detail'] == "Extra formData parameter(s) extra_formData not in spec"
 
 
@@ -158,7 +158,7 @@ def test_formdata_file_upload(simple_app):
     resp = app_client.post('/v1.0/test-formData-file-upload',
                            data={'formData': (BytesIO(b'file contents'), 'filename.txt')})
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode())
+    response = json.loads(resp.data.decode('utf-8'))
     assert response == {'filename.txt': 'file contents'}
 
 
@@ -166,7 +166,7 @@ def test_formdata_file_upload_bad_request(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.post('/v1.0/test-formData-file-upload')
     assert resp.status_code == 400
-    response = json.loads(resp.data.decode())
+    response = json.loads(resp.data.decode('utf-8'))
     assert response['detail'] == "Missing formdata parameter 'formData'"
 
 
@@ -184,7 +184,7 @@ def test_bool_as_default_param(simple_app):
 
     resp = app_client.get('/v1.0/test-bool-param', query_string={'thruthiness': True})
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode())
+    response = json.loads(resp.data.decode('utf-8'))
     assert response is True
 
 
@@ -192,12 +192,12 @@ def test_bool_param(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-bool-param', query_string={'thruthiness': True})
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode())
+    response = json.loads(resp.data.decode('utf-8'))
     assert response is True
 
     resp = app_client.get('/v1.0/test-bool-param', query_string={'thruthiness': False})
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode())
+    response = json.loads(resp.data.decode('utf-8'))
     assert response is False
 
 
@@ -205,13 +205,13 @@ def test_bool_array_param(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-bool-array-param?thruthiness=true,true,true')
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode())
+    response = json.loads(resp.data.decode('utf-8'))
     assert response is True
 
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-bool-array-param?thruthiness=true,true,false')
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode())
+    response = json.loads(resp.data.decode('utf-8'))
     assert response is False
 
     app_client = simple_app.app.test_client()
@@ -236,7 +236,7 @@ def test_parameters_defined_in_path_level(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/parameters-in-root-path?title=nice-get')
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode()) == ["nice-get"]
+    assert json.loads(resp.data.decode('utf-8')) == ["nice-get"]
 
     resp = app_client.get('/v1.0/parameters-in-root-path')
     assert resp.status_code == 400
@@ -245,59 +245,59 @@ def test_parameters_defined_in_path_level(simple_app):
 def test_array_in_path(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-array-in-path/one_item')
-    assert json.loads(resp.data.decode()) == ["one_item"]
+    assert json.loads(resp.data.decode('utf-8')) == ["one_item"]
 
     resp = app_client.get('/v1.0/test-array-in-path/one_item,another_item')
-    assert json.loads(resp.data.decode()) == ["one_item", "another_item"]
+    assert json.loads(resp.data.decode('utf-8')) == ["one_item", "another_item"]
 
 
 def test_nullable_parameter(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/nullable-parameters?time_start=null')
-    assert json.loads(resp.data.decode()) == 'it was None'
+    assert json.loads(resp.data.decode('utf-8')) == 'it was None'
 
     resp = app_client.get('/v1.0/nullable-parameters?time_start=None')
-    assert json.loads(resp.data.decode()) == 'it was None'
+    assert json.loads(resp.data.decode('utf-8')) == 'it was None'
 
     time_start = 1010
     resp = app_client.get(
         '/v1.0/nullable-parameters?time_start={}'.format(time_start))
-    assert json.loads(resp.data.decode()) == time_start
+    assert json.loads(resp.data.decode('utf-8')) == time_start
 
     resp = app_client.post('/v1.0/nullable-parameters', data={"post_param": 'None'})
-    assert json.loads(resp.data.decode()) == 'it was None'
+    assert json.loads(resp.data.decode('utf-8')) == 'it was None'
 
     resp = app_client.post('/v1.0/nullable-parameters', data={"post_param": 'null'})
-    assert json.loads(resp.data.decode()) == 'it was None'
+    assert json.loads(resp.data.decode('utf-8')) == 'it was None'
 
     resp = app_client.put('/v1.0/nullable-parameters', data="null")
-    assert json.loads(resp.data.decode()) == 'it was None'
+    assert json.loads(resp.data.decode('utf-8')) == 'it was None'
 
     resp = app_client.put('/v1.0/nullable-parameters', data="None")
-    assert json.loads(resp.data.decode()) == 'it was None'
+    assert json.loads(resp.data.decode('utf-8')) == 'it was None'
 
 
 def test_args_kwargs(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/query-params-as-kwargs')
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode()) == {}
+    assert json.loads(resp.data.decode('utf-8')) == {}
 
     resp = app_client.get('/v1.0/query-params-as-kwargs?foo=a&bar=b')
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode()) == {'foo': 'a'}
+    assert json.loads(resp.data.decode('utf-8')) == {'foo': 'a'}
 
 
 def test_param_sanitization(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.post('/v1.0/param-sanitization')
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode()) == {}
+    assert json.loads(resp.data.decode('utf-8')) == {}
 
     resp = app_client.post('/v1.0/param-sanitization?$query=queryString',
             data={'$form': 'formString'})
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode()) == {
+    assert json.loads(resp.data.decode('utf-8')) == {
             'query': 'queryString',
             'form': 'formString',
             }
@@ -308,4 +308,4 @@ def test_param_sanitization(simple_app):
         data=json.dumps(body),
         headers={'Content-Type': 'application/json'})
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode()) == body
+    assert json.loads(resp.data.decode('utf-8')) == body

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -1,6 +1,5 @@
 import json
 from struct import unpack
-
 from connexion.decorators.produces import JSONEncoder
 
 
@@ -193,3 +192,10 @@ def test_post_wrong_content_type(simple_app):
                            data=json.dumps({"some": "data"})
                            )
     assert resp.status_code == 415
+
+
+def test_get_unicode_response(simple_app):
+    app_client = simple_app.app.test_client()
+    resp = app_client.get('/v1.0/get_unicode_response')
+    actualJson = {u'currency': u'\xa3', u'key': u'leena'}
+    assert json.loads(resp.data.decode('utf-8','replace')) == actualJson

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -45,13 +45,13 @@ def test_jsonifier(simple_app):
     post_greeting = app_client.post('/v1.0/greeting/jsantos', data={})  # type: flask.Response
     assert post_greeting.status_code == 200
     assert post_greeting.content_type == 'application/json'
-    greeting_reponse = json.loads(post_greeting.data.decode('utf-8'))
+    greeting_reponse = json.loads(post_greeting.data.decode('utf-8', 'replace'))
     assert greeting_reponse['greeting'] == 'Hello jsantos'
 
     get_list_greeting = app_client.get('/v1.0/list/jsantos', data={})  # type: flask.Response
     assert get_list_greeting.status_code == 200
     assert get_list_greeting.content_type == 'application/json'
-    greeting_reponse = json.loads(get_list_greeting.data.decode('utf-8'))
+    greeting_reponse = json.loads(get_list_greeting.data.decode('utf-8', 'replace'))
     assert len(greeting_reponse) == 2
     assert greeting_reponse[0] == 'hello'
     assert greeting_reponse[1] == 'jsantos'
@@ -59,7 +59,7 @@ def test_jsonifier(simple_app):
     get_greetings = app_client.get('/v1.0/greetings/jsantos', data={})  # type: flask.Response
     assert get_greetings.status_code == 200
     assert get_greetings.content_type == 'application/x.connexion+json'
-    greetings_reponse = json.loads(get_greetings.data.decode('utf-8'))
+    greetings_reponse = json.loads(get_greetings.data.decode('utf-8', 'replace'))
     assert len(greetings_reponse) == 1
     assert greetings_reponse['greetings'] == 'Hello jsantos'
 
@@ -103,12 +103,12 @@ def test_default_object_body(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.post('/v1.0/test-default-object-body')
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode('utf-8'))
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response['stack'] == {'image_version': 'default_image'}
 
     resp = app_client.post('/v1.0/test-default-integer-body')
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode('utf-8'))
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response == 1
 
 
@@ -126,7 +126,7 @@ def test_custom_encoder(simple_app):
 
     resp = app_client.get('/v1.0/custom-json-response')
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode('utf-8'))
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response['theResult'] == 'cool result'
 
 

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -103,12 +103,12 @@ def test_default_object_body(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.post('/v1.0/test-default-object-body')
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode())
+    response = json.loads(resp.data.decode('utf-8'))
     assert response['stack'] == {'image_version': 'default_image'}
 
     resp = app_client.post('/v1.0/test-default-integer-body')
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode())
+    response = json.loads(resp.data.decode('utf-8'))
     assert response == 1
 
 
@@ -126,7 +126,7 @@ def test_custom_encoder(simple_app):
 
     resp = app_client.get('/v1.0/custom-json-response')
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode())
+    response = json.loads(resp.data.decode('utf-8'))
     assert response['theResult'] == 'cool result'
 
 

--- a/tests/api/test_schema.py
+++ b/tests/api/test_schema.py
@@ -8,7 +8,7 @@ def test_schema(schema_app):
     empty_request = app_client.post('/v1.0/test_schema', headers=headers, data=json.dumps({}))  # type: flask.Response
     assert empty_request.status_code == 400
     assert empty_request.content_type == 'application/problem+json'
-    empty_request_response = json.loads(empty_request.data.decode('utf-8'))  # type: dict
+    empty_request_response = json.loads(empty_request.data.decode('utf-8', 'replace'))  # type: dict
     assert empty_request_response['title'] == 'Bad Request'
     assert empty_request_response['detail'].startswith("'image_version' is a required property")
 
@@ -16,27 +16,27 @@ def test_schema(schema_app):
                                data=json.dumps({'image_version': 22}))  # type: flask.Response
     assert bad_type.status_code == 400
     assert bad_type.content_type == 'application/problem+json'
-    bad_type_response = json.loads(bad_type.data.decode('utf-8'))  # type: dict
+    bad_type_response = json.loads(bad_type.data.decode('utf-8', 'replace'))  # type: dict
     assert bad_type_response['title'] == 'Bad Request'
     assert bad_type_response['detail'].startswith("22 is not of type 'string'")
 
     good_request = app_client.post('/v1.0/test_schema', headers=headers,
                                    data=json.dumps({'image_version': 'version'}))  # type: flask.Response
     assert good_request.status_code == 200
-    good_request_response = json.loads(good_request.data.decode('utf-8'))  # type: dict
+    good_request_response = json.loads(good_request.data.decode('utf-8', 'replace'))  # type: dict
     assert good_request_response['image_version'] == 'version'
 
     good_request_extra = app_client.post('/v1.0/test_schema', headers=headers,
                                          data=json.dumps({'image_version': 'version',
                                                           'extra': 'stuff'}))  # type: flask.Response
     assert good_request_extra.status_code == 200
-    good_request_extra_response = json.loads(good_request.data.decode('utf-8'))  # type: dict
+    good_request_extra_response = json.loads(good_request.data.decode('utf-8', 'replace'))  # type: dict
     assert good_request_extra_response['image_version'] == 'version'
 
     wrong_type = app_client.post('/v1.0/test_schema', headers=headers, data=json.dumps(42))  # type: flask.Response
     assert wrong_type.status_code == 400
     assert wrong_type.content_type == 'application/problem+json'
-    wrong_type_response = json.loads(wrong_type.data.decode('utf-8'))  # type: dict
+    wrong_type_response = json.loads(wrong_type.data.decode('utf-8', 'replace'))  # type: dict
     assert wrong_type_response['title'] == 'Bad Request'
     assert wrong_type_response['detail'].startswith("42 is not of type 'object'")
 
@@ -88,7 +88,7 @@ def test_schema_in_query(schema_app):
                                    query_string={'image_version': 'version',
                                                  'not_required': 'test'})  # type: flask.Response
     assert good_request.status_code == 200
-    good_request_response = json.loads(good_request.data.decode('utf-8'))  # type: dict
+    good_request_response = json.loads(good_request.data.decode('utf-8', 'replace'))  # type: dict
     assert good_request_response['image_version'] == 'version'
 
 
@@ -99,7 +99,7 @@ def test_schema_list(schema_app):
     wrong_type = app_client.post('/v1.0/test_schema_list', headers=headers, data=json.dumps(42))  # type: flask.Response
     assert wrong_type.status_code == 400
     assert wrong_type.content_type == 'application/problem+json'
-    wrong_type_response = json.loads(wrong_type.data.decode('utf-8'))  # type: dict
+    wrong_type_response = json.loads(wrong_type.data.decode('utf-8', 'replace'))  # type: dict
     assert wrong_type_response['title'] == 'Bad Request'
     assert wrong_type_response['detail'].startswith("42 is not of type 'array'")
 
@@ -107,7 +107,7 @@ def test_schema_list(schema_app):
                                   data=json.dumps([42]))  # type: flask.Response
     assert wrong_items.status_code == 400
     assert wrong_items.content_type == 'application/problem+json'
-    wrong_items_response = json.loads(wrong_items.data.decode('utf-8'))  # type: dict
+    wrong_items_response = json.loads(wrong_items.data.decode('utf-8', 'replace'))  # type: dict
     assert wrong_items_response['title'] == 'Bad Request'
     assert wrong_items_response['detail'].startswith("42 is not of type 'string'")
 
@@ -132,7 +132,7 @@ def test_schema_map(schema_app):
     wrong_type = app_client.post('/v1.0/test_schema_map', headers=headers, data=json.dumps(42))  # type: flask.Response
     assert wrong_type.status_code == 400
     assert wrong_type.content_type == 'application/problem+json'
-    wrong_type_response = json.loads(wrong_type.data.decode('utf-8'))  # type: dict
+    wrong_type_response = json.loads(wrong_type.data.decode('utf-8', 'replace'))  # type: dict
     assert wrong_type_response['title'] == 'Bad Request'
     assert wrong_type_response['detail'].startswith("42 is not of type 'object'")
 
@@ -140,7 +140,7 @@ def test_schema_map(schema_app):
                                   data=json.dumps(invalid_object))  # type: flask.Response
     assert wrong_items.status_code == 400
     assert wrong_items.content_type == 'application/problem+json'
-    wrong_items_response = json.loads(wrong_items.data.decode('utf-8'))  # type: dict
+    wrong_items_response = json.loads(wrong_items.data.decode('utf-8', 'replace'))  # type: dict
     assert wrong_items_response['title'] == 'Bad Request'
     assert wrong_items_response['detail'].startswith("42 is not of type 'object'")
 
@@ -196,7 +196,7 @@ def test_schema_format(schema_app):
                                  data=json.dumps("xy"))  # type: flask.Response
     assert wrong_type.status_code == 400
     assert wrong_type.content_type == 'application/problem+json'
-    wrong_type_response = json.loads(wrong_type.data.decode('utf-8'))  # type: dict
+    wrong_type_response = json.loads(wrong_type.data.decode('utf-8', 'replace'))  # type: dict
     assert wrong_type_response['title'] == 'Bad Request'
     assert "'xy' is not a 'date-time'" in wrong_type_response['detail']
 
@@ -209,7 +209,7 @@ def test_schema_array(schema_app):
                                    data=json.dumps(['list', 'hello']))  # type: flask.Response
     assert array_request.status_code == 200
     assert array_request.content_type == 'application/json'
-    array_response = json.loads(array_request.data.decode('utf-8'))  # type: list
+    array_response = json.loads(array_request.data.decode('utf-8', 'replace'))  # type: list
     assert array_response == ['list', 'hello']
 
 
@@ -221,11 +221,11 @@ def test_schema_int(schema_app):
                                    data=json.dumps(42))  # type: flask.Response
     assert array_request.status_code == 200
     assert array_request.content_type == 'application/json'
-    array_response = json.loads(array_request.data.decode('utf-8'))  # type: list
+    array_response = json.loads(array_request.data.decode('utf-8', 'replace'))  # type: list
     assert array_response == 42
 
 
 def test_global_response_definitions(schema_app):
     app_client = schema_app.app.test_client()
     resp = app_client.get('/v1.0/define_global_response')
-    assert json.loads(resp.data.decode('utf-8')) == ['general', 'list']
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == ['general', 'list']

--- a/tests/api/test_schema.py
+++ b/tests/api/test_schema.py
@@ -8,7 +8,7 @@ def test_schema(schema_app):
     empty_request = app_client.post('/v1.0/test_schema', headers=headers, data=json.dumps({}))  # type: flask.Response
     assert empty_request.status_code == 400
     assert empty_request.content_type == 'application/problem+json'
-    empty_request_response = json.loads(empty_request.data.decode())  # type: dict
+    empty_request_response = json.loads(empty_request.data.decode('utf-8'))  # type: dict
     assert empty_request_response['title'] == 'Bad Request'
     assert empty_request_response['detail'].startswith("'image_version' is a required property")
 
@@ -16,27 +16,27 @@ def test_schema(schema_app):
                                data=json.dumps({'image_version': 22}))  # type: flask.Response
     assert bad_type.status_code == 400
     assert bad_type.content_type == 'application/problem+json'
-    bad_type_response = json.loads(bad_type.data.decode())  # type: dict
+    bad_type_response = json.loads(bad_type.data.decode('utf-8'))  # type: dict
     assert bad_type_response['title'] == 'Bad Request'
     assert bad_type_response['detail'].startswith("22 is not of type 'string'")
 
     good_request = app_client.post('/v1.0/test_schema', headers=headers,
                                    data=json.dumps({'image_version': 'version'}))  # type: flask.Response
     assert good_request.status_code == 200
-    good_request_response = json.loads(good_request.data.decode())  # type: dict
+    good_request_response = json.loads(good_request.data.decode('utf-8'))  # type: dict
     assert good_request_response['image_version'] == 'version'
 
     good_request_extra = app_client.post('/v1.0/test_schema', headers=headers,
                                          data=json.dumps({'image_version': 'version',
                                                           'extra': 'stuff'}))  # type: flask.Response
     assert good_request_extra.status_code == 200
-    good_request_extra_response = json.loads(good_request.data.decode())  # type: dict
+    good_request_extra_response = json.loads(good_request.data.decode('utf-8'))  # type: dict
     assert good_request_extra_response['image_version'] == 'version'
 
     wrong_type = app_client.post('/v1.0/test_schema', headers=headers, data=json.dumps(42))  # type: flask.Response
     assert wrong_type.status_code == 400
     assert wrong_type.content_type == 'application/problem+json'
-    wrong_type_response = json.loads(wrong_type.data.decode())  # type: dict
+    wrong_type_response = json.loads(wrong_type.data.decode('utf-8'))  # type: dict
     assert wrong_type_response['title'] == 'Bad Request'
     assert wrong_type_response['detail'].startswith("42 is not of type 'object'")
 
@@ -88,7 +88,7 @@ def test_schema_in_query(schema_app):
                                    query_string={'image_version': 'version',
                                                  'not_required': 'test'})  # type: flask.Response
     assert good_request.status_code == 200
-    good_request_response = json.loads(good_request.data.decode())  # type: dict
+    good_request_response = json.loads(good_request.data.decode('utf-8'))  # type: dict
     assert good_request_response['image_version'] == 'version'
 
 
@@ -99,7 +99,7 @@ def test_schema_list(schema_app):
     wrong_type = app_client.post('/v1.0/test_schema_list', headers=headers, data=json.dumps(42))  # type: flask.Response
     assert wrong_type.status_code == 400
     assert wrong_type.content_type == 'application/problem+json'
-    wrong_type_response = json.loads(wrong_type.data.decode())  # type: dict
+    wrong_type_response = json.loads(wrong_type.data.decode('utf-8'))  # type: dict
     assert wrong_type_response['title'] == 'Bad Request'
     assert wrong_type_response['detail'].startswith("42 is not of type 'array'")
 
@@ -107,7 +107,7 @@ def test_schema_list(schema_app):
                                   data=json.dumps([42]))  # type: flask.Response
     assert wrong_items.status_code == 400
     assert wrong_items.content_type == 'application/problem+json'
-    wrong_items_response = json.loads(wrong_items.data.decode())  # type: dict
+    wrong_items_response = json.loads(wrong_items.data.decode('utf-8'))  # type: dict
     assert wrong_items_response['title'] == 'Bad Request'
     assert wrong_items_response['detail'].startswith("42 is not of type 'string'")
 
@@ -132,7 +132,7 @@ def test_schema_map(schema_app):
     wrong_type = app_client.post('/v1.0/test_schema_map', headers=headers, data=json.dumps(42))  # type: flask.Response
     assert wrong_type.status_code == 400
     assert wrong_type.content_type == 'application/problem+json'
-    wrong_type_response = json.loads(wrong_type.data.decode())  # type: dict
+    wrong_type_response = json.loads(wrong_type.data.decode('utf-8'))  # type: dict
     assert wrong_type_response['title'] == 'Bad Request'
     assert wrong_type_response['detail'].startswith("42 is not of type 'object'")
 
@@ -140,7 +140,7 @@ def test_schema_map(schema_app):
                                   data=json.dumps(invalid_object))  # type: flask.Response
     assert wrong_items.status_code == 400
     assert wrong_items.content_type == 'application/problem+json'
-    wrong_items_response = json.loads(wrong_items.data.decode())  # type: dict
+    wrong_items_response = json.loads(wrong_items.data.decode('utf-8'))  # type: dict
     assert wrong_items_response['title'] == 'Bad Request'
     assert wrong_items_response['detail'].startswith("42 is not of type 'object'")
 
@@ -171,7 +171,7 @@ def test_schema_recursive(schema_app):
                                  data=json.dumps(42))  # type: flask.Response
     assert wrong_type.status_code == 400
     assert wrong_type.content_type == 'application/problem+json'
-    wrong_type_response = json.loads(wrong_type.data.decode())  # type: dict
+    wrong_type_response = json.loads(wrong_type.data.decode('utf-8'))  # type: dict
     assert wrong_type_response['title'] == 'Bad Request'
     assert wrong_type_response['detail'].startswith("42 is not of type 'object'")
 
@@ -179,7 +179,7 @@ def test_schema_recursive(schema_app):
                                   data=json.dumps(invalid_object))  # type: flask.Response
     assert wrong_items.status_code == 400
     assert wrong_items.content_type == 'application/problem+json'
-    wrong_items_response = json.loads(wrong_items.data.decode())  # type: dict
+    wrong_items_response = json.loads(wrong_items.data.decode('utf-8'))  # type: dict
     assert wrong_items_response['title'] == 'Bad Request'
     assert wrong_items_response['detail'].startswith("42 is not of type 'object'")
 
@@ -196,7 +196,7 @@ def test_schema_format(schema_app):
                                  data=json.dumps("xy"))  # type: flask.Response
     assert wrong_type.status_code == 400
     assert wrong_type.content_type == 'application/problem+json'
-    wrong_type_response = json.loads(wrong_type.data.decode())  # type: dict
+    wrong_type_response = json.loads(wrong_type.data.decode('utf-8'))  # type: dict
     assert wrong_type_response['title'] == 'Bad Request'
     assert "'xy' is not a 'date-time'" in wrong_type_response['detail']
 
@@ -209,7 +209,7 @@ def test_schema_array(schema_app):
                                    data=json.dumps(['list', 'hello']))  # type: flask.Response
     assert array_request.status_code == 200
     assert array_request.content_type == 'application/json'
-    array_response = json.loads(array_request.data.decode())  # type: list
+    array_response = json.loads(array_request.data.decode('utf-8'))  # type: list
     assert array_response == ['list', 'hello']
 
 
@@ -221,11 +221,11 @@ def test_schema_int(schema_app):
                                    data=json.dumps(42))  # type: flask.Response
     assert array_request.status_code == 200
     assert array_request.content_type == 'application/json'
-    array_response = json.loads(array_request.data.decode())  # type: list
+    array_response = json.loads(array_request.data.decode('utf-8'))  # type: list
     assert array_response == 42
 
 
 def test_global_response_definitions(schema_app):
     app_client = schema_app.app.test_client()
     resp = app_client.get('/v1.0/define_global_response')
-    assert json.loads(resp.data.decode()) == ['general', 'list']
+    assert json.loads(resp.data.decode('utf-8')) == ['general', 'list']

--- a/tests/api/test_secure_api.py
+++ b/tests/api/test_secure_api.py
@@ -42,7 +42,7 @@ def test_security(oauth_requests, secure_endpoint_app):
     get_bye_no_auth = app_client.get('/v1.0/byesecure/jsantos')  # type: flask.Response
     assert get_bye_no_auth.status_code == 401
     assert get_bye_no_auth.content_type == 'application/problem+json'
-    get_bye_no_auth_reponse = json.loads(get_bye_no_auth.data.decode())  # type: dict
+    get_bye_no_auth_reponse = json.loads(get_bye_no_auth.data.decode('utf-8'))  # type: dict
     assert get_bye_no_auth_reponse['title'] == 'Unauthorized'
     assert get_bye_no_auth_reponse['detail'] == "No authorization token provided"
 
@@ -55,7 +55,7 @@ def test_security(oauth_requests, secure_endpoint_app):
     get_bye_wrong_scope = app_client.get('/v1.0/byesecure/jsantos', headers=headers)  # type: flask.Response
     assert get_bye_wrong_scope.status_code == 403
     assert get_bye_wrong_scope.content_type == 'application/problem+json'
-    get_bye_wrong_scope_reponse = json.loads(get_bye_wrong_scope.data.decode())  # type: dict
+    get_bye_wrong_scope_reponse = json.loads(get_bye_wrong_scope.data.decode('utf-8'))  # type: dict
     assert get_bye_wrong_scope_reponse['title'] == 'Forbidden'
     assert get_bye_wrong_scope_reponse['detail'] == "Provided token doesn't have the required scope"
 
@@ -63,7 +63,7 @@ def test_security(oauth_requests, secure_endpoint_app):
     get_bye_bad_token = app_client.get('/v1.0/byesecure/jsantos', headers=headers)  # type: flask.Response
     assert get_bye_bad_token.status_code == 401
     assert get_bye_bad_token.content_type == 'application/problem+json'
-    get_bye_bad_token_reponse = json.loads(get_bye_bad_token.data.decode())  # type: dict
+    get_bye_bad_token_reponse = json.loads(get_bye_bad_token.data.decode('utf-8'))  # type: dict
     assert get_bye_bad_token_reponse['title'] == 'Unauthorized'
     assert get_bye_bad_token_reponse['detail'] == "Provided oauth token is not valid"
 

--- a/tests/api/test_secure_api.py
+++ b/tests/api/test_secure_api.py
@@ -42,7 +42,7 @@ def test_security(oauth_requests, secure_endpoint_app):
     get_bye_no_auth = app_client.get('/v1.0/byesecure/jsantos')  # type: flask.Response
     assert get_bye_no_auth.status_code == 401
     assert get_bye_no_auth.content_type == 'application/problem+json'
-    get_bye_no_auth_reponse = json.loads(get_bye_no_auth.data.decode('utf-8'))  # type: dict
+    get_bye_no_auth_reponse = json.loads(get_bye_no_auth.data.decode('utf-8', 'replace'))  # type: dict
     assert get_bye_no_auth_reponse['title'] == 'Unauthorized'
     assert get_bye_no_auth_reponse['detail'] == "No authorization token provided"
 
@@ -55,7 +55,7 @@ def test_security(oauth_requests, secure_endpoint_app):
     get_bye_wrong_scope = app_client.get('/v1.0/byesecure/jsantos', headers=headers)  # type: flask.Response
     assert get_bye_wrong_scope.status_code == 403
     assert get_bye_wrong_scope.content_type == 'application/problem+json'
-    get_bye_wrong_scope_reponse = json.loads(get_bye_wrong_scope.data.decode('utf-8'))  # type: dict
+    get_bye_wrong_scope_reponse = json.loads(get_bye_wrong_scope.data.decode('utf-8', 'replace'))  # type: dict
     assert get_bye_wrong_scope_reponse['title'] == 'Forbidden'
     assert get_bye_wrong_scope_reponse['detail'] == "Provided token doesn't have the required scope"
 
@@ -63,7 +63,7 @@ def test_security(oauth_requests, secure_endpoint_app):
     get_bye_bad_token = app_client.get('/v1.0/byesecure/jsantos', headers=headers)  # type: flask.Response
     assert get_bye_bad_token.status_code == 401
     assert get_bye_bad_token.content_type == 'application/problem+json'
-    get_bye_bad_token_reponse = json.loads(get_bye_bad_token.data.decode('utf-8'))  # type: dict
+    get_bye_bad_token_reponse = json.loads(get_bye_bad_token.data.decode('utf-8', 'replace'))  # type: dict
     assert get_bye_bad_token_reponse['title'] == 'Unauthorized'
     assert get_bye_bad_token_reponse['detail'] == "Provided oauth token is not valid"
 

--- a/tests/api/test_unordered_definition.py
+++ b/tests/api/test_unordered_definition.py
@@ -5,5 +5,5 @@ def test_app(unordered_definition_app):
     app_client = unordered_definition_app.app.test_client()
     response = app_client.get('/v1.0/unordered-params/1?first=first&second=2')  # type: flask.Response
     assert response.status_code == 400
-    response_data = json.loads(response.data.decode('utf-8'))
+    response_data = json.loads(response.data.decode('utf-8', 'replace'))
     assert response_data['detail'] == 'Wrong type, expected \'integer\' for query parameter \'first\''

--- a/tests/api/test_unordered_definition.py
+++ b/tests/api/test_unordered_definition.py
@@ -5,5 +5,5 @@ def test_app(unordered_definition_app):
     app_client = unordered_definition_app.app.test_client()
     response = app_client.get('/v1.0/unordered-params/1?first=first&second=2')  # type: flask.Response
     assert response.status_code == 400
-    response_data = json.loads(response.data.decode())
+    response_data = json.loads(response.data.decode('utf-8'))
     assert response_data['detail'] == 'Wrong type, expected \'integer\' for query parameter \'first\''

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -244,7 +244,7 @@ def test_formdata_missing_param():
 
 def test_formdata_file_upload(formData):
     filename = formData.filename
-    contents = formData.read().decode('utf-8')
+    contents = formData.read().decode('utf-8', 'replace')
     return {filename: contents}
 
 

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -382,3 +382,7 @@ def test_body_sanitization(body=None):
 
 def post_wrong_content_type():
     return "NOT OK"
+
+def get_unicode_data():
+    jsonResponse = {u'currency': u'\xa3', u'key': u'leena'}
+    return jsonResponse

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -729,6 +729,16 @@ paths:
         215:
           description: NOT-OK
 
+  /get_unicode_response:
+    get:
+      operationId: fakeapi.hello.get_unicode_data
+      produces:
+        - "application/json"
+      responses:
+        200:
+          description: Some unicode response
+          schema:
+            type: object
 
 definitions:
   new_stack:


### PR DESCRIPTION
Issue #395 
Passing keyword argument "encoding=utf-8" to flask.json.dumps to make sure responses are encoded using utf-8.
