### PR TITLE
Remove unnecessary dependency on strict-rfc3339

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,7 +1,6 @@
 -e git+https://github.com/Julian/jsonschema.git#egg=jsonschema
 -e git+https://github.com/pallets/flask.git#egg=flask
 -e git+https://github.com/kennethreitz/requests#egg=requests
--e git+https://github.com/danielrichman/strict-rfc3339.git#egg=strict-rfc3339
 -e git+https://github.com/Yelp/swagger_spec_validator.git#egg=swagger-spec-validator
 -e git+https://github.com/zalando/python-clickclick.git#egg=clickclick
 -e hg+https://bitbucket.org/pitrou/pathlib#egg=pathlib

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ install_requires = [
     'PyYAML>=3.11',
     'requests>=2.9.1',
     'six>=1.9',
-    'strict-rfc3339>=0.6',
     'swagger-spec-validator>=2.0.2',
 ]
 

--- a/tests/api/test_schema.py
+++ b/tests/api/test_schema.py
@@ -198,7 +198,7 @@ def test_schema_format(schema_app):
     assert wrong_type.content_type == 'application/problem+json'
     wrong_type_response = json.loads(wrong_type.data.decode('utf-8', 'replace'))  # type: dict
     assert wrong_type_response['title'] == 'Bad Request'
-    assert "'xy' is not a 'date-time'" in wrong_type_response['detail']
+    assert "'xy' is not a 'email'" in wrong_type_response['detail']
 
 
 def test_schema_array(schema_app):

--- a/tests/fixtures/different_schemas/swagger.yaml
+++ b/tests/fixtures/different_schemas/swagger.yaml
@@ -244,7 +244,7 @@ paths:
           in: body
           schema:
             type: string
-            format: date-time
+            format: email
       produces:
         - application/json
       responses:


### PR DESCRIPTION
This pull request removes the unnecessary dependency on strict-rfc3339 specified in setup.py and requirements.txt. Calls to functions of this module were removed in commit 559af21f90e833044be4acdf872ef97d42cb0181 and the actual import in 6554de8dc38a0d04ee4a73b6e4e1a43c2822ab66, both of which were made some time in 2015.

Since strict-rfc3339 is licensed under the GPLv3 and connexion under the Apache 2.0 license, this change also makes it more clear that there is no licensing issue any more.