### PR TITLE
Add capability to pass framework's request context to handler functions

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -41,7 +41,8 @@ class AbstractAPI(object):
     def __init__(self, specification, base_path=None, arguments=None,
                  validate_responses=False, strict_validation=False, resolver=None,
                  auth_all_paths=False, debug=False, resolver_error_handler=None,
-                 validator_map=None, pythonic_params=False, options=None, **old_style_options):
+                 validator_map=None, pythonic_params=False, options=None, pass_context_arg_name=None,
+                 **old_style_options):
         """
         :type specification: pathlib.Path | dict
         :type base_path: str | None
@@ -61,6 +62,9 @@ class AbstractAPI(object):
         :type pythonic_params: bool
         :param options: New style options dictionary.
         :type options: dict | None
+        :param pass_context_arg_name: If not None URL request handling functions with an argument matching this name
+        will be passed the framework's request context.
+        :type pass_context_arg_name: str | None
         :param old_style_options: Old style options support for backward compatibility. Preference is
                                   what is defined in `options` parameter.
         """
@@ -129,6 +133,9 @@ class AbstractAPI(object):
 
         logger.debug('Pythonic params: %s', str(pythonic_params))
         self.pythonic_params = pythonic_params
+
+        logger.debug('pass_context_arg_name: %s', pass_context_arg_name)
+        self.pass_context_arg_name = pass_context_arg_name
 
         if self.options.openapi_spec_available:
             self.add_swagger_json()
@@ -204,7 +211,8 @@ class AbstractAPI(object):
                               strict_validation=self.strict_validation,
                               resolver=self.resolver,
                               pythonic_params=self.pythonic_params,
-                              uri_parser_class=self.options.uri_parser_class)
+                              uri_parser_class=self.options.uri_parser_class,
+                              pass_context_arg_name=self.pass_context_arg_name)
         self._add_operation_internal(method, path, operation)
 
     @abc.abstractmethod

--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -180,7 +180,8 @@ class AioHttpApi(AbstractAPI):
                                 headers=headers,
                                 body=body,
                                 json_getter=lambda: cls.jsonifier.loads(body),
-                                files={})
+                                files={},
+                                context=req)
 
     @classmethod
     @asyncio.coroutine

--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -90,7 +90,7 @@ class AbstractApp(object):
     def add_api(self, specification, base_path=None, arguments=None,
                 auth_all_paths=None, validate_responses=False,
                 strict_validation=False, resolver=Resolver(), resolver_error=None,
-                pythonic_params=False, options=None, **old_style_options):
+                pythonic_params=False, options=None, pass_context_arg_name=None, **old_style_options):
         """
         Adds an API to the application based on a swagger file or API dict
 
@@ -115,6 +115,8 @@ class AbstractApp(object):
         :type pythonic_params: bool
         :param options: New style options dictionary.
         :type options: dict | None
+        :param pass_context_arg_name: Name of argument in handler functions to pass request context to.
+        :type pass_context_arg_name: str | None
         :param old_style_options: Old style options support for backward compatibility. Preference is
                                   what is defined in `options` parameter.
         :type old_style_options: dict
@@ -156,6 +158,7 @@ class AbstractApp(object):
                            debug=self.debug,
                            validator_map=self.validator_map,
                            pythonic_params=pythonic_params,
+                           pass_context_arg_name=pass_context_arg_name,
                            options=api_options.as_dict())
         return api
 

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -81,7 +81,7 @@ def snake_and_shadow(name):
     return snake
 
 
-def parameter_to_arg(parameters, consumes, function, pythonic_params=False):
+def parameter_to_arg(parameters, consumes, function, pythonic_params=False, pass_context_arg_name=None):
     """
     Pass query and body parameters as keyword arguments to handler function.
 
@@ -91,10 +91,13 @@ def parameter_to_arg(parameters, consumes, function, pythonic_params=False):
     :param consumes: The list of content types the operation consumes
     :type consumes: list
     :param function: The handler function for the REST endpoint.
+    :type function: function|None
     :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended to
     any shadowed built-ins
     :type pythonic_params: bool
-    :type function: function|None
+    :param pass_context_arg_name: If not None URL and function has an argument matching this name, the framework's
+    request context will be passed as that argument.
+    :type pass_context_arg_name: str|None
     """
     def sanitize_param(name):
         if name and pythonic_params:
@@ -196,6 +199,11 @@ def parameter_to_arg(parameters, consumes, function, pythonic_params=False):
                 kwargs[key] = value
             else:
                 logger.debug("Context parameter '%s' not in function arguments", key)
+
+        # attempt to provide the request context to the function
+        if pass_context_arg_name and (has_kwargs or pass_context_arg_name in arguments):
+            kwargs[pass_context_arg_name] = request.context
+
         return function(**kwargs)
 
     return wrapper

--- a/connexion/lifecycle.py
+++ b/connexion/lifecycle.py
@@ -20,7 +20,7 @@ class ConnexionRequest(object):
         self.body = body
         self.json_getter = json_getter
         self.files = files
-        self.context = context or {}
+        self.context = context if context is not None else {}
 
     @property
     def json(self):

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -142,7 +142,8 @@ class Operation(SecureOperation):
                  path_parameters=None, app_security=None, security_definitions=None,
                  definitions=None, parameter_definitions=None, response_definitions=None,
                  validate_responses=False, strict_validation=False, randomize_endpoint=None,
-                 validator_map=None, pythonic_params=False, uri_parser_class=None):
+                 validator_map=None, pythonic_params=False, uri_parser_class=None,
+                 pass_context_arg_name=None):
         """
         This class uses the OperationID identify the module and function that will handle the operation
 
