### PR TITLE
Fix the examples

### DIFF
--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -113,7 +113,7 @@ class FlaskApp(AbstractApp):
             logger.info('Listening on %s:%s..', self.host, self.port)
             http_server.serve_forever()
         else:
-            raise Exception('Server %s not recognized', self.server)
+            raise Exception('Server {} not recognized'.format(self.server))
 
 
 class FlaskJSONEncoder(json.JSONEncoder):

--- a/examples/enforcedefaults/enforcedefaults.py
+++ b/examples/enforcedefaults/enforcedefaults.py
@@ -43,6 +43,6 @@ validator_map = {
 
 if __name__ == '__main__':
     app = connexion.FlaskApp(
-        __name__, 8080, specification_dir='.', validator_map=validator_map)
+        __name__, port=8080, specification_dir='.', validator_map=validator_map)
     app.add_api('enforcedefaults-api.yaml')
     app.run()

--- a/examples/helloworld/hello.py
+++ b/examples/helloworld/hello.py
@@ -7,6 +7,6 @@ def post_greeting(name: str) -> str:
     return 'Hello {name}'.format(name=name)
 
 if __name__ == '__main__':
-    app = connexion.FlaskApp(__name__, 9090, specification_dir='swagger/')
+    app = connexion.FlaskApp(__name__, port=9090, specification_dir='swagger/')
     app.add_api('helloworld-api.yaml', arguments={'title': 'Hello World Example'})
     app.run()


### PR DESCRIPTION
Some of the [examples](https://github.com/zalando/connexion/tree/master/examples/) were raising an `Exception` when ran according to the provided `README` documentation. This occurred because the port was passed incorrectly as the `server`-argument. Fixed also the exception string which had incorrect string formatting.