### PR TITLE
Add for support relative paths in schema refs

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -78,10 +78,14 @@ class AbstractAPI(object):
                             'swagger_url': self.options.openapi_console_ui_path,
                             'auth_all_paths': auth_all_paths})
 
+        # File url for resolving local refs
+        specification_file_url = ''
+
         if isinstance(specification, dict):
             self.specification = specification
         else:
             specification_path = pathlib.Path(specification)
+            specification_file_url = str(specification_path.resolve().as_uri())
             self.specification = self.load_spec_from_file(arguments, specification_path)
 
         self.specification = compatibility_layer(self.specification)
@@ -89,7 +93,7 @@ class AbstractAPI(object):
 
         # Avoid validator having ability to modify specification
         spec = copy.deepcopy(self.specification)
-        validate_spec(spec)
+        validate_spec(spec, specification_file_url)
 
         # https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#fixed-fields
         # If base_path is not on provided then we try to read it from the swagger.yaml or use / by default

--- a/tests/api/test_schema.py
+++ b/tests/api/test_schema.py
@@ -1,4 +1,5 @@
 import json
+
 import pytest
 
 

--- a/tests/api/test_schema.py
+++ b/tests/api/test_schema.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 
 
 def test_schema(schema_app):
@@ -186,6 +187,18 @@ def test_schema_recursive(schema_app):
     right_type = app_client.post('/v1.0/test_schema_recursive', headers=headers,
                                  data=json.dumps(valid_object))  # type: flask.Response
     assert right_type.status_code == 200
+
+
+@pytest.mark.skip(reason='Skipped until relative ref resolution is fully implemented')
+def test_schema_relative_ref(schema_app):
+    app_client = schema_app.app.test_client()
+    headers = {'Content-type': 'application/json'}
+
+    good_request = app_client.get('/v1.0/test_schema_relative_ref', headers=headers,
+                                  query_string={'image_version': 'version'})
+    # Currently returns a 500 error since Operation.resolve_reference expects
+    # a ref in the same file
+    assert good_request.status_code == 200
 
 
 def test_schema_format(schema_app):

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -194,6 +194,10 @@ def schema_recursive():
     return ''
 
 
+def schema_relative_ref(image_version=None):
+    return {'image_version': image_version}
+
+
 def schema_format():
     return ''
 

--- a/tests/fixtures/different_schemas/definitions.json
+++ b/tests/fixtures/different_schemas/definitions.json
@@ -1,0 +1,12 @@
+{
+  "new_stack": {
+    "type": "object",
+    "properties": {
+      "image_version": {
+        "type": "string",
+        "description": "Docker image version to deploy"
+      }
+    },
+    "required": ["image_version"]
+  }
+}

--- a/tests/fixtures/different_schemas/definitions.yaml
+++ b/tests/fixtures/different_schemas/definitions.yaml
@@ -1,0 +1,8 @@
+new_stack:
+  type: object
+  properties:
+    image_version:
+      type: string
+      description: Docker image version to deploy
+  required:
+    - image_version

--- a/tests/fixtures/different_schemas/definitions.yaml
+++ b/tests/fixtures/different_schemas/definitions.yaml
@@ -1,8 +1,0 @@
-new_stack:
-  type: object
-  properties:
-    image_version:
-      type: string
-      description: Docker image version to deploy
-  required:
-    - image_version

--- a/tests/fixtures/different_schemas/swagger.yaml
+++ b/tests/fixtures/different_schemas/swagger.yaml
@@ -233,6 +233,24 @@ paths:
           schema:
             type: string
 
+  /test_schema_relative_ref:
+    get:
+      summary: Returns the image version
+      description: Returns the image version
+      operationId: fakeapi.hello.schema_relative_ref
+      parameters:
+        - name: image_version
+          required: true
+          in: query
+          type: string
+      produces:
+        - application/json
+      responses:
+        200:
+          description: goodbye response
+          schema:
+            $ref: 'definitions.yaml#/new_stack'
+
   /test_schema_format:
     post:
       summary: Returns empty response

--- a/tests/fixtures/different_schemas/swagger.yaml
+++ b/tests/fixtures/different_schemas/swagger.yaml
@@ -249,7 +249,7 @@ paths:
         200:
           description: goodbye response
           schema:
-            $ref: 'definitions.yaml#/new_stack'
+            $ref: 'definitions.json#/new_stack'
 
   /test_schema_format:
     post:


### PR DESCRIPTION
Refs #461
Refs #254 

Fix to allow the json schema validation to handle relative refs by passing in the spec file path. This will only work when passing a file path to `add_api` and not a `dict`.

**Note:** This will only work with response validation disabled. There are more changes required to support
local refs elsewhere in the code.