### PR TITLE
query parameters only explode if collectionFormat is 'multi'

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -111,13 +111,12 @@ def parameter_to_arg(parameters, consumes, function, pythonic_params=False):
             for k, v in request.query.to_dict(flat=False).items():
                 k = sanitize_param(k)
                 query_param = query_types.get(k, None)
-                if query_param is not None and query_param["type"] == "array":
-                    if query_param.get("collectionFormat", None) == "pipes":
-                        request_query[k] = "|".join(v)
-                    else:
-                        request_query[k] = ",".join(v)
+                if (query_param is not None
+                        and query_param["type"] == "array"
+                        and query_param.get("collectionFormat") == "multi"):
+                    request_query[k] = ",".join(v)
                 else:
-                    request_query[k] = v[0]
+                    request_query[k] = v[-1]
         except AttributeError:
             request_query = {sanitize_param(k): v for k, v in request.query.items()}
         return request_query

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -57,11 +57,15 @@ def test_array_query_param(simple_app):
     url = '/v1.0/test_array_csv_query_param?items=A&items=B&items=C&items=D,E,F'
     response = app_client.get(url, headers=headers)
     array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [str] multi array with csv format
-    assert array_response == ['A', 'B', 'C', 'D', 'E', 'F']
+    assert array_response == ['D', 'E', 'F']
     url = '/v1.0/test_array_pipes_query_param?items=4&items=5&items=6&items=7|8|9'
     response = app_client.get(url, headers=headers)
     array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [int] multi array with pipes format
-    assert array_response == [4, 5, 6, 7, 8, 9]
+    assert array_response == [7, 8, 9]
+    url = '/v1.0/test_array_multi_query_param?items=A&items=B&items=C&items=D'
+    response = app_client.get(url, headers=headers)
+    array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [str] multi array with multi format
+    assert array_response == ['A', 'B', 'C', 'D']
 
 
 def test_extra_query_param(simple_app):

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -210,6 +210,10 @@ def test_array_csv_query_param(items):
     return items
 
 
+def test_array_multi_query_param(items):
+    return items
+
+
 def test_array_pipes_query_param(items):
     return items
 

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -260,6 +260,22 @@ paths:
         200:
           description: OK
 
+  /test_array_multi_query_param:
+    get:
+      operationId: fakeapi.hello.test_array_multi_query_param
+      parameters:
+        - name: items
+          in: query
+          description: A multi array of items
+          required: true
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+      responses:
+        200:
+          description: OK
+
   /test_array_pipes_query_param:
     get:
       operationId: fakeapi.hello.test_array_pipes_query_param


### PR DESCRIPTION
Fixes #323 .
This changes the behavior from #500 to adhere to https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#fixed-fields-7

While there is no defined HTTP spec on this behavior (see https://stackoverflow.com/a/1746566), the openapi3 spec provides some insight on the intent of the swagger2 spec here:
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#style-values

> Form style parameters defined by RFC6570. This option replaces collectionFormat with a csv (when explode is false) or multi (when explode is true) value from OpenAPI 2.0.

Changes proposed in this pull request:
 - support for `collectionFormat: multi`
 - query parameters that are defined multiple times use the last (right-most) one, unless the collectionFormat is multi

for example, if collectionFormat == csv then
`https://myapi.com/api?items=a&items=b,c`
would result in `items = ["b", "c"]`

for more concrete examples, see the unit tests.

@lhannest may have some context that I'm missing. It might be a contentious change because it could potentially break users who are relying on this behavior.