### PR TITLE
 Security decorator should log client IP address

### DIFF
--- a/connexion/api.py
+++ b/connexion/api.py
@@ -62,7 +62,8 @@ class Api(object):
     def __init__(self, specification, base_url=None, arguments=None,
                  swagger_json=None, swagger_ui=None, swagger_path=None, swagger_url=None,
                  validate_responses=False, strict_validation=False, resolver=None,
-                 auth_all_paths=False, debug=False, resolver_error_handler=None, validator_map=None):
+                 auth_all_paths=False, debug=False, resolver_error_handler=None,
+                 validator_map=None, pythonic_params=False):
         """
         :type specification: pathlib.Path | dict
         :type base_url: str | None
@@ -81,6 +82,9 @@ class Api(object):
         :param resolver_error_handler: If given, a callable that generates an
             Operation used for handling ResolveErrors
         :type resolver_error_handler: callable | None
+        :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended
+        to any shadowed built-ins
+        :type pythonic_params: bool
         """
         self.debug = debug
         self.validator_map = validator_map
@@ -142,6 +146,9 @@ class Api(object):
         logger.debug('Strict Request Validation: %s', str(validate_responses))
         self.strict_validation = strict_validation
 
+        logger.debug('Pythonic params: %s', str(pythonic_params))
+        self.pythonic_params = pythonic_params
+
         # Create blueprint and endpoints
         self.blueprint = self.create_blueprint()
 
@@ -186,7 +193,8 @@ class Api(object):
                               validate_responses=self.validate_responses,
                               validator_map=self.validator_map,
                               strict_validation=self.strict_validation,
-                              resolver=self.resolver)
+                              resolver=self.resolver,
+                              pythonic_params=self.pythonic_params)
         self._add_operation_internal(method, path, operation)
 
     def _add_resolver_error_handler(self, method, path, err):

--- a/connexion/app.py
+++ b/connexion/app.py
@@ -100,7 +100,7 @@ class App(object):
 
     def add_api(self, specification, base_path=None, arguments=None, auth_all_paths=None, swagger_json=None,
                 swagger_ui=None, swagger_path=None, swagger_url=None, validate_responses=False,
-                strict_validation=False, resolver=Resolver(), resolver_error=None):
+                strict_validation=False, resolver=Resolver(), resolver_error=None, pythonic_params=False):
         """
         Adds an API to the application based on a swagger file or API dict
 
@@ -129,6 +129,8 @@ class App(object):
         :param resolver_error: If specified, turns ResolverError into error
             responses with the given status code.
         :type resolver_error: int | None
+        :param pythonic_params: When True CamelCase parameters are converted to snake_case
+        :type pythonic_params: bool
         :rtype: Api
         """
         # Turn the resolver_error code into a handler object
@@ -165,7 +167,8 @@ class App(object):
                   strict_validation=strict_validation,
                   auth_all_paths=auth_all_paths,
                   debug=self.debug,
-                  validator_map=self.validator_map)
+                  validator_map=self.validator_map,
+                  pythonic_params=pythonic_params)
         self.app.register_blueprint(api.blueprint)
         return api
 

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -77,6 +77,7 @@ def snake_and_shadow(name):
         return "{}_".format(snake)
     return snake
 
+
 def parameter_to_arg(parameters, consumes, function, pythonic_params=False):
     """
     Pass query and body parameters as keyword arguments to handler function.
@@ -179,7 +180,6 @@ def parameter_to_arg(parameters, consumes, function, pythonic_params=False):
             else:
                 logger.debug("File parameter (formData) '%s' in function arguments", key)
                 kwargs[key] = value
-
 
         # optionally convert parameter variable names to un-shadowed, snake_case form
         if pythonic_params:

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -3,17 +3,20 @@ import functools
 import inspect
 import logging
 import re
+
+import flask
 import inflection
+import six
+import werkzeug.exceptions as exceptions
+
+from ..utils import all_json, boolean, is_null, is_nullable
+
 try:
     import builtins
 except ImportError:
     import __builtin__ as builtins
 
-import flask
-import six
-import werkzeug.exceptions as exceptions
 
-from ..utils import all_json, boolean, is_null, is_nullable
 
 logger = logging.getLogger(__name__)
 

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -17,7 +17,6 @@ except ImportError:
     import __builtin__ as builtins
 
 
-
 logger = logging.getLogger(__name__)
 
 # https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#data-types

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -74,7 +74,7 @@ def snake_and_shadow(name):
     """
     snake = inflection.underscore(name)
     if snake in builtins.__dict__.keys():
