### PR TITLE
Add inbound license notice

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -3,6 +3,13 @@ Contributing to Connexion/TODOs
 
 We welcome your ideas, issues, and pull requests. Just follow the usual/standard GitHub practices.
 
+Unless you explicitly state otherwise in advance, any non trivial 
+contribution intentionally submitted for inclusion in this project by you 
+to the steward of this repository (Zalando SE, Berlin) shall be under the 
+terms and conditions of the `Apache License 2.0`_, 
+without any additional copyright information, terms or conditions.
+
+
 TODOs
 -----
 
@@ -10,3 +17,4 @@ If you'd like to become a more consistent contributor to Connexion, we'd love yo
 these we have a list of `issues where we are looking for contributions`_.
 
 .. _issues where we are looking for contributions: https://github.com/zalando/connexion/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
+.. _Apache License 2.0: README.rst#license

--- a/README.rst
+++ b/README.rst
@@ -435,6 +435,12 @@ Contributing to Connexion/TODOs
 We welcome your ideas, issues, and pull requests. Just follow the
 usual/standard GitHub practices.
 
+Unless you explicitly state otherwise in advance, any non trivial 
+contribution intentionally submitted for inclusion in this project by you 
+to the steward of this repository (Zalando SE, Berlin) shall be under the 
+terms and conditions of Apache License 2.0 written below, without any 
+additional copyright information, terms or conditions.
+
 TODOs
 -----
 


### PR DESCRIPTION
Contributors need to be made aware of the terms and conditions under which they contribute to this repository.