### PR TITLE
Fix for Issue #308: MockResolver: support "example" in definitions

### DIFF
--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -67,8 +67,8 @@ class MockResolver(Resolver):
             # No response example, check for schema example
             response_schema = response_definition.get('schema', {})
             definitions = response_schema.get('definitions')
-            ref = response_schema.get('$ref')
-            ref = ref[ref.rfind('/')+1:]
+            ref = response_schema.get('$ref', '')
+            ref = ref[ref.rfind('/')+1:] or ''
             ref_schema = definitions.get(ref, {})
             schema_example = ref_schema.get('example')
             if schema_example:

--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -66,7 +66,7 @@ class MockResolver(Resolver):
         else:
             # No response example, check for schema example
             response_schema = response_definition.get('schema', {})
-            definitions = response_schema.get('definitions')
+            definitions = response_schema.get('definitions', {})
             ref = response_schema.get('$ref', '')
             ref = ref[ref.rfind('/')+1:] or ''
             ref_schema = definitions.get(ref, {})

--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -64,4 +64,14 @@ class MockResolver(Resolver):
         if examples:
             return list(examples.values())[0], status_code
         else:
-            return 'No example response was defined.', status_code
+            # No response example, check for schema example
+            response_schema = response_definition.get('schema', {})
+            definitions = response_schema.get('definitions')
+            ref = response_schema.get('$ref')
+            ref = ref[ref.rfind('/')+1:]
+            ref_schema = definitions.get(ref, {})
+            schema_example = ref_schema.get('example')
+            if schema_example:
+                return schema_example, status_code
+            else:
+                return 'No example response or schema was defined.', status_code

--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -74,4 +74,4 @@ class MockResolver(Resolver):
             if schema_example:
                 return schema_example, status_code
             else:
-                return 'No example response or schema was defined.', status_code
+                return 'No example response was defined.', status_code

--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -67,10 +67,16 @@ class MockResolver(Resolver):
             # No response example, check for schema example
             response_schema = response_definition.get('schema', {})
             definitions = response_schema.get('definitions', {})
-            ref = response_schema.get('$ref', '')
-            ref = ref[ref.rfind('/')+1:] or ''
-            ref_schema = definitions.get(ref, {})
-            schema_example = ref_schema.get('example')
+            schema_example = None
+            ref = response_schema.get('$ref')
+            if ref:
+                # Referenced schema
+                ref = ref[ref.rfind('/')+1:] or ''
+                ref_schema = definitions.get(ref, {})
+                schema_example = ref_schema.get('example')
+            else:
+                # Inline schema
+                schema_example = response_schema.get('example')
             if schema_example:
                 return schema_example, status_code
             else:

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -43,7 +43,7 @@ def test_mock_resolver():
     assert status_code == 200
     assert response == {'foo': 'bar'}
 
-def test_mock_resolver_schema_example():
+def test_mock_resolver_ref_schema_example():
     resolver = MockResolver(mock_all=True)
 
     responses = {
@@ -72,6 +72,45 @@ def test_mock_resolver_schema_example():
                                   }
                               }
                           },
+                          parameter_definitions={},
+                          resolver=resolver)
+    assert operation.operation_id == 'mock-1'
+
+    response, status_code = resolver.mock_operation(operation)
+    assert status_code == 200
+    assert response == {'foo': 'bar'}
+
+def test_mock_resolver_inline_schema_example():
+    resolver = MockResolver(mock_all=True)
+
+    responses = {
+        'default': {
+            'schema': {
+                'type': 'object',
+                'properties': {
+                    'foo': {
+                        'type': 'string'
+                    }
+                },
+                'example': {
+                    'foo': 'bar'
+                }
+            }
+        }
+    }
+
+    operation = Operation(api=None,
+                          method='GET',
+                          path='endpoint',
+                          path_parameters=[],
+                          operation={
+                              'responses': responses
+                          },
+                          app_produces=['application/json'],
+                          app_consumes=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
                           parameter_definitions={},
                           resolver=resolver)
     assert operation.operation_id == 'mock-1'

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -43,6 +43,42 @@ def test_mock_resolver():
     assert status_code == 200
     assert response == {'foo': 'bar'}
 
+def test_mock_resolver_schema_example():
+    resolver = MockResolver(mock_all=True)
+
+    responses = {
+        'default': {
+            'schema': {
+                '$ref': '#/definitions/Schema'
+            }
+        }
+    }
+
+    operation = Operation(api=None,
+                          method='GET',
+                          path='endpoint',
+                          path_parameters=[],
+                          operation={
+                              'responses': responses
+                          },
+                          app_produces=['application/json'],
+                          app_consumes=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={
+                              'Schema': {
+                                  'example': {
+                                      'foo': 'bar'
+                                  }
+                              }
+                          },
+                          parameter_definitions={},
+                          resolver=resolver)
+    assert operation.operation_id == 'mock-1'
+
+    response, status_code = resolver.mock_operation(operation)
+    assert status_code == 200
+    assert response == {'foo': 'bar'}
 
 def test_mock_resolver_no_examples():
     resolver = MockResolver(mock_all=True)


### PR DESCRIPTION
Fixes #308 .

Adding support for "example" in definitions to be returned from the mock server instead of "No example response was defined." for more robust mocking.

Changes proposed in this pull request:

 - If response example is not provided, use "example" defined in response type schema
 - If no response example or schema example is provided return error message as before
