### PR TITLE
Preserving the multiplicity of array type query parameters

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -101,8 +101,7 @@ def parameter_to_arg(parameters, consumes, function, pythonic_params=False):
 
     def make_request_query(request):
         request_query = {}
-        isMultiDict = callable(getattr(request.query, "to_dict", None))
-        if isMultiDict:
+        try:
             for k, v in request.query.to_dict(flat=False).items():
                 k = sanitize_param(k)
                 query_param = query_types.get(k, None)
@@ -113,7 +112,7 @@ def parameter_to_arg(parameters, consumes, function, pythonic_params=False):
                         request_query[k] = ",".join(v)
                 else:
                     request_query[k] = v[0]
-        else:
+        except AttributeError:
             request_query = {sanitize_param(k): v for k, v in request.form.items()}
         return request_query
 

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -51,14 +51,14 @@ def test_array_query_param(simple_app):
     response = app_client.get(url, headers=headers)
     array_response = json.loads(response.data.decode('utf-8', 'replace'))  # [str] unsupported collectionFormat
     assert array_response == ["1;2;3"]
-    url = '/v1.0/test_array_csv_query_param?items=A&items=B&items=C'
+    url = '/v1.0/test_array_csv_query_param?items=A&items=B&items=C&items=D,E,F'
     response = app_client.get(url, headers=headers)
     array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [str] multi array with csv format
-    assert array_response == ['A', 'B', 'C']
-    url = '/v1.0/test_array_pipes_query_param?items=4&items=5&items=6'
+    assert array_response == ['A', 'B', 'C', 'D', 'E', 'F']
+    url = '/v1.0/test_array_pipes_query_param?items=4&items=5&items=6&items=7|8|9'
     response = app_client.get(url, headers=headers)
     array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [int] multi array with pipes format
-    assert array_response == [4, 5, 6]
+    assert array_response == [4, 5, 6, 7, 8, 9]
 
 
 def test_extra_query_param(simple_app):


### PR DESCRIPTION
Fixes issue #323

This is a better implementation of what I was doing in the #499 pull request.

Changes proposed in this pull request:

 - On line 146 of parameter.py: updating the request query parameters being added to `query_arguments` so as to preserve lists that are encoded by having multiple values to a single key.