@@ -191,6 +192,9 @@ class Operation(SecureOperation):
         :type pythonic_params: bool
         :param uri_parser_class: A URI parser class that inherits from AbstractURIParser
         :type uri_parser_class: AbstractURIParser
+        :param pass_context_arg_name: If not None will try to inject the request context to the function using this
+        name.
+        :type pass_context_arg_name: str|None
         """
 
         self.api = api
@@ -213,6 +217,7 @@ class Operation(SecureOperation):
         self.randomize_endpoint = randomize_endpoint
         self.pythonic_params = pythonic_params
         self.uri_parser_class = uri_parser_class or AlwaysMultiURIParser
+        self.pass_context_arg_name = pass_context_arg_name
 
         # todo support definition references
         # todo support references to application level parameters
@@ -377,7 +382,8 @@ class Operation(SecureOperation):
         """
 
         function = parameter_to_arg(
-            self.parameters, self.consumes, self.__undecorated_function, self.pythonic_params)
+            self.parameters, self.consumes, self.__undecorated_function, self.pythonic_params,
+            self.pass_context_arg_name)
         function = self._request_begin_lifecycle_decorator(function)
 
         if self.validate_responses:

--- a/tests/aiohttp/test_aiohttp_simple_api.py
+++ b/tests/aiohttp/test_aiohttp_simple_api.py
@@ -16,7 +16,7 @@ def aiohttp_app(aiohttp_api_spec_dir):
     app = AioHttpApp(__name__, port=5001,
                      specification_dir=aiohttp_api_spec_dir,
                      debug=True)
-    app.add_api('swagger_simple.yaml', validate_responses=True)
+    app.add_api('swagger_simple.yaml', validate_responses=True, pass_context_arg_name='request_ctx')
     return app
 
 
@@ -214,3 +214,10 @@ def test_create_user(test_client, aiohttp_app):
     user = {'name': 'Maksim'}
     resp = yield from app_client.post('/v1.0/users', json=user, headers={'Content-type': 'application/json'})
     assert resp.status == 201
+
+
+@asyncio.coroutine
+def test_access_request_context(test_client, aiohttp_app):
+    app_client = yield from test_client(aiohttp_app.app)
+    resp = yield from app_client.post('/v1.0/aiohttp_access_request_context')
+    assert resp.status == 204

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -5,7 +5,7 @@ from mock import MagicMock
 from testfixtures import LogCapture
 
 
-def test_injection(monkeypatch):
+def test_injection():
     request = MagicMock(name='request', path_params={'p1': '123'})
     request.args = {}
     request.headers = {}
@@ -19,6 +19,9 @@ def test_injection(monkeypatch):
     parameter_to_arg({}, [], handler)(request)
 
     func.assert_called_with(p1='123')
+
+    parameter_to_arg({}, [], handler, pass_context_arg_name='framework_request_ctx')(request)
+    func.assert_called_with(p1='123', framework_request_ctx=request.context)
 
 
 def test_query_sanitazion(query_sanitazion):

--- a/tests/fakeapi/aiohttp_handlers.py
+++ b/tests/fakeapi/aiohttp_handlers.py
@@ -2,6 +2,7 @@
 import asyncio
 
 import aiohttp
+from aiohttp.web import Request
 from aiohttp.web import Response as AioHttpResponse
 from connexion.lifecycle import ConnexionResponse
 
@@ -35,6 +36,13 @@ def aiohttp_validate_responses():
 def aiohttp_post_greeting(name, **kwargs):
     data = {'greeting': 'Hello {name}'.format(name=name)}
     return ConnexionResponse(body=data)
+
+
+@asyncio.coroutine
+def aiohttp_access_request_context(request_ctx):
+    assert request_ctx is not None
+    assert isinstance(request_ctx, aiohttp.web.Request)
+    return ConnexionResponse(status_code=204)
 
 
 USERS = [

--- a/tests/fixtures/aiohttp/swagger_simple.yaml
+++ b/tests/fixtures/aiohttp/swagger_simple.yaml
@@ -76,6 +76,15 @@ paths:
           schema:
             type: object
 
+  /aiohttp_access_request_context:
+    post:
+      summary: Test request context access
+      description: Test request context access in handlers.
+      operationId: fakeapi.aiohttp_handlers.aiohttp_access_request_context
+      responses:
+        204:
+          description: success no content.
+
   /users:
     get:
       summary: Test get users


### PR DESCRIPTION
Fixes #603



Changes proposed in this pull request:

 - Add new argument (currently named `pass_context_arg_name` but could probably use a nicer name) to `connexion.apps.abstract.AbstractApp.add_api` to inject the framework's request context to the handler functions.
