### PR TITLE
Pass kwargs from RestyResolver to Resolver

### DIFF
--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -76,6 +76,15 @@ class RestyResolver(Resolver):
         """
         :param default_module_name: Default module name for operations
         :type default_module_name: str
+        :param \**kwargs:
+            Pass arguments to Resolver.__init__
+
+        :Keyword Arguments:
+            * *function_resolver* (``types.FunctionType``) --
+              Function that resolves functions using an operationId
+
+        :param kwargs: Keyword arguments to pass on to Resolver.__init__
+        :type kwargs: dict
         """
         Resolver.__init__(self, **kwargs)
         self.default_module_name = default_module_name

--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -72,12 +72,12 @@ class RestyResolver(Resolver):
     Resolves endpoint functions using REST semantics (unless overridden by specifying operationId)
     """
 
-    def __init__(self, default_module_name, collection_endpoint_name='search'):
+    def __init__(self, default_module_name, collection_endpoint_name='search', **kwargs):
         """
         :param default_module_name: Default module name for operations
         :type default_module_name: str
         """
-        Resolver.__init__(self)
+        Resolver.__init__(self, **kwargs)
         self.default_module_name = default_module_name
         self.collection_endpoint_name = collection_endpoint_name
 


### PR DESCRIPTION
Allows for `function_resolver` override

In my particular use case I choose to use a loaded python module. `RestyResolverEx` below is `RestyResolver` with my proposed change.

```python
class ModuleResolver(RestyResolverEx):
  def __init__(self, module, collection_endpoint_name='search'):
    """
    :param module: Default module name for operations
    :type module: any
    """
    RestyResolverEx.__init__(
      self,
      default_module_name=module.__name__,
      collection_endpoint_name=collection_endpoint_name,
      function_resolver=self.get_function_from_name,
    )
    self.module = module

  def get_function_from_name(self, function_name):
    """
    Tries to get function by fully qualified name (e.g. "mymodule.myobj.myfunc")
    :type function_name: str
    """
    if function_name is None:
      raise ValueError("Empty function name")
    function_name_parts = function_name.split('.')
    assert function_name_parts[0] == self.module.__name__
    return utils.deep_getattr(self.module, '.'.join(function_name_parts[1:]))
```



Changes proposed in this pull request:

 - add kwargs to RestyResolver constructor
 - pass to Resolver initialization
