### PR TITLE
Allow http.HTTPStatus enums as response status codes.

### DIFF
--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -154,6 +154,12 @@ class FlaskApi(AbstractAPI):
         flask_response = flask.current_app.response_class(**kwargs)  # type: flask.Response
 
         if status_code is not None:
+            try:
+                # If we got an enum instead of an int, extract the value.
+                status_code = status_code.value
+            except AttributeError:
+                pass
+
             flask_response.status_code = status_code
 
         if data is not None and data is not NoContent:

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -154,11 +154,9 @@ class FlaskApi(AbstractAPI):
         flask_response = flask.current_app.response_class(**kwargs)  # type: flask.Response
 
         if status_code is not None:
-            try:
-                # If we got an enum instead of an int, extract the value.
+            # If we got an enum instead of an int, extract the value.
+            if hasattr(status_code, "value"):
                 status_code = status_code.value
-            except AttributeError:
-                pass
 
             flask_response.status_code = status_code
 

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -28,16 +28,10 @@ class ResponseValidator(BaseDecorator):
         Validates the Response object based on what has been declared in the specification.
         Ensures the response body matches the declated schema.
         :type data: dict
-        :type status_code: int | enum.Enum
+        :type status_code: int
         :type headers: dict
         :rtype bool | None
         """
-        try:
-            # If we got an enum instead of an int, extract the value.
-            status_code = status_code.value
-        except AttributeError:
-            pass
-
         response_definitions = self.operation.operation["responses"]
         response_definition = response_definitions.get(str(status_code), response_definitions.get("default", {}))
         response_definition = self.operation.resolve_reference(response_definition)

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -28,14 +28,19 @@ class ResponseValidator(BaseDecorator):
         Validates the Response object based on what has been declared in the specification.
         Ensures the response body matches the declated schema.
         :type data: dict
-        :type status_code: int
+        :type status_code: int | enum.Enum
         :type headers: dict
         :rtype bool | None
         """
+        try:
+            # If we got an enum instead of an int, extract the value.
+            status_code = status_code.value
+        except AttributeError:
+            pass
+
         response_definitions = self.operation.operation["responses"]
         response_definition = response_definitions.get(str(status_code), response_definitions.get("default", {}))
         response_definition = self.operation.resolve_reference(response_definition)
-        # TODO handle default response definitions
 
         if self.is_json_schema_compatible(response_definition):
             schema = response_definition.get("schema")

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -221,6 +221,12 @@ def test_get_unicode_response(simple_app):
     assert json.loads(resp.data.decode('utf-8','replace')) == actualJson
 
 
+def test_get_httpstatus_response(simple_app):
+    app_client = simple_app.app.test_client()
+    resp = app_client.get('/v1.0/get_httpstatus_response')
+    assert resp.status_code == 200
+
+
 def test_get_bad_default_response(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/get_bad_default_response/200')

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -242,6 +242,11 @@ def test_get_unicode_response(simple_app):
     assert json.loads(resp.data.decode('utf-8','replace')) == actualJson
 
 
+def test_get_enum_response(simple_app):
+    app_client = simple_app.app.test_client()
+    resp = app_client.get('/v1.0/get_enum_response')
+    assert resp.status_code == 200
+
 def test_get_httpstatus_response(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/get_httpstatus_response')

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python3
-import sys
-import unittest
-
 import flask
 from flask import jsonify, redirect
 

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import sys
+import unittest
 
 import flask
 from flask import jsonify, redirect
@@ -415,18 +417,24 @@ def get_unicode_data():
     return jsonResponse
 
 
-@unittest.skipIf(sys.version_info < (3, 4), "Not supported in this version")
-def get_httpstatus_response():
-    from enum import Enum
-    class HTTPStatus(Enum):
-        OK = 200
-    return {}, HTTPStatus.OK
+def get_enum_response():
+    try:
+        from enum import Enum
+        class HTTPStatus(Enum):
+            OK = 200
+    except ImportError:
+        return {}, 200
+    else:
+        return {}, HTTPStatus.OK
 
 
-@unittest.skipIf(sys.version_info < (3, 5), "Not supported in this version")
 def get_httpstatus_response():
-    from http import HTTPStatus
-    return {}, HTTPStatus.OK
+    try:
+        from http import HTTPStatus
+    except ImportError:
+        return {}, 200
+    else:
+        return {}, HTTPStatus.OK
 
 
 def get_bad_default_response(response_code):

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -408,5 +408,14 @@ def get_unicode_data():
     jsonResponse = {u'currency': u'\xa3', u'key': u'leena'}
     return jsonResponse
 
+def get_httpstatus_response():
+    try:
+        # Available in python 3.5+
+        from http import HTTPStatus
+    except ImportError:
+        return {}, 200
+    else:
+        return {}, HTTPStatus.OK
+
 def get_bad_default_response(response_code):
     return {}, response_code

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -415,14 +415,18 @@ def get_unicode_data():
     return jsonResponse
 
 
+@unittest.skipIf(sys.version_info < (3, 4), "Not supported in this version")
 def get_httpstatus_response():
-    try:
-        # Available in python 3.5+
-        from http import HTTPStatus
-    except ImportError:
-        return {}, 200
-    else:
-        return {}, HTTPStatus.OK
+    from enum import Enum
+    class HTTPStatus(Enum):
+        OK = 200
+    return {}, HTTPStatus.OK
+
+
+@unittest.skipIf(sys.version_info < (3, 5), "Not supported in this version")
+def get_httpstatus_response():
+    from http import HTTPStatus
+    return {}, HTTPStatus.OK
 
 
 def get_bad_default_response(response_code):

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -774,6 +774,17 @@ paths:
           schema:
             type: object
 
+  /get_httpstatus_response:
+    get:
+      operationId: fakeapi.hello.get_httpstatus_response
+      produces:
+        - "application/json"
+      responses:
+        200:
+          description: Some HTTPStatus response
+          schema:
+            type: object
+
   /get_bad_default_response/{response_code}:
     get:
       operationId: fakeapi.hello.get_bad_default_response

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -786,6 +786,17 @@ paths:
           schema:
             type: object
 
+  /get_enum_response:
+    get:
+      operationId: fakeapi.hello.get_enum_response
+      produces:
+        - "application/json"
+      responses:
+        200:
+          description: Some HTTPStatus response
+          schema:
+            type: object
+
   /get_httpstatus_response:
     get:
       operationId: fakeapi.hello.get_httpstatus_response


### PR DESCRIPTION
Python 3.5 introduced a new enumeration "http.HTTPStatus" for
representing HTTP response status codes. The default response validation
introduced in connexion 1.1.12 highlighted the fact that connexion does
not natively support this type and was previously silently ignoring
non-integer status code representations.

This modifies the response validation code to extract the value when
given an enum instead of an int. Somewhat hacky test code is added to
check for enum support on python versions that include
"http.HTTPStatus".

Fixes #503 



Changes proposed in this pull request:

 - Convert enums to ints in response validation matching.