### PR TITLE
449 path format

### DIFF
--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -18,6 +18,12 @@ def test_app(simple_app):
     swagger_icon = app_client.get('/v1.0/ui/images/favicon.ico')  # type: flask.Response
     assert swagger_icon.status_code == 200
 
+    post_greeting_url = app_client.post('/v1.0/greeting/jsantos/the/third/of/his/name', data={})  # type: flask.Response
+    assert post_greeting_url.status_code == 200
+    assert post_greeting_url.content_type == 'application/json'
+    greeting_response_url = json.loads(post_greeting_url.data.decode('utf-8'))
+    assert greeting_response_url['greeting'] == 'Hello jsantos thanks for the/third/of/his/name'
+
     post_greeting = app_client.post('/v1.0/greeting/jsantos', data={})  # type: flask.Response
     assert post_greeting.status_code == 200
     assert post_greeting.content_type == 'application/json'

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -38,6 +38,9 @@ def post_greeting(name, **kwargs):
     data = {'greeting': 'Hello {name}'.format(name=name)}
     return data
 
+def post_greeting_url(name, remainder, **kwargs):
+    data = {'greeting': 'Hello {name} thanks for {remainder}'.format(name=name,remainder=remainder)}
+    return data
 
 def post_goodday(name):
     data = {'greeting': 'Hello {name}'.format(name=name)}

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -23,7 +23,28 @@ paths:
           description: Name of the person to greet.
           required: true
           type: string
-
+  /greeting/{name}/{remainder}:
+    post:
+      summary: Generate greeting and collect the remainder of the url
+      description: Generates a greeting message and includes the rest of the url.
+      operationId: fakeapi.hello.post_greeting_url
+      responses:
+        '200':
+          description: greeting response with url
+          schema:
+            type: object
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to greet.
+          required: true
+          type: string
+        - name: remainder
+          in: path
+          description: the rest of the url
+          required: true
+          type: string
+          format: path
   /greetings/{name}:
     get:
       summary: Generate greeting

--- a/tests/test_flask_utils.py
+++ b/tests/test_flask_utils.py
@@ -8,6 +8,7 @@ def test_flaskify_path():
     assert flask_utils.flaskify_path("foo_bar/{a-b}/{c_d}") == "foo_bar/<a_b>/<c_d>"
     assert flask_utils.flaskify_path("foo/{a}/{b}", {'a': 'integer'}) == "foo/<int:a>/<b>"
     assert flask_utils.flaskify_path("foo/{a}/{b}", {'a': 'number'}) == "foo/<float:a>/<b>"
+    assert flask_utils.flaskify_path("foo/{a}/{b}", {'a': 'path'}) == "foo/<path:a>/<b>"
     assert flask_utils.flaskify_path("foo/{a}", {'a': 'path'}) == "foo/<path:a>"
 
 

--- a/tests/test_flask_utils.py
+++ b/tests/test_flask_utils.py
@@ -8,7 +8,7 @@ def test_flaskify_path():
     assert flask_utils.flaskify_path("foo_bar/{a-b}/{c_d}") == "foo_bar/<a_b>/<c_d>"
     assert flask_utils.flaskify_path("foo/{a}/{b}", {'a': 'integer'}) == "foo/<int:a>/<b>"
     assert flask_utils.flaskify_path("foo/{a}/{b}", {'a': 'number'}) == "foo/<float:a>/<b>"
-    assert flask_utils.flaskify_path("foo/{a}/{b}", {'a': 'path'}) == "foo/<path:a>/<b>"
+    assert flask_utils.flaskify_path("foo/{a}", {'a': 'path'}) == "foo/<path:a>"
 
 
 def test_flaskify_endpoint():


### PR DESCRIPTION
Addresses #449 (adds test) .

None. I wrote a test based on what I expected the behavior to be, prior to making any code changes, and the test passes.  turns out I was using a version of connexion that came with the generated swagger.io stubs, and it is older (connexion-1.0.129), and the path formatting seems to not work as of that version. I upgraded connexion, fixed a small JSON encoding issue with the stub code, and it now runs as expected. But here's a test that covers the scenario I described.

Changes proposed in this pull request:

None, just another coverage point.
 