### PR TITLE
Split tokeninfo scope if it is a string

### DIFF
--- a/connexion/decorators/security.py
+++ b/connexion/decorators/security.py
@@ -71,7 +71,10 @@ def verify_oauth(token_info_url, allowed_scopes, function):
                     token_response=token_request
                 )
             token_info = token_request.json()  # type: dict
-            user_scopes = set(token_info['scope'])
+            if isinstance(token_info['scope'], list):
+                user_scopes = set(token_info['scope'])
+            else:
+                user_scopes = set(token_info['scope'].split())
             logger.debug("... Scopes required: %s", allowed_scopes)
             logger.debug("... User scopes: %s", user_scopes)
             if not allowed_scopes <= user_scopes:

--- a/tests/decorators/test_security.py
+++ b/tests/decorators/test_security.py
@@ -1,10 +1,11 @@
 import json
 
+import requests
+
 import pytest
 from connexion.decorators.security import get_tokeninfo_url, verify_oauth
 from connexion.exceptions import OAuthProblem, OAuthScopeProblem
 from mock import MagicMock
-import requests
 
 
 def test_get_tokeninfo_url(monkeypatch):

--- a/tests/decorators/test_security.py
+++ b/tests/decorators/test_security.py
@@ -1,7 +1,10 @@
+import json
+
 import pytest
 from connexion.decorators.security import get_tokeninfo_url, verify_oauth
-from connexion.exceptions import OAuthProblem
+from connexion.exceptions import OAuthProblem, OAuthScopeProblem
 from mock import MagicMock
+import requests
 
 
 def test_get_tokeninfo_url(monkeypatch):
@@ -31,5 +34,43 @@ def test_verify_oauth_invalid_auth_header(monkeypatch):
     app = MagicMock()
     monkeypatch.setattr('flask.current_app', app)
 
-    with pytest.raises(OAuthProblem) as exc_info:
-        wrapped_func(MagicMock())
+    with pytest.raises(OAuthProblem):
+        wrapped_func(request)
+
+
+def test_verify_oauth_scopes(monkeypatch):
+    tokeninfo = dict(uid="foo", scope="scope1 scope2")
+
+    def get_tokeninfo_response(*args, **kwargs):
+        tokeninfo_response = requests.Response()
+        tokeninfo_response.status_code = requests.codes.ok
+        tokeninfo_response._content = json.dumps(tokeninfo).encode()
+        return tokeninfo_response
+
+    def func(request):
+        pass
+
+    wrapped_func = verify_oauth('https://example.org/tokeninfo', set(['admin']), func)
+
+    request = MagicMock()
+    request.headers = {}
+    request.headers["Authorization"] = "Bearer 123"
+    app = MagicMock()
+    monkeypatch.setattr('flask.current_app', app)
+
+    session = MagicMock()
+    session.get = get_tokeninfo_response
+    monkeypatch.setattr('connexion.decorators.security.session', session)
+
+    with pytest.raises(OAuthScopeProblem, message="Provided token doesn't have the required scope"):
+        wrapped_func(request)
+
+    tokeninfo["scope"] += " admin"
+    wrapped_func(request)
+
+    tokeninfo["scope"] = ["foo", "bar"]
+    with pytest.raises(OAuthScopeProblem, message="Provided token doesn't have the required scope"):
+        wrapped_func(request)
+
+    tokeninfo["scope"].append("admin")
+    wrapped_func(request)


### PR DESCRIPTION
Fixes #475. 

I couldn't find a relevant test.