### PR TITLE
FIX a typo causing an ERROR log

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -119,7 +119,7 @@ def parameter_to_arg(parameters, consumes, function, pythonic_params=False):
                 else:
                     request_query[k] = v[0]
         except AttributeError:
-            request_query = {sanitize_param(k): v for k, v in request.form.items()}
+            request_query = {sanitize_param(k): v for k, v in request.query.items()}
         return request_query
 
     body_parameters = [parameter for parameter in parameters if parameter['in'] == 'body'] or [{}]

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -6,6 +6,7 @@
 inflection
 mock
 pytest
+testfixtures>=5.3.0
 # This repo doesn't have the latest version released on PyPI
 # -e hg+https://bitbucket.org/pitrou/pathlib#egg=pathlib
 # PyYAML is not that easy to build manually, it may fail.

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ tests_require = [
     'mock',
     'pytest',
     'pytest-cov',
+    'testfixtures',
     flask_require
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,3 +142,8 @@ def unordered_definition_app():
 @pytest.fixture(scope="session")
 def bad_operations_app():
     return build_app_from_fixture('bad_operations', resolver_error=501)
+
+
+@pytest.fixture(scope="session")
+def query_sanitazion():
+    return build_app_from_fixture('query_sanitazion')

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -1,6 +1,8 @@
+
 from connexion.decorators.parameter import parameter_to_arg
 # we are using "mock" module here for Py 2.7 support
 from mock import MagicMock
+from testfixtures import LogCapture
 
 
 def test_injection(monkeypatch):
@@ -17,3 +19,22 @@ def test_injection(monkeypatch):
     parameter_to_arg({}, [], handler)(request)
 
     func.assert_called_with(p1='123')
+
+
+def test_query_sanitazion(query_sanitazion):
+    app_client = query_sanitazion.app.test_client()
+    l = LogCapture()
+
+    url = '/v1.0/greeting'
+    response = app_client.post(url, data={'name': 'Jane Doe'})
+    # This is ugly. The reason for asserting the logging in this way
+    # is that in order to use LogCapture().check, we'd have to assert that
+    # a specific sequence of logging has occurred. This is too restricting
+    # for future development, and we are really only interested in the fact
+    # a single message is logged.
+    messages = [x.strip() for x in str(l).split("\n")]
+    assert "FormData parameter 'name' in function arguments" in messages
+    assert "Query Parameter 'name' in function arguments" not in messages
+    assert "Function argument 'name' not defined in specification" not in messages
+    assert response.status_code == 200
+    l.uninstall()

--- a/tests/fixtures/query_sanitazion/swagger.yaml
+++ b/tests/fixtures/query_sanitazion/swagger.yaml
@@ -1,0 +1,22 @@
+swagger: "2.0"
+info:
+  title: "{{title}}"
+  version: "1.0"
+basePath: /v1.0
+paths:
+  /greeting:
+    post:
+      summary: Generate greeting
+      description: Generates a greeting message.
+      operationId: fakeapi.hello.post_greeting
+      responses:
+        '200':
+          description: greeting response
+          schema:
+            type: object
+      parameters:
+        - name: name
+          in: formData
+          description: Name of the person to greet.
+          required: true
+          type: string


### PR DESCRIPTION
A small bug was introduced in #500 when sanitizing the request query
parameters. Instead of fetching the arguments from `request.query`,
the parameters were sanitized from the `request.form`. This causes an
error log to be printed, as the parameters are not expected for the
query (for example in the case of a POST request).

Fixes #522