### PR TITLE
RestyResolver for nested paths

### DIFF
--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -107,8 +107,11 @@ class RestyResolver(Resolver):
                 has_trailing_slash = True
             elif tail.startswith('{'):
                 tail_parameter = path_fragments.pop()
+        logger.debug('Has trailing slash: %s', has_trailing_slash)
+        logger.debug('Tail parameter: %s', tail_parameter)
 
         resource_names = [resource_name for resource_name in path_fragments if resource_name]
+        logger.debug('Resource names: %s', resource_names)
 
         def get_controller_name():
             x_router_controller = operation.operation.get('x-swagger-router-controller')
@@ -117,12 +120,17 @@ class RestyResolver(Resolver):
 
             if x_router_controller:
                 name = x_router_controller
+                logger.debug('Controller name from router controller: %s', x_router_controller)
 
             elif resource_names:
                 converted_resource_names = [
                     resource_name.replace('-', '_').strip('{}') for resource_name in resource_names
                 ]
                 name = '.'.join([name] + converted_resource_names)
+                logger.debug('Controller name from resource names: %s', name)
+
+            else:
+                logger.debug('Controller name from default module name: %s', name)
 
             return name
 
@@ -133,6 +141,7 @@ class RestyResolver(Resolver):
                 method == 'get' \
                 and resource_names \
                 and not (has_trailing_slash or tail_parameter)
+            logger.debug('Use "search" function: %s', is_collection_endpoint)
 
             return self.collection_endpoint_name if is_collection_endpoint else method
 

--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -71,7 +71,7 @@ class RestyResolver(Resolver):
     Resolves endpoint functions using REST semantics (unless overridden by specifying operationId)
     """
 
-    def __init__(self, default_module_name, collection_endpoint_name='search'):
+    def __init__(self, default_module_name, collection_endpoint_name='search', module_separator='.'):
         """
         :param default_module_name: Default module name for operations
         :type default_module_name: str
@@ -79,6 +79,7 @@ class RestyResolver(Resolver):
         Resolver.__init__(self)
         self.default_module_name = default_module_name
         self.collection_endpoint_name = collection_endpoint_name
+        self.module_separator = module_separator
 
     def resolve_operation_id(self, operation):
         """
@@ -126,7 +127,7 @@ class RestyResolver(Resolver):
                 converted_resource_names = [
                     resource_name.replace('-', '_').strip('{}') for resource_name in resource_names
                 ]
-                name = '.'.join([name] + converted_resource_names)
+                name = self.module_separator.join([name] + converted_resource_names)
                 logger.debug('Controller name from resource names: %s', name)
 
             else:

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,5 +1,7 @@
-import connexion.apps
+import mock
 import pytest
+
+import connexion.apps
 from connexion.exceptions import ResolverError
 from connexion.operation import Operation
 from connexion.resolver import Resolver, RestyResolver
@@ -235,3 +237,31 @@ def test_resty_resolve_with_default_module_name_will_resolve_resource_root_post_
                           parameter_definitions=PARAMETER_DEFINITIONS,
                           resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.post'
+
+
+@pytest.mark.parametrize('function,path', [
+    ('fakeapi.get', '/'),
+    ('fakeapi.nested.search', '/nested'),
+    ('fakeapi.nested.get', '/nested/'),
+    ('fakeapi.nested.game.search', '/nested/game'),
+    ('fakeapi.nested.game.get', '/nested/game/'),
+    ('fakeapi.nested.game.get', '/nested/game/{name}'),
+    ('fakeapi.nested.game.name.brand.search', '/nested/game/{name}/brand'),
+    ('fakeapi.nested.game.name.brand.get', '/nested/game/{name}/brand/'),
+])
+def test_resty_resolve_with_nested_paths(function, path):
+    resolver = RestyResolver('fakeapi')
+    resolver.function_resolver = mock.MagicMock()
+    operation = Operation(api=None,
+                          method='GET',
+                          path=path,
+                          path_parameters=[],
+                          operation={},
+                          app_produces=['application/json'],
+                          app_consumes=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=resolver)
+    assert operation.operation_id == function

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -265,3 +265,31 @@ def test_resty_resolve_with_nested_paths(function, path):
                           parameter_definitions=PARAMETER_DEFINITIONS,
                           resolver=resolver)
     assert operation.operation_id == function
+
+
+@pytest.mark.parametrize('function,path', [
+    ('fakeapi.get', '/'),
+    ('fakeapi_nested.search', '/nested'),
+    ('fakeapi_nested.get', '/nested/'),
+    ('fakeapi_nested_game.search', '/nested/game'),
+    ('fakeapi_nested_game.get', '/nested/game/'),
+    ('fakeapi_nested_game.get', '/nested/game/{name}'),
+    ('fakeapi_nested_game_name_brand.search', '/nested/game/{name}/brand'),
+    ('fakeapi_nested_game_name_brand.get', '/nested/game/{name}/brand/'),
+])
+def test_resty_resolve_with_nested_paths_and_module_separator(function, path):
+    resolver = RestyResolver('fakeapi', module_separator='_')
+    resolver.function_resolver = mock.MagicMock()
+    operation = Operation(api=None,
+                          method='GET',
+                          path=path,
+                          path_parameters=[],
+                          operation={},
+                          app_produces=['application/json'],
+                          app_consumes=['application/json'],
+                          app_security=[],
+                          security_definitions={},
+                          definitions={},
+                          parameter_definitions=PARAMETER_DEFINITIONS,
+                          resolver=resolver)
+    assert operation.operation_id == function


### PR DESCRIPTION
Fixes #206.

There has been some discussion about fixing `RestyResolver` to work with nested paths. I've bumped into this issue multiple times trying to create a new API with Connexion.

After looking over the regex, it seems that parsing would become extremely complicated. Going the more basic route, I feel `str.split()` can cover most of the situations and using conditionals can be more maintainable and easier to read for newcomers.

Hopefully the new test cases can clearly demonstrate what is handled by this code change. Do let me know if this is not the intended behaviour or if something must be changed. Feel free to take whichever parts of the code or test cases that would be beneficial to the project.

Changes proposed in this pull request:

 - Support nested paths
 - Define a custom module name separator