### PR TITLE
fix on utils.has_coroutine function

### DIFF
--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -148,7 +148,6 @@ class Jsonifier(object):
 def has_coroutine(function, api=None):
     """
     Checks if function is a couroutine.
- 
     If ``function`` is a decorator (has a ``__wrapped__`` attribute)
     this function will also look at the wrapped function.
     """

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -148,12 +148,20 @@ class Jsonifier(object):
 def has_coroutine(function, api=None):
     if six.PY3:  # pragma: 2.7 no cover
         import asyncio
+
+        def iscorofunc(func):
+            iscorofunc = asyncio.iscoroutinefunction(func)
+            while not iscorofunc and hasattr(func, '__wrapped__'):
+                func = func.__wrapped__
+                iscorofunc = asyncio.iscoroutinefunction(func)
+            return iscorofunc
+
         if api is None:
-            return asyncio.iscoroutinefunction(function)
+            return iscorofunc(function)
 
         else:
             return any(
-                asyncio.iscoroutinefunction(func) for func in (
+                iscorofunc(func) for func in (
                     function, api.get_request, api.get_response
                 )
             )

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -146,6 +146,12 @@ class Jsonifier(object):
 
 
 def has_coroutine(function, api=None):
+    """
+    Checks if function is a couroutine.
+ 
+    If ``function`` is a decorator (has a ``__wrapped__`` attribute)
+    this function will also look at the wrapped function.
+    """
     if six.PY3:  # pragma: 2.7 no cover
         import asyncio
 
@@ -166,4 +172,5 @@ def has_coroutine(function, api=None):
                 )
             )
     else:  # pragma: 3 no cover
+        # there's no asyncio in python 2
         return False

--- a/tests/aiohttp/test_aiohttp_simple_api.py
+++ b/tests/aiohttp/test_aiohttp_simple_api.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 
 import aiohttp.web
 import pytest
@@ -221,3 +222,21 @@ def test_access_request_context(test_client, aiohttp_app):
     app_client = yield from test_client(aiohttp_app.app)
     resp = yield from app_client.post('/v1.0/aiohttp_access_request_context')
     assert resp.status == 204
+
+
+if sys.version_info[0:2] >= (3, 5):
+    @pytest.fixture
+    def aiohttp_app_async_def(aiohttp_api_spec_dir):
+        app = AioHttpApp(__name__, port=5001,
+                         specification_dir=aiohttp_api_spec_dir,
+                         debug=True)
+        app.add_api('swagger_simple_async_def.yaml', validate_responses=True)
+        return app
+
+
+    @asyncio.coroutine
+    def test_validate_responses_async_def(aiohttp_app_async_def, test_client):
+        app_client = yield from test_client(aiohttp_app_async_def.app)
+        get_bye = yield from app_client.get('/v1.0/aiohttp_validate_responses')
+        assert get_bye.status == 200
+        assert (yield from get_bye.read()) == b'{"validate": true}'

--- a/tests/fakeapi/aiohttp_handlers_async_def.py
+++ b/tests/fakeapi/aiohttp_handlers_async_def.py
@@ -1,0 +1,5 @@
+from connexion.lifecycle import ConnexionResponse
+
+
+async def aiohttp_validate_responses():
+    return ConnexionResponse(body=b'{"validate": true}')

--- a/tests/fixtures/aiohttp/swagger_simple_async_def.yaml
+++ b/tests/fixtures/aiohttp/swagger_simple_async_def.yaml
@@ -1,0 +1,21 @@
+swagger: "2.0"
+
+info:
+  title: "{{title}}"
+  version: "1.0"
+
+basePath: /v1.0
+
+paths:
+  /aiohttp_validate_responses:
+    get:
+      summary: Return a bytes response
+      description: Test returning a bytes response
+      operationId: fakeapi.aiohttp_handlers_async_def.aiohttp_validate_responses
+      produces:
+        - application/json
+      responses:
+        200:
+          description: json response
+          schema:
+            type: object


### PR DESCRIPTION
   Fixed coroutinefunction verification when has async def.
   It is necessary because there's no @asyncio.coroutine decorator to validate

Fixes # .



Changes proposed in this pull request:

 -
 -
 -