-        return "{0}_".format(snake)
+        return "{}_".format(snake)
     return snake
 
 def parameter_to_arg(parameters, consumes, function, pythonic_params=False):

--- a/connexion/handlers.py
+++ b/connexion/handlers.py
@@ -11,7 +11,7 @@ class AuthErrorHandler(SecureOperation):
     Wraps an error with authentication.
     """
 
-    def __init__(self, exception, security, security_definitions):
+    def __init__(self, exception, security, security_definitions, trusted_ips=None):
         """
         This class uses the exception instance to produce the proper response problem in case the
         request is authenticated.
@@ -23,9 +23,13 @@ class AuthErrorHandler(SecureOperation):
         :param security_definitions: `Security Definitions Object
             <https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#security-definitions-object>`_
         :type security_definitions: dict
+        :param trusted_ips: A list of trusted IPs. If request.remote_addr is in this list (i.e. it's a proxy we control)
+        then we'll also trust the X-Forwarded-For HTTP header.
+        :type trusted_ips: list
         """
         self.exception = exception
-        SecureOperation.__init__(self, security, security_definitions)
+        trusted_ips = trusted_ips or []
+        SecureOperation.__init__(self, security, security_definitions, trusted_ips)
 
     @property
     def function(self):

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -133,7 +133,7 @@ class Operation(SecureOperation):
                  path_parameters=None, app_security=None, security_definitions=None,
                  definitions=None, parameter_definitions=None, response_definitions=None,
                  validate_responses=False, strict_validation=False, randomize_endpoint=None,
-                 validator_map=None):
+                 validator_map=None, pythonic_params=False):
         """
         This class uses the OperationID identify the module and function that will handle the operation
 
@@ -177,6 +177,9 @@ class Operation(SecureOperation):
         :type validate_responses: bool
         :param strict_validation: True enables validation on invalid request parameters
         :type strict_validation: bool
+        :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended
+        to any shadowed built-ins
+        :type pythonic_params: bool
         """
 
         self.method = method
@@ -196,6 +199,7 @@ class Operation(SecureOperation):
         self.strict_validation = strict_validation
         self.operation = operation
         self.randomize_endpoint = randomize_endpoint
+        self.pythonic_params = pythonic_params
 
         # todo support definition references
         # todo support references to application level parameters
@@ -361,7 +365,7 @@ class Operation(SecureOperation):
         """
 
         function = parameter_to_arg(
-            self.parameters, self.consumes, self.__undecorated_function)
+            self.parameters, self.consumes, self.__undecorated_function, self.pythonic_params)
         function = self._request_begin_lifecycle_decorator(function)
 
         if self.validate_responses:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ tests_require = [
     'decorator',
     'mock',
     'pytest',
-    'pytest-cov'
+    'pytest-cov',
+    'testfixtures'
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ install_requires = [
     'six>=1.9',
     'strict-rfc3339>=0.6',
     'swagger-spec-validator>=2.0.2',
+    'inflection>=0.3.1'
 ]
 
 if py_major_minor_version < (3, 4):

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -309,3 +309,24 @@ def test_param_sanitization(simple_app):
         headers={'Content-Type': 'application/json'})
     assert resp.status_code == 200
     assert json.loads(resp.data.decode('utf-8', 'replace')) == body
