### PR TITLE
Allow splitting spec file using jinja2 env and/or json references

### DIFF
--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -3,6 +3,7 @@ import logging
 import pathlib
 
 import six
+import jinja2
 
 from ..options import ConnexionOptions
 from ..resolver import Resolver
@@ -60,8 +61,16 @@ class AbstractApp(object):
 
         specification_dir = pathlib.Path(specification_dir)  # Ensure specification dir is a Path
         if specification_dir.is_absolute():
+            self.env = jinja2.Environment(
+                loader=jinja2.FileSystemLoader(str(specification_dir)),
+                autoescape=False
+            )
             self.specification_dir = specification_dir
         else:
+            self.env = jinja2.Environment(
+                loader=jinja2.PackageLoader(import_name, str(specification_dir)),
+                autoescape=False
+            )
             self.specification_dir = self.root_path / specification_dir
 
         logger.debug('Specification directory: %s', self.specification_dir)
@@ -156,6 +165,7 @@ class AbstractApp(object):
                            debug=self.debug,
                            validator_map=self.validator_map,
                            pythonic_params=pythonic_params,
+                           jinja2_env=self.env,
                            options=api_options.as_dict())
         return api
 

--- a/connexion/specification_loader.py
+++ b/connexion/specification_loader.py
@@ -1,0 +1,89 @@
+import pathlib
+import json
+from jsonschema.compat import urlsplit
+
+import yaml
+import jinja2
+from swagger_spec_validator.validator20 import validate_spec as _validate_spec
+
+
+def file_resolver(url, base_path, jinja2_env=None, arguments=None):
+    arguments = arguments or {}
+    if base_path is None:
+        split = urlsplit(url)
+        path = pathlib.Path(split.path)
+    else:
+        path = base_path / url.lstrip('/')
+    is_yaml = any(path.suffix.startswith(ext) for ext in ('.yaml', '.yml'))
+    is_jinja2 = any(path.suffix.endswith(ext) for ext in ('.j2',))
+
+    if is_jinja2 and jinja2_env is not None:
+        swagger_string = jinja2_env.get_template(str(path.name)).render(**arguments)
+        return yaml.safe_load(swagger_string) if is_yaml else json.loads(swagger_string)
+    elif is_jinja2 and jinja2_env is None:
+        with path.open(mode='rb') as resolved_file:
+            contents = resolved_file.read()
+            try:
+                swagger_template = contents.decode()
+            except UnicodeDecodeError:
+                swagger_template = contents.decode('utf-8', 'replace')
+
+            swagger_string = jinja2.Template(swagger_template).render(**arguments)
+        return yaml.safe_load(swagger_string) if is_yaml else json.loads(swagger_string)
+    else:
+        with path.open(mode='rb') as resolved_file:
+            return yaml.safe_load(resolved_file) if is_yaml else json.load(resolved_file)
+
+
+def get_reference_resolvers(base_path, jinja2_env=None, arguments=None):
+    base_path = str(base_path) if base_path is not None else None
+    return {
+        '': lambda url: file_resolver(url=url, base_path=base_path, jinja2_env=jinja2_env, arguments=arguments),
+        'file': lambda url: file_resolver(url=url, base_path=None),
+    }
+
+
+def load_spec_string_from_file(arguments, specification, jinja2_env=None):
+    arguments = arguments or {}
+
+    if jinja2_env is None:
+        with specification.open(mode='rb') as swagger_yaml:
+            contents = swagger_yaml.read()
+            try:
+                swagger_template = contents.decode()
+            except UnicodeDecodeError:
+                swagger_template = contents.decode('utf-8', 'replace')
+
+            return jinja2.Template(swagger_template).render(**arguments)
+    else:
+        return jinja2_env.get_template(str(specification.name)).render(**arguments)
+
+
+def load_spec_from_file(arguments, specification, jinja2_env=None):
+    swagger_string = load_spec_string_from_file(arguments, specification, jinja2_env)
+    return yaml.safe_load(swagger_string)  # type: dict
+
+
+def validate_spec(spec, specification_dir=None, jinja2_env=None, arguments=None):
+    return _validate_spec(spec, http_handlers=get_reference_resolvers(specification_dir, jinja2_env, arguments))
+
+
+def compatibility_layer(spec):
+    """Make specs compatible with older versions of Connexion."""
+    if not isinstance(spec, dict):
+        return spec
+
+    # Make all response codes be string
+    for path_name, methods_available in spec.get('paths', {}).items():
+        for method_name, method_def in methods_available.items():
+            if (method_name == 'parameters' or not isinstance(
+                    method_def, dict)):
+                continue
+
+            response_definitions = {}
+            for response_code, response_def in method_def.get(
+                    'responses', {}).items():
+                response_definitions[str(response_code)] = response_def
+
+            method_def['responses'] = response_definitions
+    return spec


### PR DESCRIPTION
Fixes #254 .

This breaks almost all tests, most probably because this change affects the way definitions are loaded and the Swagger spec file is loaded.

It's still work in progress, and any feedback or help is welcome. It's "works on my machine ™️" quality till now.

Changes proposed in this pull request:

 - Use a jinja2 environment when rendering the YAML swagger spec to allow to include other jinja2 files in the template (including macros, etc.).
 - Resolve JSON references, and render those too using jinja2 when applicable (based on file extension)
 - Use `jsonschema`'s `RefResolver` to load all definitions (WIP)
