### PR TITLE
Fix bug on mocking APIs partially

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
-  - "3.6-dev"
+  - "3.6"
 install:
   - pip install tox tox-travis coveralls
 script:

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -246,10 +246,7 @@ class AbstractAPI(object):
                     if self.resolver_error_handler is not None:
                         self._add_resolver_error_handler(method, path, err)
                     else:
-                        exc_info = err.exc_info
-                        if exc_info is None:
-                            exc_info = sys.exc_info()
-                        self._handle_add_operation_error(path, method, exc_info)
+                        self._handle_add_operation_error(path, method, err.exc_info)
                 except Exception:
                     # All other relevant exceptions should be handled as well.
                     self._handle_add_operation_error(path, method, sys.exc_info())

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -12,7 +12,7 @@ from ..utils import all_json, boolean, is_null, is_nullable
 
 try:
     import builtins
-except ImportError:
+except ImportError:  # pragma: no cover
     import __builtin__ as builtins
 
 

--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -1,4 +1,8 @@
+import logging
+
 from connexion.resolver import Resolution, Resolver, ResolverError
+
+logger = logging.getLogger(__name__)
 
 
 def partial(func, **frozen):
@@ -15,6 +19,7 @@ def partial(func, **frozen):
 class MockResolver(Resolver):
 
     def __init__(self, mock_all):
+        super(MockResolver, self).__init__()
         self.mock_all = mock_all
         self._operation_id_counter = 1
 
@@ -36,7 +41,10 @@ class MockResolver(Resolver):
         else:
             try:
                 func = self.resolve_function_from_operation_id(operation_id)
-            except ResolverError:
+                logger.debug('... Resolved operationId "{}"! Mock is *not* used for this operation.'.format(
+                    operation_id))
+            except ResolverError as resolution_error:
+                logger.debug('... {} Mock function used for this operation.'.format(resolution_error.reason))
                 func = mock_func
         return Resolution(func, operation_id)
 

--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -41,8 +41,9 @@ class MockResolver(Resolver):
         else:
             try:
                 func = self.resolve_function_from_operation_id(operation_id)
-                logger.debug('... Resolved operationId "{}"! Mock is *not* used for this operation.'.format(
-                    operation_id))
+                msg = '... Successfully resolved operationId "{}"! Mock is *not* used for this operation.'.format(
+                    operation_id)
+                logger.debug(msg)
             except ResolverError as resolution_error:
                 logger.debug('... {} Mock function used for this operation.'.format(resolution_error.reason))
                 func = mock_func

--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -41,11 +41,12 @@ class MockResolver(Resolver):
         else:
             try:
                 func = self.resolve_function_from_operation_id(operation_id)
