### PR TITLE
Convert JSON/Swagger date or dateTime value to Python datetime Object

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -8,7 +8,7 @@ import inflection
 import six
 
 from ..lifecycle import ConnexionRequest  # NOQA
-from ..utils import all_json, boolean, is_null, is_nullable
+from ..utils import all_json, boolean, is_null, is_nullable, date, date_time
 
 try:
     import builtins
@@ -24,7 +24,9 @@ TYPE_MAP = {'integer': int,
             'string': str,
             'boolean': boolean,
             'array': list,
-            'object': dict}  # map of swagger types to python types
+            'object': dict,
+            'date': date,
+            'dateTime': date_time}  # map of swagger types to python types
 
 
 def inspect_function_arguments(function):  # pragma: no cover

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -1,5 +1,6 @@
 import functools
 import importlib
+from datetime import datetime
 
 
 def deep_getattr(obj, attr):
@@ -96,6 +97,28 @@ def boolean(s):
         return False
     else:
         raise ValueError('Invalid boolean value')
+
+
+def date(d):
+    '''
+    Convert JSON/Swagger date value to Python datetime Object, raise ValueError otherwise
+
+    >>> date("2017-01-01")
+    datetime.datetime(2017, 1, 1, 0, 0)
+
+    '''
+    return datetime.strptime(d, "%Y-%m-%d")
+
+
+def date_time(d):
+    '''
+    Convert JSON/Swagger dateTime value to Python datetime Object, raise ValueError otherwise
+    
+    >>> date_time("2017-01-01T10:20:30")
+    datetime.datetime(2017, 1, 1, 10, 20, 30)
+
+    '''
+    return datetime.strptime(d, "%Y-%m-%dT%H:%M:%S")
 
 
 def is_nullable(param_def):


### PR DESCRIPTION

Fixes #451(at least trying)

Changes proposed in this pull request:

 - Convert JSON/Swagger date value to Python datetime Object
 - Convert JSON/Swagger dateTime value to Python datetime Object
 -