+
+
+def test_parameters_snake_case(snake_case_app):
+    app_client = snake_case_app.app.test_client()
+    headers = {'Content-type': 'application/json'}
+    resp = app_client.post('/v1.0/test-post-path-snake/123', headers=headers, data=json.dumps({"a": "test"}))
+    assert resp.status_code == 200
+    resp = app_client.post('/v1.0/test-post-path-shadow/123', headers=headers, data=json.dumps({"a": "test"}))
+    assert resp.status_code == 200
+    resp = app_client.post('/v1.0/test-post-query-snake?someId=123', headers=headers, data=json.dumps({"a": "test"}))
+    assert resp.status_code == 200
+    resp = app_client.post('/v1.0/test-post-query-shadow?id=123', headers=headers, data=json.dumps({"a": "test"}))
+    assert resp.status_code == 200
+    resp = app_client.get('/v1.0/test-get-path-snake/123')
+    assert resp.status_code == 200
+    resp = app_client.get('/v1.0/test-get-path-shadow/123')
+    assert resp.status_code == 200
+    resp = app_client.get('/v1.0/test-get-query-snake?someId=123')
+    assert resp.status_code == 200
+    resp = app_client.get('/v1.0/test-get-query-shadow?list=123')
+    assert resp.status_code == 200

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,11 @@ def simple_app():
 
 
 @pytest.fixture(scope="session")
+def snake_case_app():
+    return build_app_from_fixture('snake_case', validate_responses=True, pythonic_params=True)
+
+
+@pytest.fixture(scope="session")
 def invalid_resp_allowed_app():
     return build_app_from_fixture('simple', validate_responses=False)
 

--- a/tests/decorators/test_security.py
+++ b/tests/decorators/test_security.py
@@ -1,7 +1,9 @@
 import pytest
 from connexion.decorators.security import get_tokeninfo_url, verify_oauth
-from connexion.exceptions import OAuthProblem
-from mock import MagicMock
+from connexion.exceptions import (OAuthProblem, OAuthResponseProblem,
+                                  OAuthScopeProblem)
+from mock import MagicMock, PropertyMock
+from testfixtures import LogCapture
 
 
 def test_get_tokeninfo_url(monkeypatch):
@@ -25,7 +27,7 @@ def test_verify_oauth_invalid_auth_header(monkeypatch):
     def func():
         pass
 
-    wrapped_func = verify_oauth('https://example.org/tokeninfo', set(['admin']), func)
+    wrapped_func = verify_oauth('https://example.org/tokeninfo', set(['admin']), [], func)
 
     request = MagicMock()
     app = MagicMock()
@@ -34,3 +36,137 @@ def test_verify_oauth_invalid_auth_header(monkeypatch):
 
     with pytest.raises(OAuthProblem):
         wrapped_func()
