### PR TITLE
Update CORS documentation

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -78,7 +78,7 @@ to set CORS headers:
 .. code-block:: python
 
     import connexion
-    from flask.ext.cors import CORS
+    from flask_cors import CORS
 
     app = connexion.FlaskApp(__name__)
     app.add_api('swagger.yaml')


### PR DESCRIPTION
Resolved error since flask cors was moved to its own project: `ExtDeprecationWarning: Importing flask.ext.cors is deprecated, use flask_cors instead.`

Will also require installation `pip install -U flask-cors`

Fixes # .



Changes proposed in this pull request:

 -
 -
 -
