### PR TITLE
Use Authorization headers for verifying token info

### DIFF
--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -97,7 +97,7 @@ class FlaskApp(AbstractApp):
                 import tornado.wsgi
                 import tornado.httpserver
                 import tornado.ioloop
-            except:
+            except ImportError:
                 raise Exception('tornado library not installed')
             wsgi_container = tornado.wsgi.WSGIContainer(self.app)
             http_server = tornado.httpserver.HTTPServer(wsgi_container, **options)
@@ -107,7 +107,7 @@ class FlaskApp(AbstractApp):
         elif self.server == 'gevent':
             try:
                 import gevent.wsgi
-            except:
+            except ImportError:
                 raise Exception('gevent library not installed')
             http_server = gevent.wsgi.WSGIServer((self.host, self.port), self.app, **options)
             logger.info('Listening on %s:%s..', self.host, self.port)

--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -16,12 +16,12 @@ def validate_wsgi_server_requirements(ctx, param, value):
     if value == 'gevent':
         try:
             import gevent  # NOQA
-        except:
+        except ImportError:
             fatal_error('gevent library is not installed')
     elif value == 'tornado':
         try:
             import tornado  # NOQA
-        except:
+        except ImportError:
             fatal_error('tornado library is not installed')
 
 

--- a/connexion/decorators/security.py
+++ b/connexion/decorators/security.py
@@ -63,7 +63,7 @@ def verify_oauth(token_info_url, allowed_scopes, function):
             except ValueError:
                 raise OAuthProblem(description='Invalid authorization header')
             logger.debug("... Getting token from %s", token_info_url)
-            token_request = session.get(token_info_url, params={'access_token': token}, timeout=5)
+            token_request = session.get(token_info_url, headers={'Authorization': 'Bearer {}'.format(token)}, timeout=5)
             logger.debug("... Token info (%d): %s", token_request.status_code, token_request.text)
             if not token_request.ok:
                 raise OAuthResponseProblem(

--- a/examples/oauth2/mock_tokeninfo.py
+++ b/examples/oauth2/mock_tokeninfo.py
@@ -4,17 +4,28 @@ Mock OAuth2 token info
 '''
 
 import connexion
+from connexion import request
 
 # our hardcoded mock "Bearer" access tokens
-TOKENS = {'123': 'jdoe',
-          '456': 'rms'}
+TOKENS = {
+    '123': 'jdoe',
+    '456': 'rms'
+}
 
 
-def get_tokeninfo(access_token: str) -> dict:
+def get_tokeninfo() -> dict:
+    try:
+        _, access_token = request.headers['Authorization'].split()
+    except Exception:
+        access_token = ''
+
     uid = TOKENS.get(access_token)
+
     if not uid:
         return 'No such token', 401
+
     return {'uid': uid, 'scope': ['uid']}
+
 
 if __name__ == '__main__':
     app = connexion.FlaskApp(__name__)

--- a/examples/oauth2/mock_tokeninfo.yaml
+++ b/examples/oauth2/mock_tokeninfo.yaml
@@ -9,11 +9,6 @@ paths:
     get:
       summary: OAuth2 token info
       operationId: mock_tokeninfo.get_tokeninfo
-      parameters:
-        - name: access_token
-          in: query
-          type: string
-          required: true
       responses:
         200:
           description: Token info object

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,14 +32,15 @@ class FakeResponse(object):
 
 @pytest.fixture
 def oauth_requests(monkeypatch):
-    def fake_get(url, params=None, timeout=None):
+    def fake_get(url, params=None, headers=None, timeout=None):
         """
         :type url: str
         :type params: dict| None
         """
         params = params or {}
+        headers = headers or {}
         if url == "https://oauth.example/token_info":
-            token = params['access_token']
+            token = params.get('access_token') or headers.get('Authorization', 'invalid').split()[-1]
             if token in ["100", "has_myscope"]:
                 return FakeResponse(200, '{"uid": "test-user", "scope": ["myscope"]}')
             if token in ["200", "has_wrongscope"]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,10 +37,9 @@ def oauth_requests(monkeypatch):
         :type url: str
         :type params: dict| None
         """
-        params = params or {}
         headers = headers or {}
         if url == "https://oauth.example/token_info":
-            token = params.get('access_token') or headers.get('Authorization', 'invalid').split()[-1]
+            token = headers.get('Authorization', 'invalid').split()[-1]
             if token in ["100", "has_myscope"]:
                 return FakeResponse(200, '{"uid": "test-user", "scope": ["myscope"]}')
             if token in ["200", "has_wrongscope"]:


### PR DESCRIPTION
Fixes #541 

Changes proposed in this pull request:

 - Change token info verification to use Authorization headers rather than url params.

Note: Not sure if url params is a requirement, left it in the test case fixture, but could be removed if Authorization headers would suffice.