+
+
+def _setup_request_mock(remote_addr, x_forwarded_for=None):
+    def get_header(header):
+        if header == "Authorization":
+            return "Bearer 12345678"
+        elif header == "X-Forwarded-For":
+            return x_forwarded_for
+    headers = MagicMock(side_effect=get_header)
+    request = MagicMock()
+    type(request).url = PropertyMock(return_value="http://localhost:9090/v1/resource/123")
+    type(request).remote_addr = PropertyMock(return_value=remote_addr)
+    return request, headers
+
+
+def _setup_token_request_mock(valid=True, status_code=200, text="OK"):
+    token_request = MagicMock()
+    type(token_request.return_value).ok = PropertyMock(return_value=valid)
+    type(token_request.return_value).status_code = PropertyMock(return_value=status_code)
+    type(token_request.return_value).text = PropertyMock(return_value=text)
+    return token_request
+
+
+def test_correct_client_ip_logged(monkeypatch):
+    def func():
+        pass
+
+    app = MagicMock()
+    monkeypatch.setattr('flask.current_app', app)
+
+    # 1) remote_addr, no x-forwarded-for, invalid token (401)
+    with LogCapture() as l:
+        wrapped_func = verify_oauth('https://example.org/tokeninfo', set(['admin']), [], func)
+        request, headers = _setup_request_mock(remote_addr="123.123.123.123")
+        monkeypatch.setattr('connexion.decorators.security.request', request)
+        monkeypatch.setattr('connexion.decorators.security.request.headers.get', headers)
+        token_request = _setup_token_request_mock(valid=False, status_code=401, text="Invalid token")
+        monkeypatch.setattr('connexion.decorators.security.session.get', token_request)
+        with pytest.raises(OAuthResponseProblem):
+            wrapped_func()
+        l.check(
+            ('connexion.api.security', 'DEBUG', 'http://localhost:9090/v1/resource/123 Oauth verification...'),
+            ('connexion.api.security', 'DEBUG', '... Getting token from https://example.org/tokeninfo'),
+            ('connexion.api.security', 'DEBUG', "... Token info (401): Invalid token for client IP '123.123.123.123'"))
+
+    # 2) remote_addr, x-forwarded-for, trusted ip, invalid token (401)
+    with LogCapture() as l:
+        wrapped_func = verify_oauth('https://example.org/tokeninfo', set(['admin']), ["192.168.1.10"], func)
+        request, headers = _setup_request_mock(remote_addr="192.168.1.10", x_forwarded_for="123.123.123.123")
+        monkeypatch.setattr('connexion.decorators.security.request', request)
+        monkeypatch.setattr('connexion.decorators.security.request.headers.get', headers)
+        token_request = _setup_token_request_mock(valid=False, status_code=401, text="Invalid token")
+        monkeypatch.setattr('connexion.decorators.security.session.get', token_request)
+        with pytest.raises(OAuthResponseProblem):
+            wrapped_func()
+        l.check(
+            ('connexion.api.security', 'DEBUG', 'http://localhost:9090/v1/resource/123 Oauth verification...'),
+            ('connexion.api.security', 'DEBUG', '... Getting token from https://example.org/tokeninfo'),
+            ('connexion.api.security', 'DEBUG', "... Token info (401): Invalid token for client IP '123.123.123.123'"))
+
+    # 3) remote_addr, x-forwarded-for, untrusted ip, invalid token (401)
+    with LogCapture() as l:
+        wrapped_func = verify_oauth('https://example.org/tokeninfo', set(['admin']), ["192.168.1.10"], func)
+        request, headers = _setup_request_mock(remote_addr="1.2.3.4", x_forwarded_for="123.123.123.123")
+        monkeypatch.setattr('connexion.decorators.security.request', request)
+        monkeypatch.setattr('connexion.decorators.security.request.headers.get', headers)
+        token_request = _setup_token_request_mock(valid=False, status_code=401, text="Invalid token")
+        monkeypatch.setattr('connexion.decorators.security.session.get', token_request)
+        with pytest.raises(OAuthResponseProblem):
+            wrapped_func()
+        l.check(
+            ('connexion.api.security', 'DEBUG', 'http://localhost:9090/v1/resource/123 Oauth verification...'),
+            ('connexion.api.security', 'DEBUG', '... Getting token from https://example.org/tokeninfo'),
+            ('connexion.api.security', 'DEBUG', "... Token info (401): Invalid token for client IP '1.2.3.4'"))
+
+    # 4) remote_addr, no x-forwarded-for, insufficient scope (403)
+    with LogCapture() as l:
+        wrapped_func = verify_oauth('https://example.org/tokeninfo', set(['admin']), [], func)
+        request, headers = _setup_request_mock(remote_addr="123.123.123.123")
+        monkeypatch.setattr('connexion.decorators.security.request', request)
+        monkeypatch.setattr('connexion.decorators.security.request.headers.get', headers)
+        token_request = _setup_token_request_mock(valid=True, status_code=200, text="OK")
+        monkeypatch.setattr('connexion.decorators.security.session.get', token_request)
+        with pytest.raises(OAuthScopeProblem):
+            wrapped_func()
+        l.check(
+            ('connexion.api.security', 'DEBUG', 'http://localhost:9090/v1/resource/123 Oauth verification...'),
+            ('connexion.api.security', 'DEBUG', '... Getting token from https://example.org/tokeninfo'),
+            ('connexion.api.security', 'DEBUG', "... Token info (200): OK for client IP '123.123.123.123'"),
+            ('connexion.api.security', 'DEBUG', "... Scopes required: admin"),
+            ('connexion.api.security', 'DEBUG', "... User scopes: None"),
+            ('connexion.api.security', 'INFO', ("... User scopes (None) do not match the scopes necessary "
+                                                "to call endpoint (admin). "
+                                                "Aborting with 403 for client IP '123.123.123.123'")))
+
+    # 5) remote_addr, x-forwarded-for, trusted ip, insufficient scope (403)
+    with LogCapture() as l:
+        wrapped_func = verify_oauth('https://example.org/tokeninfo', set(['admin']), ["192.168.1.10"], func)
+        request, headers = _setup_request_mock(remote_addr="192.168.1.10", x_forwarded_for="123.123.123.123")
+        monkeypatch.setattr('connexion.decorators.security.request', request)
+        monkeypatch.setattr('connexion.decorators.security.request.headers.get', headers)
+        token_request = _setup_token_request_mock(valid=True, status_code=200, text="OK")
+        monkeypatch.setattr('connexion.decorators.security.session.get', token_request)
+        with pytest.raises(OAuthScopeProblem):
+            wrapped_func()
+        l.check(
+            ('connexion.api.security', 'DEBUG', 'http://localhost:9090/v1/resource/123 Oauth verification...'),
+            ('connexion.api.security', 'DEBUG', '... Getting token from https://example.org/tokeninfo'),
+            ('connexion.api.security', 'DEBUG', "... Token info (200): OK for client IP '123.123.123.123'"),
+            ('connexion.api.security', 'DEBUG', "... Scopes required: admin"),
+            ('connexion.api.security', 'DEBUG', "... User scopes: None"),
+            ('connexion.api.security', 'INFO', ("... User scopes (None) do not match the scopes necessary "
+                                                "to call endpoint (admin). "
+                                                "Aborting with 403 for client IP '123.123.123.123'")))
+
+    # 6) remote_addr, x-forwarded-for, untrusted ip, insufficient scope (403)
+    with LogCapture() as l:
+        wrapped_func = verify_oauth('https://example.org/tokeninfo', set(['admin']), ["192.168.1.10"], func)
+        request, headers = _setup_request_mock(remote_addr="1.2.3.4", x_forwarded_for="123.123.123.123")
+        monkeypatch.setattr('connexion.decorators.security.request', request)
+        monkeypatch.setattr('connexion.decorators.security.request.headers.get', headers)
+        token_request = _setup_token_request_mock(valid=True, status_code=200, text="OK")
+        monkeypatch.setattr('connexion.decorators.security.session.get', token_request)
+        with pytest.raises(OAuthScopeProblem):
+            wrapped_func()
+        l.check(
+            ('connexion.api.security', 'DEBUG', 'http://localhost:9090/v1/resource/123 Oauth verification...'),
+            ('connexion.api.security', 'DEBUG', '... Getting token from https://example.org/tokeninfo'),
+            ('connexion.api.security', 'DEBUG', "... Token info (200): OK for client IP '1.2.3.4'"),
+            ('connexion.api.security', 'DEBUG', "... Scopes required: admin"),
+            ('connexion.api.security', 'DEBUG', "... User scopes: None"),
+            ('connexion.api.security', 'INFO', ("... User scopes (None) do not match the scopes necessary "
+                                                "to call endpoint (admin). "
+                                                "Aborting with 403 for client IP '1.2.3.4'")))

