### PR TITLE
New style Connexion options

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -22,34 +22,6 @@ RESOLVER_ERROR_ENDPOINT_RANDOM_DIGITS = 6
 logger = logging.getLogger('connexion.apis')
 
 
-def canonical_base_url(base_path):
-    """
-    Make given "basePath" a canonical base URL which can be prepended to paths starting with "/".
-    """
-    return base_path.rstrip('/')
-
-
-def compatibility_layer(spec):
-    """Make specs compatible with older versions of Connexion."""
-    if not isinstance(spec, dict):
-        return spec
-
-    # Make all response codes be string
-    for path_name, methods_available in spec.get('paths', {}).items():
-        for method_name, method_def in methods_available.items():
-            if (method_name == 'parameters' or not isinstance(
-                    method_def, dict)):
-                continue
-
-            response_definitions = {}
-            for response_code, response_def in method_def.get(
-                    'responses', {}).items():
-                response_definitions[str(response_code)] = response_def
-
-            method_def['responses'] = response_definitions
-    return spec
-
-
 @six.add_metaclass(abc.ABCMeta)
 class AbstractAPI(object):
     """
@@ -317,3 +289,32 @@ class AbstractAPI(object):
         :type response: ConnexionResponse
         :type mimetype: str
         """
+
+
+def canonical_base_url(base_path):
+    """
+    Make given "basePath" a canonical base URL which can be prepended to paths starting with "/".
+    """
+    return base_path.rstrip('/')
+
+
+def compatibility_layer(spec):
+    """Make specs compatible with older versions of Connexion."""
+    if not isinstance(spec, dict):
+        return spec
+
+    # Make all response codes be string
+    for path_name, methods_available in spec.get('paths', {}).items():
+        for method_name, method_def in methods_available.items():
+            if (method_name == 'parameters' or not isinstance(
+                    method_def, dict)):
+                continue
+
+            response_definitions = {}
+            for response_code, response_def in method_def.get(
+                    'responses', {}).items():
+                response_definitions[str(response_code)] = response_def
+
+            method_def['responses'] = response_definitions
+    return spec
+

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -15,35 +15,6 @@ from connexion.utils import is_json_mimetype
 logger = logging.getLogger('connexion.apis.flask_api')
 
 
-class Jsonifier(BaseSerializer):
-    @staticmethod
-    def dumps(data):
-        """ Central point where JSON serialization happens inside
-        Connexion.
-        """
-        return "{}\n".format(flask.json.dumps(data, indent=2))
-
-    @staticmethod
-    def loads(data):
-        """ Central point where JSON serialization happens inside
-        Connexion.
-        """
-        if isinstance(data, six.binary_type):
-            data = data.decode()
-
-        try:
-            return flask.json.loads(data)
-        except Exception as error:
-            if isinstance(data, six.string_types):
-                return data
-
-    def __repr__(self):
-        """
-        :rtype: str
-        """
-        return '<Jsonifier: {}>'.format(self.mimetype)
-
-
 class FlaskApi(AbstractAPI):
     jsonifier = Jsonifier
 
@@ -275,3 +246,33 @@ class FlaskRequestContextProxy(object):
     def items(self):
         # type: () -> list
         return self.values.items()
+
+
+class Jsonifier(BaseSerializer):
+    @staticmethod
+    def dumps(data):
+        """ Central point where JSON serialization happens inside
+        Connexion.
+        """
+        return "{}\n".format(flask.json.dumps(data, indent=2))
+
+    @staticmethod
+    def loads(data):
+        """ Central point where JSON serialization happens inside
+        Connexion.
+        """
+        if isinstance(data, six.binary_type):
+            data = data.decode()
+
+        try:
+            return flask.json.loads(data)
+        except Exception as error:
+            if isinstance(data, six.string_types):
+                return data
+
+    def __repr__(self):
+        """
+        :rtype: str
+        """
+        return '<Jsonifier: {}>'.format(self.mimetype)
+

--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -12,9 +12,9 @@ logger = logging.getLogger('connexion.app')
 
 @six.add_metaclass(abc.ABCMeta)
 class AbstractApp(object):
