### PR TITLE
Fix KeyError if no Content-Type was provided in request

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -111,7 +111,7 @@ class RequestBodyValidator(object):
                     return problem(415,
                                    "Unsupported Media Type",
                                    "Invalid Content-type ({content_type}), expected JSON data".format(
-                                       content_type=request.headers["Content-Type"]
+                                       content_type=request.headers.get("Content-Type", "")
                                    ))
 
                 logger.debug("%s validating schema...", request.url)

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -1,6 +1,8 @@
 import json
 from struct import unpack
 
+from werkzeug.test import Client, EnvironBuilder
+
 from connexion.apps.flask_app import FlaskJSONEncoder
 
 
@@ -219,7 +221,6 @@ def test_post_wrong_content_type(simple_app):
     # (https://github.com/pallets/werkzeug/issues/1159)
     # so that content-type is added to every request, we remove it here manually for our test
     # this test can be removed once the werkzeug issue is addressed
-    from werkzeug.test import Client, EnvironBuilder
     builder = EnvironBuilder(path='/v1.0/post_wrong_content_type', method='POST',
                              data=json.dumps({"some": "data"}))
     try:

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -219,7 +219,7 @@ def test_post_wrong_content_type(simple_app):
     # (https://github.com/pallets/werkzeug/issues/1159)
     # so that content-type is added to every request, we remove it here manually for our test
     # this test can be removed once the werkzeug issue is addressed
-    from werkzeug.test import EnvironBuilder
+    from werkzeug.test import Client, EnvironBuilder
     builder = EnvironBuilder(path='/v1.0/post_wrong_content_type', method='POST',
                              data=json.dumps({"some": "data"}))
     try:
@@ -227,7 +227,10 @@ def test_post_wrong_content_type(simple_app):
     finally:
         builder.close()
     environ.pop('CONTENT_TYPE')
-    resp = app_client.open(environ)
+    # we cannot just call app_client.open() since app_client is a flask.testing.FlaskClient
+    # which overrides werkzeug.test.Client.open() but does not allow passing an environment
+    # directly
+    resp = Client.open(app_client, environ)
     assert resp.status_code == 415
 
 

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -213,6 +213,23 @@ def test_post_wrong_content_type(simple_app):
                            )
     assert resp.status_code == 415
 
+    # this test checks exactly what the test directly above is supposed to check,
+    # i.e. no content-type is provided in the header
+    # unfortunately there is an issue with the werkzeug test environment
+    # (https://github.com/pallets/werkzeug/issues/1159)
+    # so that content-type is added to every request, we remove it here manually for our test
+    # this test can be removed once the werkzeug issue is addressed
+    from werkzeug.test import EnvironBuilder
+    builder = EnvironBuilder(path='/v1.0/post_wrong_content_type', method='POST',
+                             data=json.dumps({"some": "data"}))
+    try:
+        environ = builder.get_environ()
+    finally:
+        builder.close()
+    environ.pop('CONTENT_TYPE')
+    resp = app_client.open(environ)
+    assert resp.status_code == 415
+
 
 def test_get_unicode_response(simple_app):
     app_client = simple_app.app.test_client()


### PR DESCRIPTION
At the moment if no `Content-Type` is provided in the request the validation wrapper raises a `KeyError`.

Can we expect a fix to make it into a release soon or should we look for a temporary workaround until that happens?