--- a/tests/fakeapi/snake_case.py
+++ b/tests/fakeapi/snake_case.py
@@ -24,8 +24,8 @@ def post_path_snake(some_id, some_other_id):
     return data
 
 
-def post_path_shadow(id_, reduce_):
-    data = {'id': id_, 'reduce': reduce_}
+def post_path_shadow(id_, round_):
+    data = {'id': id_, 'reduce': round_}
     return data
 
 
@@ -34,6 +34,6 @@ def post_query_snake(some_id, some_other_id):
     return data
 
 
-def post_query_shadow(id_, format_):
-    data = {'id': id_, 'format': format_}
+def post_query_shadow(id_, next_):
+    data = {'id': id_, 'next': next_}
     return data

--- a/tests/fakeapi/snake_case.py
+++ b/tests/fakeapi/snake_case.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+def get_path_snake(some_id):
+    data = {'SomeId': some_id}
+    return data
+
+
+def get_path_shadow(id_):
+    data = {'id': id_}
+    return data
+
+
+def get_query_snake(some_id):
+    data = {'someId': some_id}
+    return data
+
+
+def get_query_shadow(list_):
+    data = {'list': list_}
+    return data
+
+
+def post_path_snake(some_id, some_other_id):
+    data = {'SomeId': some_id, 'SomeOtherId': some_other_id}
+    return data
+
+
+def post_path_shadow(id_, reduce_):
+    data = {'id': id_, 'reduce': reduce_}
+    return data
+
+
+def post_query_snake(some_id, some_other_id):
+    data = {'someId': some_id, 'someOtherId': some_other_id}
+    return data
+
+
+def post_query_shadow(id_, format_):
+    data = {'id': id_, 'format': format_}
+    return data

