### PR TITLE
Ignore context args

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -184,7 +184,12 @@ def parameter_to_arg(parameters, consumes, function, pythonic_params=False):
         if pythonic_params:
             kwargs = {snake_and_shadow(k): v for k, v in kwargs.items()}
 
-        kwargs.update(request.context)
+        # add context info (e.g. from security decorator)
+        for key, value in request.context.items():
+            if not has_kwargs and key not in arguments:
+                logger.debug("Context parameter '%s' not in function arguments", key)
+            else:
+                kwargs[key] = value
         return function(**kwargs)
 
     return wrapper

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -12,7 +12,7 @@ receive the OAuth token in the ``Authorization`` header field in the
 format described in `RFC 6750 <rfc6750_>`_ section 2.1. This aspect
 represents a significant difference from the usual OAuth flow.
 
-The ``uid`` property (username) of the Token Info response will be stored in ``flask.request.user`` for convenient access.
+The ``uid`` property (username) of the Token Info response will be passed in the ``user`` argument to the handler function.
 
 You can find a `minimal OAuth example application`_ in Connexion's "examples" folder.
 

--- a/examples/oauth2/app.py
+++ b/examples/oauth2/app.py
@@ -4,12 +4,11 @@ Basic example of a resource server
 '''
 
 import connexion
-import flask
 
 
-def get_secret() -> str:
-    # the token's uid will be set in request.user
-    return 'You are: {uid}'.format(uid=flask.request.user)
+def get_secret(user) -> str:
+    return 'You are: {uid}'.format(uid=user)
+
 
 if __name__ == '__main__':
     app = connexion.FlaskApp(__name__)

--- a/tests/api/test_secure_api.py
+++ b/tests/api/test_secure_api.py
@@ -73,6 +73,11 @@ def test_security(oauth_requests, secure_endpoint_app):
     response = app_client.get('/v1.0/user-handled-security')  # type: flask.Response
     assert response.status_code == 200
 
+    headers = {"Authorization": "Bearer 100"}
+    get_bye_good_auth = app_client.get('/v1.0/byesecure-ignoring-context/hjacobs', headers=headers)  # type: flask.Response
+    assert get_bye_good_auth.status_code == 200
+    assert get_bye_good_auth.data == b'Goodbye hjacobs (Secure!)'
+
 
 def test_checking_that_client_token_has_all_necessary_scopes(
         oauth_requests, secure_endpoint_app):

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -69,6 +69,9 @@ def get_flask_response_tuple():
 def get_bye_secure(name, user, token_info):
     return 'Goodbye {name} (Secure: {user})'.format(name=name, user=user)
 
+def get_bye_secure_ignoring_context(name):
+    return 'Goodbye {name} (Secure!)'.format(name=name)
+
 
 def with_problem():
     return problem(type='http://www.example.com/error',

--- a/tests/fixtures/secure_endpoint/swagger.yaml
+++ b/tests/fixtures/secure_endpoint/swagger.yaml
@@ -44,6 +44,28 @@ paths:
           required: true
           type: string
 
+  /byesecure-ignoring-context/{name}:
+    get:
+      summary: Generate goodbye
+      description: Generates a goodbye message.
+      operationId: fakeapi.hello.get_bye_secure_ignoring_context
+      security:
+        - oauth:
+          - myscope
+      produces:
+        - text/plain
+      responses:
+        200:
+          description: goodbye response
+          schema:
+            type: string
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to say bye.
+          required: true
+          type: string
+
   /more-than-one-security-definition:
     get:
       summary: Some external call to API


### PR DESCRIPTION
Fixes #428.

Allow using handler functions without using `user` or `token_info` args (set by security decorator).