-    def __init__(self, import_name, api_cls, host=None, port=None, specification_dir='',
-                 server=None, arguments=None, auth_all_paths=False,
-                 debug=False, validator_map=None, options=None, **old_style_options):
+    def __init__(self, import_name, api_cls, port=None, specification_dir='',
+                 host=None, server=None, arguments=None, auth_all_paths=False, debug=False,
+                 validator_map=None, options=None, **old_style_options):
         """
         :param import_name: the name of the application package
         :type import_name: str
@@ -49,7 +49,7 @@ class AbstractApp(object):
 
         self.options = ConnexionOptions(old_style_options)
         # options is added last to preserve the highest priority
-        self.options = self.options.extend(options)
+        self.options = self.options.extend(options)  # type: ConnexionOptions
 
         self.app = self.create_app()
         self.server = server
@@ -129,7 +129,7 @@ class AbstractApp(object):
         resolver = Resolver(resolver) if hasattr(resolver, '__call__') else resolver
 
         auth_all_paths = auth_all_paths if auth_all_paths is not None else self.auth_all_paths
-        # TODO test if base_url starts with an / (if not none)
+        # TODO test if base_path starts with an / (if not none)
         arguments = arguments or dict()
         arguments = dict(self.arguments, **arguments)  # copy global arguments and update with api specfic
 
@@ -145,8 +145,8 @@ class AbstractApp(object):
         # locally defined options are added last to preserve highest priority
         api_options = api_options.extend(options)
 
-        api = self.api_cls(specification=specification,
-                           base_url=base_path,
+        api = self.api_cls(specification,
+                           base_path=base_path,
                            arguments=arguments,
                            resolver=resolver,
                            resolver_error_handler=resolver_error_handler,

--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import pathlib
 from decimal import Decimal
+from types import FunctionType
 
 import flask
 import werkzeug.exceptions
@@ -10,25 +11,14 @@ from flask import json
 from ..apis.flask_api import FlaskApi
 from ..exceptions import ProblemException
 from ..problem import problem
-from ..resolver import Resolver
 from .abstract import AbstractApp
 
 logger = logging.getLogger('connexion.app')
 
 
 class FlaskApp(AbstractApp):
-    def __init__(self, import_name, port=None, specification_dir='',
-                 server=None, arguments=None, auth_all_paths=False,
-                 debug=False, swagger_json=True, swagger_ui=True, swagger_path=None,
-                 swagger_url=None, host=None, validator_map=None):
-        server = server or 'flask'
-        super(FlaskApp, self).__init__(
-            import_name, port=port, specification_dir=specification_dir,
-            server=server, arguments=arguments, auth_all_paths=auth_all_paths,
-            debug=debug, swagger_json=swagger_json, swagger_ui=swagger_ui,
-            swagger_path=swagger_path, swagger_url=swagger_url,
-            host=host, validator_map=validator_map, api_cls=FlaskApi
-        )
+    def __init__(self, import_name, **kwargs):
+        super(FlaskApp, self).__init__(import_name, FlaskApi, server='flask', **kwargs)
 
     def create_app(self):
         app = flask.Flask(self.import_name)
@@ -63,27 +53,13 @@ class FlaskApp(AbstractApp):
         response = FlaskApi.get_response(response)
         return response
 
-    def add_api(self, specification, base_path=None, arguments=None,
-                auth_all_paths=None, swagger_json=None, swagger_ui=None,
-                swagger_path=None, swagger_url=None, validate_responses=False,
-                strict_validation=False, resolver=Resolver(), resolver_error=None,
-                pythonic_params=False):
-        api = super(FlaskApp, self).add_api(
-            specification, base_path=base_path,
-            arguments=arguments, auth_all_paths=auth_all_paths, swagger_json=swagger_json,
-            swagger_ui=swagger_ui, swagger_path=swagger_path, swagger_url=swagger_url,
-            validate_responses=validate_responses, strict_validation=strict_validation,
-            resolver=resolver, resolver_error=resolver_error, pythonic_params=pythonic_params
-        )
+    def add_api(self, specification, **kwargs):
+        api = super(FlaskApp, self).add_api(specification, **kwargs)
         self.app.register_blueprint(api.blueprint)
         return api
 
     def add_error_handler(self, error_code, function):
-        """
-
-        :type error_code: int
-        :type function: types.FunctionType
-        """
+        # type: (int, FunctionType) -> None
         self.app.register_error_handler(error_code, function)
 
     def run(self, port=None, server=None, debug=None, host=None, **options):  # pragma: no cover

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -416,8 +416,8 @@ class Operation(SecureOperation):
         mimetype = self.get_mimetype()
         if all_json(self.produces):  # endpoint will return json
             logger.debug('... Produces json', extra=vars(self))
-            jsonify = self.api.jsonifier(mimetype)
-            return jsonify
+            # TODO: Refactor this.
+            return lambda f: f
 
         elif len(self.produces) == 1:
             logger.debug('... Produces %s', mimetype, extra=vars(self))
@@ -453,8 +453,9 @@ class Operation(SecureOperation):
 
     def json_loads(self, data):
         """
