### PR TITLE
suppress DeprecationWarning -- using request.get_json() instead of request.json

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -121,7 +121,7 @@ def parameter_to_arg(parameters, consumes, function, pythonic_params=False):
         kwargs = {}
 
         if all_json(consumes):
-            request_body = request.json
+            request_body = request.get_json()
         else:
             request_body = request.body
 

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -104,7 +104,7 @@ class RequestBodyValidator(object):
         @functools.wraps(function)
         def wrapper(request):
             if all_json(self.consumes):
-                data = request.json
+                data = request.get_json()
 
                 if data is None and len(request.body) > 0 and not self.is_null_value_valid:
                     # the body has contents that were not parsed as JSON


### PR DESCRIPTION
Fixes # .

When using  connexion, deprecation warning messages are showed, such as bellow.

```
/home/me/venv/lib/python3.5/site-packages/werkzeug/local.py:343: DeprecationWarning: json is deprecated.  Use get_json() instead.
```

This is noisy, little bit.