--- a/tests/fixtures/snake_case/swagger.yaml
+++ b/tests/fixtures/snake_case/swagger.yaml
@@ -1,0 +1,166 @@
+swagger: "2.0"
+info:
+  title: "{{title}}"
+  version: "1.0"
+basePath: /v1.0
+paths:
+  /test-get-path-snake/{SomeId}:
+    get:
+      summary: Test converting to snake_case in path
+      description: Test converting to snake_case in path
+      operationId: fakeapi.snake_case.get_path_snake
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success response
+          schema:
+            type: object
+      parameters:
+        - name: SomeId
+          in: path
+          description: SomeId parameter
+          required: true
+          type: integer
+  /test-get-path-shadow/{id}:
+    get:
+      summary: Test converting to un-shadowed parameter in path
+      description: Test converting to un-shadowed parameter in path
+      operationId: fakeapi.snake_case.get_path_shadow
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success response
+          schema:
+            type: object
+      parameters:
+        - name: id
+          in: path
+          description: id parameter
+          required: true
+          type: integer
+  /test-get-query-snake:
+    get:
+      summary: Test converting to snake_case parameter in query
+      description: Test converting to snake_case parameter in query
+      operationId: fakeapi.snake_case.get_query_snake
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success response
+          schema:
+            type: object
+      parameters:
+        - name: someId
+          in: query
+          description: id parameter
+          required: true
+          type: integer
+  /test-get-query-shadow:
+    get:
+      summary: Test converting to un-shadowed parameter in query
+      description: est converting to un-shadowed parameter in query
+      operationId: fakeapi.snake_case.get_query_shadow
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success response
+          schema:
+            type: object
+      parameters:
+        - name: list
+          in: query
+          description: id parameter
+          required: true
+          type: integer
+  /test-post-path-snake/{SomeId}:
+    post:
+      summary: Test converting to snake_case in path
+      description: Test converting to snake_case in path
+      operationId: fakeapi.snake_case.post_path_snake
+      responses:
+        '200':
+          description: greeting response
+          schema:
+            type: object
+      parameters:
+        - name: SomeId
+          in: path
+          description: SomeId parameter
+          required: true
+          type: integer
+        - name: SomeOtherId
+          in: body
+          description: SomeOtherId parameter
+          required: true
+          schema:
+            type: object
+  /test-post-path-shadow/{id}:
+    post:
+      summary: Test converting to un-shadowed in path
+      description: Test converting to un-shadowed in path
+      operationId: fakeapi.snake_case.post_path_shadow
+      responses:
+        '200':
+          description: greeting response
+          schema:
+            type: object
+      parameters:
+        - name: id
+          in: path
+          description: id parameter
+          required: true
+          type: integer
+        - name: reduce
+          in: body
+          description: reduce parameter
+          required: true
+          schema:
+            type: object
+  /test-post-query-snake:
+    post:
+      summary: Test converting to snake_case in query
+      description: Test converting to snake_case in query
+      operationId: fakeapi.snake_case.post_query_snake
+      responses:
+        '200':
+          description: greeting response
+          schema:
+            type: object
+      parameters:
+        - name: someId
+          in: query
+          description: someId parameter
+          required: true
+          type: integer
+        - name: SomeOtherId
+          in: body
+          description: someOtherId parameter
+          required: true
+          schema:
+            type: object
+  /test-post-query-shadow:
+    post:
+      summary: Test converting to un-shadowed in query
+      description: Test converting to un-shadowed in query
+      operationId: fakeapi.snake_case.post_query_shadow
+      responses:
+        '200':
+          description: greeting response
+          schema:
+            type: object
+      parameters:
+        - name: id
+          in: query
+          description: id parameter
+          required: true
+          type: integer
+        - name: format
+          in: body
+          description: format parameter
+          required: true
+          schema:
+            type: object

