### PR TITLE
Default to all scopes checked for oauth2

### DIFF
--- a/connexion/vendor/swagger-ui/swagger-ui.js
+++ b/connexion/vendor/swagger-ui/swagger-ui.js
@@ -220,7 +220,7 @@ templates['main'] = template({"1":function(container,depth0,helpers,partials,dat
 templates['oauth2'] = template({"1":function(container,depth0,helpers,partials,data) {
     var stack1, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing;
 
-  return "            <li>\n                <input class=\"oauth-scope\" type=\"checkbox\" data-scope=\""
+  return "            <li>\n                <input class=\"oauth-scope\" checked=\"checked\" type=\"checkbox\" data-scope=\""
     + ((stack1 = (helpers.escape || (depth0 && depth0.escape) || alias2).call(alias1,(depth0 != null ? depth0.scope : depth0),{"name":"escape","hash":{},"data":data})) != null ? stack1 : "")
     + "\" oauthtype=\""
     + ((stack1 = (helpers.escape || (depth0 && depth0.escape) || alias2).call(alias1,(depth0 != null ? depth0.OAuthSchemeKey : depth0),{"name":"escape","hash":{},"data":data})) != null ? stack1 : "")
@@ -22709,7 +22709,7 @@ SwaggerUi.Models.Oauth2Model = Backbone.Model.extend({
       var valid = false;
       var scp = this.get('scopes');
       var idx =  _.findIndex(scp, function (o) {
-         return o.checked === true;
+         return o.checked !== false;
       });
 
       if(scp.length > 0 && idx >= 0) {


### PR DESCRIPTION
Changes proposed in this pull request:

 - Automatically check all oauth2 scopes by default

If you're using the UI to debug it's very annoying to have to check all of the scopes every time you refresh the page. This fixes that issue and is a much more convenient default.