### PR TITLE
Fix UnicodeEncodeError for query-strings on Python 2

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -18,10 +18,16 @@ except ImportError:  # pragma: no cover
 
 logger = logging.getLogger(__name__)
 
+# Python 2/3 compatibility:
+try:
+    py_string = unicode
+except NameError:  # pragma: no cover
+    py_string = str  # pragma: no cover
+
 # https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#data-types
 TYPE_MAP = {'integer': int,
             'number': float,
-            'string': str,
+            'string': py_string,
             'boolean': boolean,
             'array': list,
             'object': dict}  # map of swagger types to python types

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import json
 from io import BytesIO
 
@@ -331,3 +333,11 @@ def test_parameters_snake_case(snake_case_app):
     assert resp.status_code == 200
     resp = app_client.get('/v1.0/test-get-query-shadow?list=123')
     assert resp.status_code == 200
+
+
+def test_get_unicode_request(simple_app):
+    """Regression test for Python 2 UnicodeEncodeError bug during parameter parsing."""
+    app_client = simple_app.app.test_client()
+    resp = app_client.get('/v1.0/get_unicode_request?price=%C2%A319.99')
+    assert resp.status_code == 200
+    assert json.loads(resp.data)['price'] == u'\xa319.99'

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 import json
 from io import BytesIO
@@ -338,6 +339,6 @@ def test_parameters_snake_case(snake_case_app):
 def test_get_unicode_request(simple_app):
     """Regression test for Python 2 UnicodeEncodeError bug during parameter parsing."""
     app_client = simple_app.app.test_client()
-    resp = app_client.get('/v1.0/get_unicode_request?price=%C2%A319.99')
+    resp = app_client.get('/v1.0/get_unicode_request?price=%C2%A319.99')  # £19.99
     assert resp.status_code == 200
-    assert json.loads(resp.data)['price'] == u'\xa319.99'
+    assert json.loads(resp.data.decode('utf-8'))['price'] == '£19.99'

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -401,12 +401,19 @@ def test_param_sanitization(query=None, form=None):
 def test_body_sanitization(body=None):
     return body
 
+
 def post_wrong_content_type():
     return "NOT OK"
+
+
+def get_unicode_query(price=None):
+    return {'price': price}
+
 
 def get_unicode_data():
     jsonResponse = {u'currency': u'\xa3', u'key': u'leena'}
     return jsonResponse
+
 
 def get_bad_default_response(response_code):
     return {}, response_code

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -763,6 +763,18 @@ paths:
         215:
           description: NOT-OK
 
+  /get_unicode_request:
+    get:
+      summary: Test if a unicode string in query parameter works properly in Python 2
+      operationId: fakeapi.hello.get_unicode_query
+      parameters:
+        - name: price
+          in: query
+          type: string
+      responses:
+        200:
+          description: OK
+
   /get_unicode_response:
     get:
       operationId: fakeapi.hello.get_unicode_data


### PR DESCRIPTION
Fixes #485 .



Changes proposed in this pull request:

 - Use the proper string type based on the python version.