--- a/tests/fixtures/snake_case/swagger.yaml
+++ b/tests/fixtures/snake_case/swagger.yaml
@@ -114,9 +114,9 @@ paths:
           description: id parameter
           required: true
           type: integer
-        - name: reduce
+        - name: round
           in: body
-          description: reduce parameter
+          description: round parameter
           required: true
           schema:
             type: object
@@ -158,9 +158,9 @@ paths:
           description: id parameter
           required: true
           type: integer
-        - name: format
+        - name: next
           in: body
-          description: format parameter
+          description: next parameter
           required: true
           schema:
             type: object

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -245,12 +245,15 @@ def test_operation():
                           security_definitions=SECURITY_DEFINITIONS,
                           definitions=DEFINITIONS,
                           parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=Resolver())
+                          resolver=Resolver(),
+                          trusted_ips=["192.168.1.10", "127.0.0.1"])
     assert isinstance(operation.function, types.FunctionType)
     # security decorator should be a partial with verify_oauth as the function and token url and scopes as arguments.
     # See https://docs.python.org/2/library/functools.html#partial-objects
     assert operation.security_decorator.func is verify_oauth
-    assert operation.security_decorator.args == ('https://oauth.example/token_info', set(['uid']))
+    assert operation.security_decorator.args == ('https://oauth.example/token_info',
+                                                 set(['uid']),
+                                                 ["192.168.1.10", "127.0.0.1"])
 
     assert operation.method == 'GET'
     assert operation.produces == ['application/json']
@@ -280,7 +283,7 @@ def test_operation_array():
     # security decorator should be a partial with verify_oauth as the function and token url and scopes as arguments.
     # See https://docs.python.org/2/library/functools.html#partial-objects
     assert operation.security_decorator.func is verify_oauth
-    assert operation.security_decorator.args == ('https://oauth.example/token_info', set(['uid']))
+    assert operation.security_decorator.args == ('https://oauth.example/token_info', set(['uid']), [])
 
     assert operation.method == 'GET'
     assert operation.produces == ['application/json']
@@ -310,7 +313,7 @@ def test_operation_composed_definition():
     # security decorator should be a partial with verify_oauth as the function and token url and scopes as arguments.
     # See https://docs.python.org/2/library/functools.html#partial-objects
     assert operation.security_decorator.func is verify_oauth
-    assert operation.security_decorator.args == ('https://oauth.example/token_info', set(['uid']))
+    assert operation.security_decorator.args == ('https://oauth.example/token_info', set(['uid']), [])
 
     assert operation.method == 'GET'
     assert operation.produces == ['application/json']


### PR DESCRIPTION
Fixes #410 

Changes proposed in this pull request:

 - trusted_ips list optionally passed in at application start. If passed then we'll only trust X-Forwarded-For if remote_addr is in the list of trusted IPs (i.e. known proxies under our control)
- "for client IP 'x.x.x.x" format string is added to log lines
- testfixtures added to setup.py in order to make use of LogCapture. I wouldn't normally recommend testing log lines (it does feel fragile) but in this case we need to be sure the correct IP is logged. 
