### PR TITLE
Validate responses against the default response field if the code is not found

### DIFF
--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -33,7 +33,7 @@ class ResponseValidator(BaseDecorator):
         :rtype bool | None
         """
         response_definitions = self.operation.operation["responses"]
-        response_definition = response_definitions.get(str(status_code), {})
+        response_definition = response_definitions.get(str(status_code), response_definitions.get("default", {}))
         response_definition = self.operation.resolve_reference(response_definition)
         # TODO handle default response definitions
 

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -219,3 +219,12 @@ def test_get_unicode_response(simple_app):
     resp = app_client.get('/v1.0/get_unicode_response')
     actualJson = {u'currency': u'\xa3', u'key': u'leena'}
     assert json.loads(resp.data.decode('utf-8','replace')) == actualJson
+
+
+def test_get_bad_default_response(simple_app):
+    app_client = simple_app.app.test_client()
+    resp = app_client.get('/v1.0/get_bad_default_response/200')
+    assert resp.status_code == 200
+
+    resp = app_client.get('/v1.0/get_bad_default_response/202')
+    assert resp.status_code == 500

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -407,3 +407,6 @@ def post_wrong_content_type():
 def get_unicode_data():
     jsonResponse = {u'currency': u'\xa3', u'key': u'leena'}
     return jsonResponse
+
+def get_bad_default_response(response_code):
+    return {}, response_code

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -774,6 +774,26 @@ paths:
           schema:
             type: object
 
+  /get_bad_default_response/{response_code}:
+    get:
+      operationId: fakeapi.hello.get_bad_default_response
+      produces:
+        - "application/json"
+      parameters:
+        - name: response_code
+          in: path
+          type: integer
+          required: true
+      responses:
+        200:
+          description: Some object response
+          schema:
+            type: object
+        default:
+          description: Some array response
+          schema:
+            type: array
+
 definitions:
   new_stack:
     type: object


### PR DESCRIPTION
Currently, if a spec does not define a schema for a response code but defines a default schema, it is not validated.  This change pulls the default schema if the response code lookup fails.