### PR TITLE
Downgrade log message severity when there are multiple security definitions

### DIFF
--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -71,8 +71,8 @@ class SecureOperation(object):
         logger.debug('... Security: %s', self.security, extra=vars(self))
         if self.security:
             if len(self.security) > 1:
-                logger.warning("... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**",
-                               extra=vars(self))
+                logger.debug("... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**",
+                             extra=vars(self))
                 return security_passthrough
 
             security = self.security[0]  # type: dict


### PR DESCRIPTION
My Swagger spec has multiple security definitions (for Basic auth and JWT/Bearer auth), and whenever I start my server I see lots of output telling me that Connexion isn't going to verify the passed credentials.

This PR downgrades the message severity. There is a similar message at debug level for when the API has Basic auth, as Connexion doesn't validate that either.

```
py27-dredd runtests: commands[1] | ./test_api.sh
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:17] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
info: Configuration './dredd.yml' found, ignoring other arguments.
info: Starting backend server process with command: python ./run.py
info: Waiting 3 seconds for backend server process to start.
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
[08/May/2017 13:23:20] WARNING connexion.operation ... More than one security requirement defined. **IGNORING SECURITY REQUIREMENTS**
```



Changes proposed in this pull request:

 - Downgrade message severity
