### PR TITLE
Fix example enforcedefaults

### DIFF
--- a/examples/enforcedefaults/enforcedefaults.py
+++ b/examples/enforcedefaults/enforcedefaults.py
@@ -43,6 +43,6 @@ validator_map = {
 
 if __name__ == '__main__':
     app = connexion.FlaskApp(
-        __name__, port=8080, specification_dir='.', validator_map=validator_map)
+        __name__, specification_dir='.', validator_map=validator_map)
     app.add_api('enforcedefaults-api.yaml')
-    app.run()
+    app.run(port=8080)


### PR DESCRIPTION
Moved port setting to `run` input.

As this was it would raise an error:
`Exception: Server 8080 not recognized`