### PR TITLE
Added python version check for Jsonifier dumps

### DIFF
--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -254,7 +254,12 @@ class Jsonifier(object):
         """ Central point where JSON serialization happens inside
         Connexion.
         """
-        return "{}\n".format(flask.json.dumps(data, indent=2))
+        if six.PY2:
+            json_content = flask.json.dumps(data, indent=2, encoding="utf-8")
+        else:
+            json_content = flask.json.dumps(data, indent=2)
+
+        return "{}\n".format(json_content)
 
     @staticmethod
     def loads(data):


### PR DESCRIPTION
Fix encoding bug in Jsonifier.dumps() for Python 2.7.

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/lib/python2.7/site-packages/connexion/decorators/decorator.py", line 66, in wrapper
    response = function(request)
  File "/usr/lib/python2.7/site-packages/connexion/decorators/validation.py", line 293, in wrapper
    return function(request)
  File "/usr/lib/python2.7/site-packages/connexion/decorators/decorator.py", line 43, in wrapper
    return self.api.get_response(response, self.mimetype, request)
  File "/usr/lib/python2.7/site-packages/connexion/apis/flask_api.py", line 149, in get_response
    flask_response = cls._get_flask_response(response, mimetype)
  File "/usr/lib/python2.7/site-packages/connexion/apis/flask_api.py", line 224, in _get_flask_response
    return cls._build_flask_response(mimetype=mimetype, data=response)
  File "/usr/lib/python2.7/site-packages/connexion/apis/flask_api.py", line 189, in _build_flask_response
    data = cls._jsonify_data(data, mimetype)
  File "/usr/lib/python2.7/site-packages/connexion/apis/flask_api.py", line 201, in _jsonify_data
    return cls.jsonifier.dumps(data)
  File "/usr/lib/python2.7/site-packages/connexion/apis/flask_api.py", line 23, in dumps
    return "{}\n".format(flask.json.dumps(data, indent=2))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 141: ordinal not in range(128)
```