-                msg = '... Successfully resolved operationId "{}"! Mock is *not* used for this operation.'.format(
+                msg = "... Successfully resolved operationId '{}'! Mock is *not* used for this operation.".format(
                     operation_id)
                 logger.debug(msg)
             except ResolverError as resolution_error:
-                logger.debug('... {} Mock function used for this operation.'.format(resolution_error.reason))
+                logger.debug('... {}! Mock function is used for this operation.'.format(
+                    resolution_error.reason.capitalize()))
                 func = mock_func
         return Resolution(func, operation_id)
 

--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -1,6 +1,6 @@
 import logging
-import sys
 import re
+import sys
 
 import connexion.utils as utils
 from connexion.exceptions import ResolverError

--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import re
 
 import connexion.utils as utils
@@ -45,7 +46,7 @@ class Resolver(object):
         :type operation: connexion.operation.Operation
         """
         spec = operation.operation
-        operation_id = spec.get('operationId')
+        operation_id = spec.get('operationId', '')
         x_router_controller = spec.get('x-swagger-router-controller')
         if x_router_controller is None:
             return operation_id
@@ -57,15 +58,13 @@ class Resolver(object):
 
         :type operation_id: str
         """
-        msg = 'Cannot resolve operationId "{}"!'.format(operation_id)
         try:
             return self.function_resolver(operation_id)
         except ImportError as e:
-            msg = "{} Import error was '{}'".format(msg, str(e))
-            import sys
+            msg = 'Cannot resolve operationId "{}"! Import error was "{}"'.format(operation_id, str(e))
             raise ResolverError(msg, sys.exc_info())
-        except AttributeError:
-            raise ResolverError(msg)
+        except (AttributeError, ValueError) as e:
+            raise ResolverError(str(e), sys.exc_info())
 
 
 class RestyResolver(Resolver):

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -17,12 +17,19 @@ def get_function_from_name(function_name):
 
     :type function_name: str
     """
-    module_name, attr_path = function_name.rsplit('.', 1)
+    if function_name is None:
+        raise ValueError("Empty function name")
+
+    if '.' in function_name:
+        module_name, attr_path = function_name.rsplit('.', 1)
+    else:
+        module_name = ''
+        attr_path = function_name
+
     module = None
     last_import_error = None
 
     while not module:
-
         try:
             module = importlib.import_module(module_name)
         except ImportError as import_error:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -53,7 +53,7 @@ def test_invalid_operation_does_stop_application_to_setup():
         FlaskApi(TEST_FOLDER / "fixtures/op_error_api/swagger.yaml",
                  base_path="/api/v1.0", arguments={'title': 'OK'})
 
-    with pytest.raises(ResolverError):
+    with pytest.raises(ValueError):
         FlaskApi(TEST_FOLDER / "fixtures/missing_op_id/swagger.yaml",
                  base_path="/api/v1.0", arguments={'title': 'OK'})
 
@@ -63,10 +63,6 @@ def test_invalid_operation_does_stop_application_to_setup():
 
     with pytest.raises(ValueError):
         FlaskApi(TEST_FOLDER / "fixtures/user_module_loading_error/swagger.yaml",
-                 base_path="/api/v1.0", arguments={'title': 'OK'})
-
-    with pytest.raises(ResolverError):
-        FlaskApi(TEST_FOLDER / "fixtures/missing_op_id/swagger.yaml",
                  base_path="/api/v1.0", arguments={'title': 'OK'})
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -197,7 +197,7 @@ def test_run_unimplemented_operations_and_stub(mock_app_run):
     runner = CliRunner()
 
     spec_file = str(FIXTURES_FOLDER / 'missing_implementation/swagger.yaml')
-    with pytest.raises(ResolverError):
+    with pytest.raises(AttributeError):
         runner.invoke(main, ['run', spec_file], catch_exceptions=False)
     # yet can be run with --stub option
     result = runner.invoke(main, ['run', spec_file, '--stub'], catch_exceptions=False)
@@ -215,7 +215,7 @@ def test_run_unimplemented_operations_and_mock(mock_app_run):
     runner = CliRunner()
 
     spec_file = str(FIXTURES_FOLDER / 'missing_implementation/swagger.yaml')
-    with pytest.raises(ResolverError):
+    with pytest.raises(AttributeError):
         runner.invoke(main, ['run', spec_file], catch_exceptions=False)
     # yet can be run with --mock option
     result = runner.invoke(main, ['run', spec_file, '--mock=all'], catch_exceptions=False)

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -1,4 +1,3 @@
-
 from connexion.mock import MockResolver, partial
 from connexion.operation import Operation
 
@@ -76,6 +75,11 @@ def test_mock_resolver_no_examples():
 def test_mock_resolver_notimplemented():
     resolver = MockResolver(mock_all=False)
 
+    responses = {
+        '418': {}
+    }
+
+    # do not mock the existent functions
     operation = Operation(api=None,
                           method='GET',
                           path='endpoint',
@@ -91,3 +95,23 @@ def test_mock_resolver_notimplemented():
                           parameter_definitions={},
                           resolver=resolver)
     assert operation.operation_id == 'fakeapi.hello.get'
+
+    # mock only the nonexistent ones
+    operation = Operation(api=None,
+                          method='GET',
+                          path='endpoint',
+                          path_parameters=[],
+                          operation={
+                              'operationId': 'fakeapi.hello.nonexistent_function',
+                              'responses': responses
+                          },
+                          app_produces=['application/json'],
+                          app_consumes=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions={},
+                          resolver=resolver)
+
+    # check if it is using the mock function
+    assert operation._Operation__undecorated_function() == ('No example response was defined.', 418)

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
     {py27}-{min,pypi,dev}
     {py34}-{min,pypi,dev}
     {py35}-{min,pypi,dev}
+    {py36}-{min,pypi,dev}
     isort-check
     isort-check-examples
     isort-check-tests
@@ -18,6 +19,7 @@ pypy=pypy
 2.7=py27
 3.4=py34
 3.5=py35,isort-check,isort-check-examples,isort-check-tests,flake8
+3.6=py36
 
 [testenv]
 setenv=PYTHONPATH = {toxinidir}:{toxinidir}


### PR DESCRIPTION
Connexion is mocking all functions even when mocking method is **not** "mock all". This PR fixes that and also remove exposition of Connexion's `ResolverError` internal exception letting go the original exception which will be much more useful for users to debug their applications.

Changes proposed in this pull request:

 - Fixes mocking partially functions as expected;
 - Expose to users native errors when functions are not found. Make much easier to debug problems;
 - Log messages when functions are mocked or not. Improve development experience;
- Test under Python 3.6.
