### PR TITLE
Fix returning flask Response objects in a tuple

### DIFF
--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -172,6 +172,23 @@ class FlaskApi(AbstractAPI):
 
         return flask_response
 
+    @staticmethod
+    def _update_flask_response(response, status_code=None, headers=None):
+        """
+        Takes an object that is already a flask Response, and updates it
+        with the given status code and headers.
+
+        This allows one to use the common flask paradigm
+        ```return jsonify(foo='bar'), 201```
+        or
+        ```return jsonify(foo='bar'), 201, {'new_header': 'header_value'}```
+        """
+        if headers:
+            response.headers.extend(headers)
+        status_code = status_code or response.status_code or 200
+        response.status_code = status_code
+        return response
+
     @classmethod
     def _build_flask_response(cls, mimetype=None, content_type=None,
                               headers=None, status_code=None, data=None):
@@ -210,13 +227,22 @@ class FlaskApi(AbstractAPI):
 
         elif isinstance(response, tuple) and len(response) == 3:
             data, status_code, headers = response
-            return cls._build_flask_response(mimetype, None,
-                                             headers, status_code, data)
+            if flask_utils.is_flask_response(data):
+                return cls._update_flask_response(response=data,
+                                                  status_code=status_code,
+                                                  headers=headers)
+            else:
+                return cls._build_flask_response(mimetype, None,
+                                                 headers, status_code, data)
 
         elif isinstance(response, tuple) and len(response) == 2:
             data, status_code = response
-            return cls._build_flask_response(mimetype, None, None,
-                                             status_code, data)
+            if flask_utils.is_flask_response(data):
+                return cls._update_flask_response(response=data,
+                                                  status_code=status_code)
+            else:
+                return cls._build_flask_response(mimetype, None, None,
+                                                 status_code, data)
 
         else:
             return cls._build_flask_response(mimetype=mimetype, data=response)

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -39,6 +39,16 @@ def test_produce_decorator(simple_app):
     assert get_bye.content_type == 'text/plain; charset=utf-8'
 
 
+def test_returning_flask_response_tuple(simple_app):
+    app_client = simple_app.app.test_client()
+
+    result = app_client.get('/v1.0/flask_response_tuple')  # type: flask.Response
+    assert result.status_code == 201
+    assert result.content_type == 'application/json'
+    result_data = json.loads(result.data.decode('utf-8', 'replace'))
+    assert result_data == {'foo', 'bar'}
+
+
 def test_jsonifier(simple_app):
     app_client = simple_app.app.test_client()
 

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -46,7 +46,7 @@ def test_returning_flask_response_tuple(simple_app):
     assert result.status_code == 201
     assert result.content_type == 'application/json'
     result_data = json.loads(result.data.decode('utf-8', 'replace'))
-    assert result_data == {'foo', 'bar'}
+    assert result_data == {'foo': 'bar'}
 
 
 def test_jsonifier(simple_app):

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -4,7 +4,7 @@ import json
 
 from connexion import NoContent, ProblemException, problem
 from connexion.apis import FlaskApi
-from flask import redirect, request, jsonify
+from flask import jsonify, redirect, request
 
 
 class DummyClass(object):

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -4,7 +4,7 @@ import json
 
 from connexion import NoContent, ProblemException, problem
 from connexion.apis import FlaskApi
-from flask import redirect, request
+from flask import redirect, request, jsonify
 
 
 class DummyClass(object):
@@ -62,6 +62,10 @@ def get_list(name):
 
 def get_bye(name):
     return 'Goodbye {name}'.format(name=name)
+
+
+def get_flask_response_tuple():
+    return jsonify({'foo': 'bar'}), 201
 
 
 def get_bye_secure(name, user, token_info):

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -64,6 +64,19 @@ paths:
           required: true
           type: string
 
+  /flask_response_tuple:
+    get:
+      summary: Return flask response tuple
+      description: Test returning a flask response tuple
+      operationId: fakeapi.hello.get_flask_response_tuple
+      produces:
+        - application/json
+      responses:
+        200:
+          description: json response
+          schema:
+            type: object
+
   /list/{name}:
     get:
       summary: Generate a greeting in a list


### PR DESCRIPTION
Allows these flask paradigms to work in connexion endpoints:

```python
return jsonify({'foo': 'bar'}), 200
```

```python
return jsonify({'foo': 'bar'), {'new_header': 'header_value'}
```

```python
return jsonify({'foo': 'bar'}), 201, {'new_header': 'header_value'}
```
