### PR TITLE
MINOR Readme Fix: Rename "search" to "get" in main Readme for RestyResolver example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -191,7 +191,7 @@ the endpoints in your specification:
           # Implied operationId: api.get
      /foo:
        get:
-          # Implied operationId: api.foo.search
+          # Implied operationId: api.foo.get
        post:
           # Implied operationId: api.foo.post
 


### PR DESCRIPTION
If i am not mistaken, "get" should be correct here?