### PR TITLE
solving fixed argument (server) for FlaskApp

### DIFF
--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -17,8 +17,8 @@ logger = logging.getLogger('connexion.app')
 
 
 class FlaskApp(AbstractApp):
-    def __init__(self, import_name, **kwargs):
-        super(FlaskApp, self).__init__(import_name, FlaskApi, server='flask', **kwargs)
+    def __init__(self, import_name, server='flask', **kwargs):
+        super(FlaskApp, self).__init__(import_name, FlaskApi, server=server, **kwargs)
 
     def create_app(self):
         app = flask.Flask(self.import_name)

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -20,6 +20,20 @@ def test_app_with_relative_path(simple_api_spec_dir):
     assert get_bye.data == b'Goodbye jsantos'
 
 
+def test_app_with_different_server_option(simple_api_spec_dir):
+    # Create the app with a relative path and run the test_app testcase below.
+    app = App(__name__, port=5001,
+              server='gevent',
+              specification_dir='..' / simple_api_spec_dir.relative_to(TEST_FOLDER),
+              debug=True)
+    app.add_api('swagger.yaml')
+
+    app_client = app.app.test_client()
+    get_bye = app_client.get('/v1.0/bye/jsantos')  # type: flask.Response
+    assert get_bye.status_code == 200
+    assert get_bye.data == b'Goodbye jsantos'
+
+
 def test_no_swagger_ui(simple_api_spec_dir):
     app = App(__name__, port=5001, specification_dir=simple_api_spec_dir,
               swagger_ui=False, debug=True)


### PR DESCRIPTION
 
Fixes # .
1.1.10 -  introduces one backward incompatible undesired change. it fixes 'server' parameter in FlaskApp initialization making not possible to set server argument with a different value.

Changes proposed in this pull request:

 - Adding 'server' as a named argument in the flask_app module.