### PR TITLE
setup.py: Use env markers for Python version-specific dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.5"
   - "3.6"
 install:
-  - pip install tox tox-travis coveralls
+  - pip install "setuptools>=17.1" tox tox-travis coveralls
 script:
   - tox
 after_success:

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -3,7 +3,8 @@
 -e git+https://github.com/kennethreitz/requests#egg=requests
 -e git+https://github.com/Yelp/swagger_spec_validator.git#egg=swagger-spec-validator
 -e git+https://github.com/zalando/python-clickclick.git#egg=clickclick
--e hg+https://bitbucket.org/pitrou/pathlib#egg=pathlib
+# This repo doesn't have the latest version released on PyPI
+# -e hg+https://bitbucket.org/pitrou/pathlib#egg=pathlib
 # PyYAML is not that easy to build manually, it may fail.
 #-e svn+http://svn.pyyaml.org/pyyaml/trunk#egg=PyYAML
 # six is causing errors during the tests

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 
 import inspect
 import os
-import platform
 import sys
 
 from setuptools import find_packages, setup
@@ -21,9 +20,6 @@ def read_version(package):
 
 version = read_version('connexion')
 
-py_major_minor_version = tuple(int(v.rstrip('+')) for v in platform.python_version_tuple()[:2])
-
-
 install_requires = [
     'clickclick>=1.2',
     'jsonschema>=2.5.1',
@@ -32,15 +28,11 @@ install_requires = [
     'six>=1.9',
     'swagger-spec-validator>=2.0.2',
     'inflection>=0.3.1',
+    'pathlib>=1.0.1; python_version < "3.4"',
+    'typing>=3.6.1; python_version < "3.6"',
 ]
 
 flask_require = 'flask>=0.10.1'
-
-if py_major_minor_version < (3, 4):
-    install_requires.append('pathlib>=1.0.1')
-
-if py_major_minor_version < (3, 6):
-    install_requires.append('typing>=3.6.1')
 
 tests_require = [
     'decorator',


### PR DESCRIPTION
Changing package properties dynamically in setup.py means that universal
wheels will actually be built only for the builder's environment, and
might not work properly on different platforms/PYthon versions.

Closes https://github.com/zalando/connexion/issues/493