### PR TITLE
Ignore x- extensions on path obj, better error on missing operationId

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -236,7 +236,7 @@ class AbstractAPI(object):
             path_parameters = methods.get('parameters', [])
 
             for method, endpoint in methods.items():
-                if method == 'parameters':
+                if method == 'parameters' or method.startswith('x-'):
                     continue
                 try:
                     self.add_operation(method, path, endpoint, path_parameters)

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -17,9 +17,9 @@ def get_function_from_name(function_name):
 
     :type function_name: str
     """
-    if function_name is None:
-        raise ValueError("Empty function name")
-
+    if function_name is None or function_name == "":
+        raise ValueError("Empty function name. Provide operationId, or change resolver "
+                         "https://github.com/zalando/connexion#automatic-routing")
     if '.' in function_name:
         module_name, attr_path = function_name.rsplit('.', 1)
     else:
@@ -38,6 +38,8 @@ def get_function_from_name(function_name):
                 module_name, attr_path1 = module_name.rsplit('.', 1)
                 attr_path = '{0}.{1}'.format(attr_path1, attr_path)
             else:
+                if function_name is None:
+                    raise ValueError("")
                 raise
     try:
         function = deep_getattr(module, attr_path)

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -38,8 +38,6 @@ def get_function_from_name(function_name):
                 module_name, attr_path1 = module_name.rsplit('.', 1)
                 attr_path = '{0}.{1}'.format(attr_path1, attr_path)
             else:
-                if function_name is None:
-                    raise ValueError("")
                 raise
     try:
         function = deep_getattr(module, attr_path)


### PR DESCRIPTION
Changes proposed in this pull request:

 - Ignore extensions on path objects. Apiary uses x-summary and x-description.
 - Better error handling when no operationId specified with default resolver.
