### PR TITLE
Correct validator response on bad JSON

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -103,14 +103,14 @@ class RequestBodyValidator(object):
 
                 if data is None and len(request.body) > 0 and not self.is_null_value_valid:
                     try:
-                        ctype_is_json = is_json_mimetype(request.headers.get("Content-Type", "") )
-                    except:
+                        ctype_is_json = is_json_mimetype(request.headers.get("Content-Type", ""))
+                    except ValueError:
                         ctype_is_json = False
-                        
+
                     if ctype_is_json:
                         # Content-Type is json but actual body was not parsed
-                        return problem(400, 
-                                       "Bad Request", 
+                        return problem(400,
+                                       "Bad Request",
                                        "Request body is not valid JSON"
                                        )
                     else:

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -10,7 +10,7 @@ from werkzeug import FileStorage
 
 from ..exceptions import ExtraParameterProblem
 from ..problem import problem
-from ..utils import all_json, boolean, is_null, is_nullable, is_json_mimetype
+from ..utils import all_json, boolean, is_json_mimetype, is_null, is_nullable
 
 logger = logging.getLogger('connexion.decorators.validation')
 

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -235,6 +235,14 @@ def test_post_wrong_content_type(simple_app):
     assert resp.status_code == 415
 
 
+    resp = app_client.post('/v1.0/post_wrong_content_type',
+                           content_type="application/json",
+                           data="not a valid json"
+                           )
+    assert resp.status_code == 400, \
+        "Should return 400 when Content-Type is json but content not parsable"
+
+
 def test_get_unicode_response(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/get_unicode_response')


### PR DESCRIPTION
Right now request validator returns 415 Unsupported Media Type "Invalid Content-type (application/json), expected JSON data" when Content-Type is set to "application/json" (correctly) but the payload itself is not valid JSON. This error message is misleading into thinking that there is something wrong with Content-Type header (but it's not)

This patch fixes it by separating two cases:
 - Request content-type is not JSON, in this case old behaviour is retained
 - Request content-type is JSON but payload cannot be parsed into a valid JSON, in this case 400 Bad Request "Request body is not valid JSON" is returned.