-        A Wrapper for calling the jsonifier.
-        :param data: The json to loads
+        A wrapper for calling the API specific JSON loader.
+
+        :param data: The JSON data in textual form.
         :type data: bytes
         """
-        return self.api.jsonifier.loads(data)
+        return self.api.json_loads(data)

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -401,7 +401,7 @@ class Operation(SecureOperation):
 
         If the operation mimetype format is json then the function return value is jsonified
 
-        From Swagger Specfication:
+        From Swagger Specification:
 
         **Produces**
 

--- a/connexion/options.py
+++ b/connexion/options.py
@@ -1,13 +1,34 @@
 import pathlib
+from typing import Optional
 
 MODULE_PATH = pathlib.Path(__file__).absolute().parent
 INTERNAL_CONSOLE_UI_PATH = MODULE_PATH / 'vendor' / 'swagger-ui'
 
 
 class ConnexionOptions(object):
-    def __init__(self, **options):
+    def __init__(self, options=None):
         self._options = {}
-        self._options.update(options)
+        if options:
+            self._options.update(options)
+
+    def extend(self, new_values=None):
+        # type: (Optional[dict]) -> ConnexionOptions
+        """
+        Return a new instance of `ConnexionOptions` using as default the currently
+        defined options.
+        """
+        if new_values is None:
+            new_values = {}
+
+        options = dict(self._options)
+        for key, value in new_values.items():
+            if value is not None:
+                options[key] = value
+
+        return ConnexionOptions(options)
+
+    def as_dict(self):
+        return self._options
 
     @property
     def openapi_spec_available(self):
@@ -42,7 +63,7 @@ class ConnexionOptions(object):
 
         Default: /ui
         """
-        return self._options('swagger_url', '/ui')
+        return self._options.get('swagger_url', '/ui')
 
     @property
     def openapi_console_ui_from_dir(self):

--- a/connexion/options.py
+++ b/connexion/options.py
@@ -9,10 +9,7 @@ class ConnexionOptions(object):
     def __init__(self, options=None):
         self._options = {}
         if options:
-            values = dict([(key, value)
-                           for key, value in options.items()
-                           if value is not None])
-            self._options.update(values)
+            self._options.update(filter_values(options))
 
     def extend(self, new_values=None):
         # type: (Optional[dict]) -> ConnexionOptions
@@ -24,10 +21,7 @@ class ConnexionOptions(object):
             new_values = {}
 
         options = dict(self._options)
-        for key, value in new_values.items():
-            if value is not None:
-                options[key] = value
-
+        options.update(filter_values(new_values))
         return ConnexionOptions(options)
 
     def as_dict(self):
