### PR TITLE
Don't attempt to validate `Response Streamed`

### DIFF
--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -83,14 +83,19 @@ class ResponseValidator(BaseDecorator):
         @functools.wraps(function)
         def wrapper(request):
             response = function(request)
-            try:
-                self.validate_response(
-                    response.get_data(), response.status_code,
-                    response.headers, request.url)
+            
+            if not response.is_streamed:
+                try:
+                    self.validate_response(
+                        response.get_data(), response.status_code,
+                        response.headers, request.url)
 
-            except (NonConformingResponseBody, NonConformingResponseHeaders) as e:
-                response = problem(500, e.reason, e.message)
-                return self.operation.api.get_response(response)
+                except (
+                NonConformingResponseBody, NonConformingResponseHeaders) as e:
+                    response = problem(500, e.reason, e.message)
+                    return self.operation.api.get_response(response)
+            else:
+                pass
 
             return response
 


### PR DESCRIPTION
If the response is of `Response Streamed` then `get_data()` throws a RuntimeError. Response streams are likely to be binary data so there is little need to validate these as it's out of the scope of Swagger validation.

Fixes #401.