### PR TITLE
refactor catch-all exceptions

### DIFF
--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -97,7 +97,7 @@ class FlaskApp(AbstractApp):
                 import tornado.wsgi
                 import tornado.httpserver
                 import tornado.ioloop
-            except:
+            except ImportError:
                 raise Exception('tornado library not installed')
             wsgi_container = tornado.wsgi.WSGIContainer(self.app)
             http_server = tornado.httpserver.HTTPServer(wsgi_container, **options)
@@ -107,7 +107,7 @@ class FlaskApp(AbstractApp):
         elif self.server == 'gevent':
             try:
                 import gevent.wsgi
-            except:
+            except ImportError:
                 raise Exception('gevent library not installed')
             http_server = gevent.wsgi.WSGIServer((self.host, self.port), self.app, **options)
             logger.info('Listening on %s:%s..', self.host, self.port)

--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -16,12 +16,12 @@ def validate_wsgi_server_requirements(ctx, param, value):
     if value == 'gevent':
         try:
             import gevent  # NOQA
-        except:
+        except ImportError:
             fatal_error('gevent library is not installed')
     elif value == 'tornado':
         try:
             import tornado  # NOQA
-        except:
+        except ImportError:
             fatal_error('tornado library is not installed')
 
 


### PR DESCRIPTION
The flake8 checks were failing for py3.5 due to a couple of catch-all
exceptions when importing tornado and gevent libraries. Refactored to
catch the `ImportError`.