### PR TITLE
Improve the release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -22,7 +22,7 @@ fi
 tox --skip-missing-interpreters
 
 python3 setup.py sdist bdist_wheel
-#twine upload dist/*
+twine upload dist/*
 
 # revert version
 git checkout -- */__init__.py

--- a/release.sh
+++ b/release.sh
@@ -5,21 +5,27 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
-set -xe
+set -o errexit
+set -o xtrace
 
 python3 --version
 git --version
 
 version=$1
 
-sed -i "s/__version__ = .*/__version__ = '${version}'/" */__init__.py
+if [[ "$OSTYPE" == "darwin"* ]]; then
+	sed -i "" "s/__version__ = .*/__version__ = '${version}'/" */__init__.py
+else
+	sed -i "s/__version__ = .*/__version__ = '${version}'/" */__init__.py
+fi
 
 tox --skip-missing-interpreters
 
-python3 setup.py sdist bdist_wheel upload
+python3 setup.py sdist bdist_wheel
+#twine upload dist/*
 
 # revert version
-git co -- */__init__.py
+git checkout -- */__init__.py
 
-git tag ${version}
+git tag -s ${version} -m "${version}"
 git push --tags


### PR DESCRIPTION
Changes proposed in this pull request:

 - Set script flags explicitly for better maintainability;
 - Make script portable. This is to be used in MacOS systems (`sed` command interface is slightly different);
 - Use `twine` (https://packaging.python.org/distributing/#upload-your-distributions) to securely upload new packages versions to PyPi;
 - Signs new release tags.