@@ -78,3 +72,16 @@ class ConnexionOptions(object):
         Default: Connexion's vendored version of the OpenAPI Console UI.
         """
         return self._options.get('swagger_path', INTERNAL_CONSOLE_UI_PATH)
+
+
+def filter_values(dictionary):
+    # type: (dict) -> dict
+    """
+    Remove `None` value entries in the dictionary.
+
+    :param dictionary:
+    :return:
+    """
+    return dict([(key, value)
+                 for key, value in dictionary.items()
+                 if value is not None])

--- a/connexion/options.py
+++ b/connexion/options.py
@@ -9,7 +9,10 @@ class ConnexionOptions(object):
     def __init__(self, options=None):
         self._options = {}
         if options:
-            self._options.update(options)
+            values = dict([(key, value)
+                           for key, value in options.items()
+                           if value is not None])
+            self._options.update(values)
 
     def extend(self, new_values=None):
         # type: (Optional[dict]) -> ConnexionOptions

--- a/connexion/options.py
+++ b/connexion/options.py
@@ -1,0 +1,56 @@
+import pathlib
+
+MODULE_PATH = pathlib.Path(__file__).absolute().parent
+INTERNAL_CONSOLE_UI_PATH = MODULE_PATH / 'vendor' / 'swagger-ui'
+
+
+class ConnexionOptions(object):
+    def __init__(self, **options):
+        self._options = {}
+        self._options.update(options)
+
+    @property
+    def openapi_spec_available(self):
+        # type: () -> bool
+        """
+        Whether to make available the OpenAPI Specification under
+        `openapi_console_ui_path`/swagger.json path.
+
+        Default: True
+        """
+        # NOTE: Under OpenAPI v3 this should change to "/openapi.json"
+        return self._options.get('swagger_json', True)
+
+    @property
+    def openapi_console_ui_available(self):
+        # type: () -> bool
+        """
+        Whether to make the OpenAPI Console UI available under the path
+        defined in `openapi_console_ui_path` option. Note that if enabled,
+        this overrides the `openapi_spec_available` option since the specification
+        is required to be available via a HTTP endpoint to display the console UI.
+
+        Default: True
+        """
+        return self._options.get('swagger_ui', True)
+
+    @property
+    def openapi_console_ui_path(self):
+        # type: () -> str
+        """
+        Path to mount the OpenAPI Console UI and make it accessible via a browser.
+
+        Default: /ui
+        """
+        return self._options('swagger_url', '/ui')
+
+    @property
+    def openapi_console_ui_from_dir(self):
+        # type: () -> str
+        """
+        Custom OpenAPI Console UI directory from where Connexion will serve
+        the static files.
+
+        Default: Connexion's vendored version of the OpenAPI Console UI.
+        """
+        return self._options.get('swagger_path', INTERNAL_CONSOLE_UI_PATH)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ install_requires = [
     'requests>=2.9.1',
     'six>=1.9',
     'swagger-spec-validator>=2.0.2',
-    'inflection>=0.3.1'
+    'inflection>=0.3.1',
+    'typing>=3.6.1'
 ]
 
 flask_require = 'flask>=0.10.1'

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -3,13 +3,14 @@ import yaml
 
 import pytest
 from conftest import TEST_FOLDER, build_app_from_fixture
-from connexion import FlaskApp
+from connexion import App
 from connexion.exceptions import InvalidSpecification
 
 
 def test_app_with_relative_path(simple_api_spec_dir):
-    # Create the app with a realative path and run the test_app testcase below.
-    app = FlaskApp(__name__, 5001, '..' / simple_api_spec_dir.relative_to(TEST_FOLDER),
+    # Create the app with a relative path and run the test_app testcase below.
+    app = App(__name__, port=5001,
+              specification_dir='..' / simple_api_spec_dir.relative_to(TEST_FOLDER),
               debug=True)
     app.add_api('swagger.yaml')
 
@@ -20,14 +21,15 @@ def test_app_with_relative_path(simple_api_spec_dir):
 
 
 def test_no_swagger_ui(simple_api_spec_dir):
-    app = FlaskApp(__name__, 5001, simple_api_spec_dir, swagger_ui=False, debug=True)
+    app = App(__name__, port=5001, specification_dir=simple_api_spec_dir,
+              swagger_ui=False, debug=True)
     app.add_api('swagger.yaml')
 
     app_client = app.app.test_client()
     swagger_ui = app_client.get('/v1.0/ui/')  # type: flask.Response
     assert swagger_ui.status_code == 404
 
-    app2 = FlaskApp(__name__, 5001, simple_api_spec_dir, debug=True)
+    app2 = App(__name__, port=5001, specification_dir=simple_api_spec_dir, debug=True)
     app2.add_api('swagger.yaml', swagger_ui=False)
     app2_client = app2.app.test_client()
     swagger_ui2 = app2_client.get('/v1.0/ui/')  # type: flask.Response
@@ -36,7 +38,7 @@ def test_no_swagger_ui(simple_api_spec_dir):
 
 def test_swagger_json_app(simple_api_spec_dir):
     """ Verify the swagger.json file is returned for default setting passed to app. """
-    app = FlaskApp(__name__, 5001, simple_api_spec_dir, debug=True)
+    app = App(__name__, port=5001, specification_dir=simple_api_spec_dir, debug=True)
     app.add_api('swagger.yaml')
 
     app_client = app.app.test_client()
@@ -46,7 +48,8 @@ def test_swagger_json_app(simple_api_spec_dir):
 
 def test_no_swagger_json_app(simple_api_spec_dir):
     """ Verify the swagger.json file is not returned when set to False when creating app. """
-    app = FlaskApp(__name__, 5001, simple_api_spec_dir, swagger_json=False, debug=True)
+    app = App(__name__, port=5001, specification_dir=simple_api_spec_dir,
+              swagger_json=False, debug=True)
     app.add_api('swagger.yaml')
 
     app_client = app.app.test_client()
@@ -55,7 +58,6 @@ def test_no_swagger_json_app(simple_api_spec_dir):
 
 
 def test_dict_as_yaml_path(simple_api_spec_dir):
-
     swagger_yaml_path = simple_api_spec_dir / 'swagger.yaml'
 
     with swagger_yaml_path.open(mode='rb') as swagger_yaml:
@@ -68,7 +70,7 @@ def test_dict_as_yaml_path(simple_api_spec_dir):
         swagger_string = jinja2.Template(swagger_template).render({})
         specification = yaml.safe_load(swagger_string)  # type: dict
 
-    app = FlaskApp(__name__, 5001, simple_api_spec_dir, debug=True)
+    app = App(__name__, port=5001, specification_dir=simple_api_spec_dir, debug=True)
     app.add_api(specification)
 
     app_client = app.app.test_client()
@@ -78,7 +80,7 @@ def test_dict_as_yaml_path(simple_api_spec_dir):
 
 def test_swagger_json_api(simple_api_spec_dir):
     """ Verify the swagger.json file is returned for default setting passed to api. """
-    app = FlaskApp(__name__, 5001, simple_api_spec_dir, debug=True)
+    app = App(__name__, port=5001, specification_dir=simple_api_spec_dir, debug=True)
     app.add_api('swagger.yaml')
 
     app_client = app.app.test_client()
@@ -88,7 +90,7 @@ def test_swagger_json_api(simple_api_spec_dir):
 
 def test_no_swagger_json_api(simple_api_spec_dir):
     """ Verify the swagger.json file is not returned when set to False when adding api. """
-    app = FlaskApp(__name__, 5001, simple_api_spec_dir, debug=True)
+    app = App(__name__, port=5001, specification_dir=simple_api_spec_dir, debug=True)
     app.add_api('swagger.yaml', swagger_json=False)
 
     app_client = app.app.test_client()
@@ -143,7 +145,7 @@ def test_resolve_classmethod(simple_app):
 
 
 def test_add_api_with_function_resolver_function_is_wrapped(simple_api_spec_dir):
-    app = FlaskApp(__name__, specification_dir=simple_api_spec_dir)
+    app = App(__name__, specification_dir=simple_api_spec_dir)
     api = app.add_api('swagger.yaml', resolver=lambda oid: (lambda foo: 'bar'))
     assert api.resolver.resolve_function_from_operation_id('faux')('bah') == 'bar'
 

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -8,18 +8,21 @@ def test_app(simple_app):
     assert simple_app.port == 5001
 
     app_client = simple_app.app.test_client()
+
+    # by default the Swagger UI is enabled
     swagger_ui = app_client.get('/v1.0/ui/')  # type: flask.Response
     assert swagger_ui.status_code == 200
     assert b"Swagger UI" in swagger_ui.data
 
+    # test return Swagger UI static files
     swagger_icon = app_client.get('/v1.0/ui/images/favicon.ico')  # type: flask.Response
     assert swagger_icon.status_code == 200
 
     post_greeting = app_client.post('/v1.0/greeting/jsantos', data={})  # type: flask.Response
     assert post_greeting.status_code == 200
     assert post_greeting.content_type == 'application/json'
-    greeting_reponse = json.loads(post_greeting.data.decode('utf-8'))
-    assert greeting_reponse['greeting'] == 'Hello jsantos'
+    greeting_response = json.loads(post_greeting.data.decode('utf-8'))
+    assert greeting_response['greeting'] == 'Hello jsantos'
 
     get_bye = app_client.get('/v1.0/bye/jsantos')  # type: flask.Response
     assert get_bye.status_code == 200
@@ -28,8 +31,8 @@ def test_app(simple_app):
     post_greeting = app_client.post('/v1.0/greeting/jsantos', data={})  # type: flask.Response
     assert post_greeting.status_code == 200
     assert post_greeting.content_type == 'application/json'
-    greeting_reponse = json.loads(post_greeting.data.decode('utf-8'))
-    assert greeting_reponse['greeting'] == 'Hello jsantos'
+    greeting_response = json.loads(post_greeting.data.decode('utf-8'))
+    assert greeting_response['greeting'] == 'Hello jsantos'
 
 
 def test_produce_decorator(simple_app):

--- a/tests/api/test_secure_api.py
+++ b/tests/api/test_secure_api.py
@@ -4,8 +4,8 @@ from connexion import FlaskApp
 
 
 def test_security_over_inexistent_endpoints(oauth_requests, secure_api_spec_dir):
-    app1 = FlaskApp(__name__, 5001, secure_api_spec_dir, swagger_ui=False,
-               debug=True, auth_all_paths=True)
+    app1 = FlaskApp(__name__, port=5001, specification_dir=secure_api_spec_dir,
+                    swagger_ui=False, debug=True, auth_all_paths=True)
     app1.add_api('swagger.yaml')
     assert app1.port == 5001
 
@@ -74,7 +74,8 @@ def test_security(oauth_requests, secure_endpoint_app):
     assert response.status_code == 200
 
     headers = {"Authorization": "Bearer 100"}
-    get_bye_good_auth = app_client.get('/v1.0/byesecure-ignoring-context/hjacobs', headers=headers)  # type: flask.Response
+    get_bye_good_auth = app_client.get('/v1.0/byesecure-ignoring-context/hjacobs',
+                                       headers=headers)  # type: flask.Response
     assert get_bye_good_auth.status_code == 200
     assert get_bye_good_auth.data == b'Goodbye hjacobs (Secure!)'
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import logging
 import pathlib
 
 import pytest
-from connexion import FlaskApi, FlaskApp
+from connexion import App
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -55,9 +55,9 @@ def oauth_requests(monkeypatch):
 
 @pytest.fixture
 def app():
-    app = FlaskApp(__name__, 5001, SPEC_FOLDER, debug=True)
-    app.add_api('api.yaml', validate_responses=True)
-    return app
+    cnx_app = App(__name__, port=5001, specification_dir=SPEC_FOLDER, debug=True)
+    cnx_app.add_api('api.yaml', validate_responses=True)
+    return cnx_app
 
 
 @pytest.fixture
@@ -84,10 +84,14 @@ def build_app_from_fixture(api_spec_folder, **kwargs):
     debug = True
     if 'debug' in kwargs:
         debug = kwargs['debug']
-        del(kwargs['debug'])
-    app = FlaskApp(__name__, 5001, FIXTURES_FOLDER / api_spec_folder, debug=debug)
-    app.add_api('swagger.yaml', **kwargs)
-    return app
+        del (kwargs['debug'])
+
+    cnx_app = App(__name__,
+                  port=5001,
+                  specification_dir=FIXTURES_FOLDER / api_spec_folder,
+                  debug=debug)
+    cnx_app.add_api('swagger.yaml', **kwargs)
+    return cnx_app
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,112 +8,112 @@ from yaml import YAMLError
 
 import pytest
 from connexion import FlaskApi
-from connexion.apis.abstract import canonical_base_url
+from connexion.apis.abstract import canonical_base_path
 from connexion.exceptions import InvalidSpecification, ResolverError
 
 TEST_FOLDER = pathlib.Path(__file__).parent
 
 
-def test_canonical_base_url():
-    assert canonical_base_url('') == ''
-    assert canonical_base_url('/') == ''
-    assert canonical_base_url('/api') == '/api'
-    assert canonical_base_url('/api/') == '/api'
+def test_canonical_base_path():
+    assert canonical_base_path('') == ''
+    assert canonical_base_path('/') == ''
+    assert canonical_base_path('/api') == '/api'
+    assert canonical_base_path('/api/') == '/api'
 
 
 def test_api():
-    api = FlaskApi(TEST_FOLDER / "fixtures/simple/swagger.yaml", "/api/v1.0", {})
+    api = FlaskApi(TEST_FOLDER / "fixtures/simple/swagger.yaml", base_path="/api/v1.0")
     assert api.blueprint.name == '/api/v1_0'
     assert api.blueprint.url_prefix == '/api/v1.0'
-    # TODO test base_url in spec
 
     api2 = FlaskApi(TEST_FOLDER / "fixtures/simple/swagger.yaml")
     assert api2.blueprint.name == '/v1_0'
     assert api2.blueprint.url_prefix == '/v1.0'
 
 
-def test_api_basepath_slash():
-    api = FlaskApi(TEST_FOLDER / "fixtures/simple/basepath-slash.yaml", None, {})
+def test_api_base_path_slash():
+    api = FlaskApi(TEST_FOLDER / "fixtures/simple/basepath-slash.yaml")
     assert api.blueprint.name == ''
     assert api.blueprint.url_prefix == ''
 
 
 def test_template():
-    api1 = FlaskApi(TEST_FOLDER / "fixtures/simple/swagger.yaml", "/api/v1.0", {'title': 'test'})
+    api1 = FlaskApi(TEST_FOLDER / "fixtures/simple/swagger.yaml",
+                    base_path="/api/v1.0", arguments={'title': 'test'})
     assert api1.specification['info']['title'] == 'test'
 
-    api2 = FlaskApi(TEST_FOLDER / "fixtures/simple/swagger.yaml", "/api/v1.0", {'title': 'other test'})
+    api2 = FlaskApi(TEST_FOLDER / "fixtures/simple/swagger.yaml",
+                    base_path="/api/v1.0", arguments={'title': 'other test'})
     assert api2.specification['info']['title'] == 'other test'
 
 
 def test_invalid_operation_does_stop_application_to_setup():
     with pytest.raises(ImportError):
-        FlaskApi(TEST_FOLDER / "fixtures/op_error_api/swagger.yaml", "/api/v1.0",
-            {'title': 'OK'})
+        FlaskApi(TEST_FOLDER / "fixtures/op_error_api/swagger.yaml",
+                 base_path="/api/v1.0", arguments={'title': 'OK'})
 
     with pytest.raises(ResolverError):
-        FlaskApi(TEST_FOLDER / "fixtures/missing_op_id/swagger.yaml", "/api/v1.0",
-            {'title': 'OK'})
+        FlaskApi(TEST_FOLDER / "fixtures/missing_op_id/swagger.yaml",
+                 base_path="/api/v1.0", arguments={'title': 'OK'})
 
     with pytest.raises(ImportError):
-        FlaskApi(TEST_FOLDER / "fixtures/module_not_implemented/swagger.yaml", "/api/v1.0",
-            {'title': 'OK'})
+        FlaskApi(TEST_FOLDER / "fixtures/module_not_implemented/swagger.yaml",
+                 base_path="/api/v1.0", arguments={'title': 'OK'})
 
     with pytest.raises(ValueError):
-        FlaskApi(TEST_FOLDER / "fixtures/user_module_loading_error/swagger.yaml", "/api/v1.0",
-            {'title': 'OK'})
+        FlaskApi(TEST_FOLDER / "fixtures/user_module_loading_error/swagger.yaml",
+                 base_path="/api/v1.0", arguments={'title': 'OK'})
 
     with pytest.raises(ResolverError):
-        FlaskApi(TEST_FOLDER / "fixtures/missing_op_id/swagger.yaml", "/api/v1.0",
-            {'title': 'OK'})
+        FlaskApi(TEST_FOLDER / "fixtures/missing_op_id/swagger.yaml",
+                 base_path="/api/v1.0", arguments={'title': 'OK'})
 
 
 def test_invalid_operation_does_not_stop_application_in_debug_mode():
-    api = FlaskApi(TEST_FOLDER / "fixtures/op_error_api/swagger.yaml", "/api/v1.0",
-              {'title': 'OK'}, debug=True)
+    api = FlaskApi(TEST_FOLDER / "fixtures/op_error_api/swagger.yaml",
+                   base_path="/api/v1.0", arguments={'title': 'OK'}, debug=True)
     assert api.specification['info']['title'] == 'OK'
 
-    api = FlaskApi(TEST_FOLDER / "fixtures/missing_op_id/swagger.yaml", "/api/v1.0",
-              {'title': 'OK'}, debug=True)
+    api = FlaskApi(TEST_FOLDER / "fixtures/missing_op_id/swagger.yaml",
+                   base_path="/api/v1.0", arguments={'title': 'OK'}, debug=True)
     assert api.specification['info']['title'] == 'OK'
 
-    api = FlaskApi(TEST_FOLDER / "fixtures/module_not_implemented/swagger.yaml", "/api/v1.0",
-              {'title': 'OK'}, debug=True)
+    api = FlaskApi(TEST_FOLDER / "fixtures/module_not_implemented/swagger.yaml",
+                   base_path="/api/v1.0", arguments={'title': 'OK'}, debug=True)
     assert api.specification['info']['title'] == 'OK'
 
-    api = FlaskApi(TEST_FOLDER / "fixtures/user_module_loading_error/swagger.yaml", "/api/v1.0",
-              {'title': 'OK'}, debug=True)
+    api = FlaskApi(TEST_FOLDER / "fixtures/user_module_loading_error/swagger.yaml",
+                   base_path="/api/v1.0", arguments={'title': 'OK'}, debug=True)
     assert api.specification['info']['title'] == 'OK'
 
-    api = FlaskApi(TEST_FOLDER / "fixtures/missing_op_id/swagger.yaml", "/api/v1.0",
-              {'title': 'OK'}, debug=True)
+    api = FlaskApi(TEST_FOLDER / "fixtures/missing_op_id/swagger.yaml",
+                   base_path="/api/v1.0", arguments={'title': 'OK'}, debug=True)
     assert api.specification['info']['title'] == 'OK'
 
 
 def test_other_errors_stop_application_to_setup():
-    # The previous tests were just about operationId not being resolvable.
-    # Other errors should still result exceptions!
+    # Errors should still result exceptions!
     with pytest.raises(InvalidSpecification):
-        FlaskApi(TEST_FOLDER / "fixtures/bad_specs/swagger.yaml", "/api/v1.0",
-            {'title': 'OK'})
+        FlaskApi(TEST_FOLDER / "fixtures/bad_specs/swagger.yaml",
+                 base_path="/api/v1.0", arguments={'title': 'OK'})
 
     # Debug mode should ignore the error
-    api = FlaskApi(TEST_FOLDER / "fixtures/bad_specs/swagger.yaml", "/api/v1.0",
-              {'title': 'OK'}, debug=True)
+    api = FlaskApi(TEST_FOLDER / "fixtures/bad_specs/swagger.yaml",
+                   base_path="/api/v1.0", arguments={'title': 'OK'}, debug=True)
     assert api.specification['info']['title'] == 'OK'
 
 
 def test_invalid_schema_file_structure():
     with pytest.raises(SwaggerValidationError):
-        FlaskApi(TEST_FOLDER / "fixtures/invalid_schema/swagger.yaml", "/api/v1.0",
-            {'title': 'OK'}, debug=True)
+        FlaskApi(TEST_FOLDER / "fixtures/invalid_schema/swagger.yaml",
+                 base_path="/api/v1.0", arguments={'title': 'OK'}, debug=True)
 
 
 def test_invalid_encoding():
     with tempfile.NamedTemporaryFile(mode='wb') as f:
         f.write(u"swagger: '2.0'\ninfo:\n  title: Foo 整\n  version: v1\npaths: {}".encode('gbk'))
         f.flush()
-        FlaskApi(pathlib.Path(f.name), "/api/v1.0")
+        FlaskApi(pathlib.Path(f.name), base_path="/api/v1.0")
 
 
 def test_use_of_safe_load_for_yaml_swagger_specs():
@@ -122,7 +122,7 @@ def test_use_of_safe_load_for_yaml_swagger_specs():
             f.write('!!python/object:object {}\n'.encode())
             f.flush()
             try:
-                FlaskApi(pathlib.Path(f.name), "/api/v1.0")
+                FlaskApi(pathlib.Path(f.name), base_path="/api/v1.0")
             except SwaggerValidationError:
                 pytest.fail("Could load invalid YAML file, use yaml.safe_load!")
 
@@ -132,4 +132,4 @@ def test_validation_error_on_completely_invalid_swagger_spec():
         with tempfile.NamedTemporaryFile() as f:
             f.write('[1]\n'.encode())
             f.flush()
-            FlaskApi(pathlib.Path(f.name), "/api/v1.0")
+            FlaskApi(pathlib.Path(f.name), base_path="/api/v1.0")


### PR DESCRIPTION
First iteration in the series that I am working on to fix the issue described in #283.

In this PR I move to the new `ConnexionOptions` class the parameters related to the Swagger UI. I did also some clean up in the codebase along the way.

This work set the basis for the new style of passing options to Connexion which should be enabled fully under `2.x` series.

The new style options will look like:
```python
from connexion import FlaskApp

app = FlaskApp(__name__)
app.add_api(my_opan_api_spec, options={
    'openapi_console_ui_available': True,
    'openapi_console_ui_path': '/console'
})
app.run(port=8080)
```

This PR still does not make it possible to use Connexion that way. But sets the ground for the next iteration. To make it easier to review I am trying to break all the necessary changes in smaller PR's. Additionally, doing the changes in smaller iterations allow us to fix possible bugs on the way.

#### Why I am working on this in the current `1.x` codebase of Connexion?
Because we will minimize the code changes to release series `2.x` which will be essentially the same codebase of `1.x` but just breaking externally defined interfaces. But this is a discussion for the future.