### PR TITLE
Improve docstring for AbstractApp.add_api

### DIFF
--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -95,7 +95,7 @@ class AbstractApp(object):
         Adds an API to the application based on a swagger file or API dict
 
         :param specification: swagger file with the specification | specification dict
-        :type specification: pathlib.Path or dict
+        :type specification: pathlib.Path or str or dict
         :param base_path: base path where to add this api
         :type base_path: str | None
         :param arguments: api version specific arguments to replace on the specification


### PR DESCRIPTION
Changes proposed in this pull request:

 - Document that `specification` argument to `AbstractApp.add_api` can be a string
