### PR TITLE
Allow token_info response to use 'scopes' key

### DIFF
--- a/connexion/decorators/security.py
+++ b/connexion/decorators/security.py
@@ -73,10 +73,11 @@ def validate_token_info(token_info, allowed_scopes):
     :type token_info: dict
     :return: None
     """
-    if isinstance(token_info['scope'], list):
-        user_scopes = set(token_info['scope'])
+    scope = token_info.get('scope') or token_info.get('scopes')
+    if isinstance(scope, list):
+        user_scopes = set(scope)
     else:
-        user_scopes = set(token_info['scope'].split())
+        user_scopes = set(scope.split())
     logger.debug("... Scopes required: %s", allowed_scopes)
     logger.debug("... User scopes: %s", user_scopes)
     if not allowed_scopes <= user_scopes:

--- a/tests/api/test_secure_api.py
+++ b/tests/api/test_secure_api.py
@@ -111,3 +111,8 @@ def test_checking_that_client_token_has_all_necessary_scopes(
     headers = {"Authorization": "Bearer has_myscope_otherscope"}
     response = app_client.get('/v1.0/more-than-one-scope', headers=headers)  # type: flask.Response
     assert response.status_code == 200
+
+    # has all necessary scopes but under key 'scopes'
+    headers = {"Authorization": "Bearer has_scopes_in_scopes_with_s"}
+    response = app_client.get('/v1.0/more-than-one-scope', headers=headers)  # type: flask.Response
+    assert response.status_code == 200

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,8 @@ def oauth_requests(monkeypatch):
                 return FakeResponse(200, '{"uid": "test-user", "scope": ["myscope", "otherscope"]}')
             if token in ["300", "is_not_invalid"]:
                 return FakeResponse(404, '')
+            if token == "has_scopes_in_scopes_with_s":
+                return FakeResponse(200, '{"uid": "test-user", "scopes": ["myscope", "otherscope"]}')
         return url
 
     monkeypatch.setattr('connexion.decorators.security.session.get', fake_get)


### PR DESCRIPTION
Some oauth libraries use the key 'scopes' instead of 'scope' in the token info response.

https://github.com/doorkeeper-gem/doorkeeper/wiki/API-endpoint-descriptions-and-examples

Changes proposed in this pull request:
 - Allow token info responses that use 'scopes' instead of 'scope'
