### PR TITLE
Improve message if operationId has no model prefix

### DIFF
--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -1,6 +1,8 @@
 import functools
 import importlib
 
+from connexion.exceptions import ResolverError
+
 
 def deep_getattr(obj, attr):
     """
@@ -17,6 +19,8 @@ def get_function_from_name(function_name):
 
     :type function_name: str
     """
+    if (not function_name) or ('.' not in function_name):
+        raise ResolverError('operationIds must include a {module}. prefix')
     module_name, attr_path = function_name.rsplit('.', 1)
     module = None
     last_import_error = None

--- a/tests/fixtures/unprefixed_op_id/swagger.yaml
+++ b/tests/fixtures/unprefixed_op_id/swagger.yaml
@@ -1,0 +1,17 @@
+swagger: "2.0"
+
+info:
+  title: "{{title}}"
+  version: "1.0"
+
+basePath: /v1.0
+
+paths:
+  /welcome:
+    put:
+      operationId: putWelcome # has no module. prefix
+      responses:
+        200:
+          description: greeting response
+          schema:
+            type: object

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -57,6 +57,10 @@ def test_invalid_operation_does_stop_application_to_setup():
         FlaskApi(TEST_FOLDER / "fixtures/missing_op_id/swagger.yaml",
                  base_path="/api/v1.0", arguments={'title': 'OK'})
 
+    with pytest.raises(ResolverError):
+        FlaskApi(TEST_FOLDER / "fixtures/unprefixed_op_id/swagger.yaml",
+                 base_path="/api/v1.0", arguments={'title': 'OK'})
+
     with pytest.raises(ImportError):
         FlaskApi(TEST_FOLDER / "fixtures/module_not_implemented/swagger.yaml",
                  base_path="/api/v1.0", arguments={'title': 'OK'})
@@ -76,6 +80,10 @@ def test_invalid_operation_does_not_stop_application_in_debug_mode():
     assert api.specification['info']['title'] == 'OK'
 
     api = FlaskApi(TEST_FOLDER / "fixtures/missing_op_id/swagger.yaml",
+                   base_path="/api/v1.0", arguments={'title': 'OK'}, debug=True)
+    assert api.specification['info']['title'] == 'OK'
+
+    api = FlaskApi(TEST_FOLDER / "fixtures/unprefixed_op_id/swagger.yaml",
                    base_path="/api/v1.0", arguments={'title': 'OK'}, debug=True)
     assert api.specification['info']['title'] == 'OK'
 


### PR DESCRIPTION
Fixes # n/a

Changes proposed in this pull request:

 - Improves error message on importing an OpenAPI definition which does not include module prefixes on its operationIds

An alternative solution would be to provide a default module name as a command-line parameter.