### PR TITLE
Restoring Flask-Injector support by passing "undocumented" path parameters to the handler

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -153,10 +153,11 @@ def parameter_to_arg(parameters, consumes, function, pythonic_params=False):
 
         # Parse path parameters
         path_params = request.path_params
-        for key, path_param_definitions in path_types.items():
-            if key in path_params:
-                kwargs[key] = get_val_from_param(path_params[key],
-                                                 path_param_definitions)
+        for key, value in path_params.items():
+            if key in path_types:
+                kwargs[key] = get_val_from_param(value, path_types[key])
+            else:  # Assume path params mechanism used for injection
+                kwargs[key] = value
 
         # Add body parameters
         if not has_kwargs and body_name not in arguments:

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -3,6 +3,9 @@
 -e git+https://github.com/kennethreitz/requests#egg=requests
 -e git+https://github.com/Yelp/swagger_spec_validator.git#egg=swagger-spec-validator
 -e git+https://github.com/zalando/python-clickclick.git#egg=clickclick
+inflection
+mock
+pytest
 # This repo doesn't have the latest version released on PyPI
 # -e hg+https://bitbucket.org/pitrou/pathlib#egg=pathlib
 # PyYAML is not that easy to build manually, it may fail.

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -1,0 +1,15 @@
+from connexion.decorators.parameter import parameter_to_arg
+# we are using "mock" module here for Py 2.7 support
+from mock import MagicMock
+
+
+def test_injection(monkeypatch):
+    request = MagicMock(name='request', path_params={'p1': '123'})
+    request.args = {}
+    request.headers = {}
+    request.params = {}
+
+    func = MagicMock()
+    parameter_to_arg({}, [], func)(request)
+
+    func.assert_called_with(p1='123')

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -10,6 +10,10 @@ def test_injection(monkeypatch):
     request.params = {}
 
     func = MagicMock()
-    parameter_to_arg({}, [], func)(request)
+
+    def handler(**kwargs):
+        func(**kwargs)
+
+    parameter_to_arg({}, [], handler)(request)
 
     func.assert_called_with(p1='123')


### PR DESCRIPTION
Fixes #469 .



Changes proposed in this pull request:

 - Pass undocumented path parameters to the handler to allow injection.
