### PR TITLE
Add OpenAPI 3 test fixtures

### DIFF
--- a/tests/fixtures/aiohttp/openapi_empty_base_path.yaml
+++ b/tests/fixtures/aiohttp/openapi_empty_base_path.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+servers:
+  - url: /
+info:
+  title: '{{title}}'
+  version: '1.0'
+paths:
+  '/bye/{name}':
+    get:
+      summary: Generate goodbye
+      description: Generates a goodbye message.
+      operationId: fakeapi.aiohttp_handlers.get_bye
+      responses:
+        '200':
+          description: goodbye response
+          content:
+            text/plain:
+              schema:
+                type: string
+        default:
+          description: unexpected error
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to say bye.
+          required: true
+          schema:
+            type: string

--- a/tests/fixtures/aiohttp/openapi_secure.yaml
+++ b/tests/fixtures/aiohttp/openapi_secure.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.0
+servers:
+  - url: /v1.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+security:
+  - oauth:
+      - myscope
+paths:
+  '/greeting/{name}':
+    post:
+      summary: Generate greeting
+      description: Generates a greeting message.
+      operationId: fakeapi.aiohttp_handlers.aiohttp_post_greeting
+      responses:
+        '200':
+          description: greeting response
+          content:
+            '*/*':
+              schema:
+                type: object
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to greet.
+          required: true
+          schema:
+            type: string
+components:
+  securitySchemes:
+    oauth:
+      type: oauth2
+      x-tokenInfoUrl: 'https://oauth.example/token_info'
+      flows:
+        password:
+          tokenUrl: 'https://oauth.example/token'
+          scopes:
+            myscope: can do stuff

--- a/tests/fixtures/bad_operations/openapi.yaml
+++ b/tests/fixtures/bad_operations/openapi.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+paths:
+  /welcome:
+    get:
+      operationId: no.module.or.function
+      responses:
+        '200':
+          description: greeting response
+          content:
+            '*/*':
+              schema:
+                type: object
+    put:
+      responses:
+        '200':
+          description: greeting response
+          content:
+            '*/*':
+              schema:
+                type: object
+    post:
+      operationId: fakeapi.module_with_error.something
+      responses:
+        '200':
+          description: greeting response
+          content:
+            '*/*':
+              schema:
+                type: object
+servers:
+  - url: /v1.0

--- a/tests/fixtures/bad_specs/openapi.yaml
+++ b/tests/fixtures/bad_specs/openapi.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+paths:
+  /welcome:
+    get:
+      operationId: fakeapi.foo_bar.search
+      parameters:
+        - name: foo
+          in: query
+          schema:
+            type: integer
+            default: somestring
+      responses:
+        '200':
+          description: search
+          content:
+            '*/*':
+              schema:
+                type: object
+servers:
+  - url: /v1.0

--- a/tests/fixtures/default_param_error/openapi.yaml
+++ b/tests/fixtures/default_param_error/openapi.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+paths:
+  /default-param-query-does-not-match-type:
+    get:
+      summary: Default value does not match the param type
+      operationId: fakeapi.hello.test_default_missmatch_definition
+      responses:
+        '200':
+          description: OK
+      parameters:
+        - name: age
+          in: query
+          description: Simple age
+          schema:
+            type: integer
+            default: 'error'
+servers:
+  - url: /v1.0

--- a/tests/fixtures/different_schemas/openapi.yaml
+++ b/tests/fixtures/different_schemas/openapi.yaml
@@ -1,0 +1,304 @@
+openapi: 3.0.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+servers:
+  - url: /v1.0
+paths:
+  /test_schema:
+    post:
+      summary: Returns the image_version
+      description: Returns the image_version
+      operationId: fakeapi.hello.schema
+      responses:
+        '200':
+          description: goodbye response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/new_stack'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              x-body-name: new_stack
+              $ref: '#/components/schemas/new_stack'
+        required: true
+  '/test_schema/response/object/{valid}':
+    get:
+      summary: Returns an image_version as an object
+      description: Returns image_version
+      operationId: fakeapi.hello.schema_response_object
+      parameters:
+        - name: valid
+          in: path
+          description: Whether to return a valid or invalid schema in the response body
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Requested new_stack data model
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/new_stack'
+  '/test_schema/response/string/{valid}':
+    get:
+      summary: Returns an image_version as a string
+      description: Returns image_version
+      operationId: fakeapi.hello.schema_response_string
+      parameters:
+        - name: valid
+          in: path
+          description: Whether to return a valid or invalid schema in the response body
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Requested new_stack data model
+          content:
+            text/plain:
+              schema:
+                type: string
+  '/test_schema/response/integer/{valid}':
+    get:
+      summary: Returns an image_version as an integer
+      description: Returns image_version
+      operationId: fakeapi.hello.schema_response_integer
+      parameters:
+        - name: valid
+          in: path
+          description: Whether to return a valid or invalid schema in the response body
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Requested new_stack data model
+          content:
+            text/plain:
+              schema:
+                type: integer
+  '/test_schema/response/number/{valid}':
+    get:
+      summary: Returns an image_version as a number(float)
+      description: Returns image_version
+      operationId: fakeapi.hello.schema_response_number
+      parameters:
+        - name: valid
+          in: path
+          description: Whether to return a valid or invalid schema in the response body
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Requested new_stack data model
+          content:
+            text/plain:
+              schema:
+                type: number
+  '/test_schema/response/boolean/{valid}':
+    get:
+      summary: Returns an image_version as a boolean
+      description: Returns image_version
+      operationId: fakeapi.hello.schema_response_boolean
+      parameters:
+        - name: valid
+          in: path
+          description: Whether to return a valid or invalid schema in the response body
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Requested new_stack data model
+          content:
+            text/plain:
+              schema:
+                type: boolean
+  '/test_schema/response/array/{valid}':
+    get:
+      summary: Returns an image_version as a boolean
+      description: Returns image_version
+      operationId: fakeapi.hello.schema_response_array
+      parameters:
+        - name: valid
+          in: path
+          description: Whether to return a valid or invalid schema in the response body
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Requested new_stack data model
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/new_stack'
+  /test_schema_in_query:
+    post:
+      summary: Returns the image_version
+      description: Returns the image_version
+      operationId: fakeapi.hello.schema_query
+      parameters:
+        - name: image_version
+          required: true
+          in: query
+          schema:
+            type: string
+        - name: not_required
+          required: false
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: goodbye response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/new_stack'
+  /test_schema_list:
+    post:
+      summary: Returns empty response
+      description: Returns empty response
+      operationId: fakeapi.hello.schema_list
+      responses:
+        '200':
+          description: goodbye response
+          content:
+            application/json:
+              schema:
+                type: string
+      requestBody:
+        $ref: '#/components/requestBodies/fakeapi.hello.schema_listNewStack'
+  /test_schema_map:
+    post:
+      summary: Returns empty response
+      description: Returns empty response
+      operationId: fakeapi.hello.schema_map
+      responses:
+        '200':
+          description: goodbye response
+          content:
+            application/json:
+              schema:
+                type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/new_stack'
+        required: true
+  /test_schema_recursive:
+    post:
+      summary: Returns empty response
+      description: Returns empty response
+      operationId: fakeapi.hello.schema_recursive
+      responses:
+        '200':
+          description: goodbye response
+          content:
+            application/json:
+              schema:
+                type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/simple_tree'
+        required: true
+  /test_schema_format:
+    post:
+      summary: Returns empty response
+      description: Returns empty response
+      operationId: fakeapi.hello.schema_format
+      responses:
+        '200':
+          description: goodbye response
+          content:
+            application/json:
+              schema:
+                type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+              format: email
+        required: true
+  /schema_int:
+    get:
+      description: test schema int
+      operationId: fakeapi.hello.test_schema_int
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              x-body-name: test_int
+              type: integer
+        required: true
+  /schema_array:
+    get:
+      description: test schema array
+      operationId: fakeapi.hello.test_schema_array
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        $ref: '#/components/requestBodies/fakeapi.hello.schema_listNewStack'
+  /define_global_response:
+    get:
+      description: Should allow global response definitions
+      operationId: fakeapi.hello.test_global_response_definition
+      responses:
+        '200':
+          $ref: '#/components/responses/GeneralList'
+components:
+  responses:
+    GeneralList:
+      description: A nice string array
+      content:
+        'application/json':
+          schema:
+            type: array
+            items:
+              type: string
+  requestBodies:
+    fakeapi.hello.schema_listNewStack:
+      content:
+        application/json:
+          schema:
+            x-body-name: test_array
+            type: array
+            items:
+              type: string
+      required: true
+  schemas:
+    new_stack:
+      type: object
+      properties:
+        image_version:
+          type: string
+          description: Docker image version to deploy
+      required:
+        - image_version
+    simple_tree:
+      type: object
+      properties:
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/simple_tree'
+          description: Docker image version to deploy
+      additionalProperties: false

--- a/tests/fixtures/missing_implementation/openapi.yaml
+++ b/tests/fixtures/missing_implementation/openapi.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.0
+info:
+  title: Testing API
+  version: '1.0'
+paths:
+  /operation-not-implemented:
+    get:
+      summary: Operation function does not exist.
+      operationId: api.this_function_does_not_exist
+      responses:
+        '200':
+          description: OK
+servers:
+  - url: /testing

--- a/tests/fixtures/missing_op_id/openapi.yaml
+++ b/tests/fixtures/missing_op_id/openapi.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+paths:
+  /welcome:
+    put:
+      responses:
+        '200':
+          description: greeting response
+          content:
+            '*/*':
+              schema:
+                type: object
+servers:
+  - url: /v1.0

--- a/tests/fixtures/module_does_not_exist/openapi.yaml
+++ b/tests/fixtures/module_does_not_exist/openapi.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.0
+info:
+  title: Not Exist API
+  version: '1.0'
+paths:
+  /module-not-implemented:
+    get:
+      summary: Operation function does not exist.
+      operationId: m.module_does_not_exist
+      responses:
+        '200':
+          description: OK
+servers:
+  - url: /na

--- a/tests/fixtures/module_not_implemented/openapi.yaml
+++ b/tests/fixtures/module_not_implemented/openapi.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+paths:
+  /welcome:
+    get:
+      operationId: no.module.or.function
+      responses:
+        '200':
+          description: greeting response
+          content:
+            '*/*':
+              schema:
+                type: object
+servers:
+  - url: /v1.0

--- a/tests/fixtures/op_error_api/openapi.yaml
+++ b/tests/fixtures/op_error_api/openapi.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+paths:
+  /welcome:
+    get:
+      operationId: fakeapi.module_with_error.something
+      responses:
+        '200':
+          description: greeting response
+          content:
+            '*/*':
+              schema:
+                type: object
+servers:
+  - url: /v1.0

--- a/tests/fixtures/problem/openapi.yaml
+++ b/tests/fixtures/problem/openapi.yaml
@@ -1,0 +1,93 @@
+openapi: 3.0.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+paths:
+  '/greeting/{name}':
+    post:
+      summary: Generate greeting
+      description: Generates a greeting message.
+      operationId: fakeapi.hello.post_greeting
+      responses:
+        '200':
+          description: greeting response
+          content:
+            '*/*':
+              schema:
+                type: object
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to greet.
+          required: true
+          schema:
+            type: string
+  /except:
+    get:
+      summary: Fails badly
+      description: Fails badly
+      operationId: fakeapi.hello.internal_error
+      responses:
+        '200':
+          description: goodbye response
+          content:
+            text/plain:
+              schema:
+                type: string
+  /problem:
+    get:
+      summary: Fails
+      description: Fails
+      operationId: fakeapi.hello.with_problem
+      responses:
+        '200':
+          description: goodbye response
+          content:
+            application/json:
+              schema:
+                type: string
+  /other_problem:
+    get:
+      summary: Fails
+      description: Fails
+      operationId: fakeapi.hello.with_problem_txt
+      responses:
+        '200':
+          description: goodbye response
+          content:
+            text/plain:
+              schema:
+                type: string
+  /json_response_with_undefined_value_to_serialize:
+    get:
+      description: Will fail
+      operationId: fakeapi.hello.get_invalid_response
+      responses:
+        '200':
+          description: Never happens
+  /customized_problem_response:
+    get:
+      description: Custom problem response
+      operationId: fakeapi.hello.get_custom_problem_response
+      responses:
+        '200':
+          description: Custom problem response
+  /problem_exception_with_extra_args:
+    get:
+      description: Using problem as exception
+      operationId: fakeapi.hello.throw_problem_exception
+      responses:
+        '200':
+          description: Problem exception
+servers:
+  - url: /v1.0
+components:
+  securitySchemes:
+    oauth:
+      type: oauth2
+      x-tokenInfoUrl: 'https://oauth.example/token_info'
+      flows:
+        password:
+          tokenUrl: 'https://oauth.example/token'
+          scopes:
+            myscope: can do stuff

--- a/tests/fixtures/query_sanitazion/openapi.yaml
+++ b/tests/fixtures/query_sanitazion/openapi.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+paths:
+  /greeting:
+    post:
+      summary: Generate greeting
+      description: Generates a greeting message.
+      operationId: fakeapi.hello.post_greeting
+      responses:
+        '200':
+          description: greeting response
+          content:
+            'application/json':
+              schema:
+                type: object
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              x-body-name: name
+              type: object
+              properties:
+                name:
+                  description: Name of the person to greet.
+                  type: string
+              required:
+                - name
+servers:
+  - url: /v1.0

--- a/tests/fixtures/secure_api/openapi.yaml
+++ b/tests/fixtures/secure_api/openapi.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.0
+servers:
+  - url: /v1.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+security:
+  - oauth:
+      - myscope
+paths:
+  '/greeting/{name}':
+    post:
+      summary: Generate greeting
+      description: Generates a greeting message.
+      operationId: fakeapi.hello.post_greeting
+      responses:
+        '200':
+          description: greeting response
+          content:
+            '*/*':
+              schema:
+                type: object
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to greet.
+          required: true
+          schema:
+            type: string
+components:
+  securitySchemes:
+    oauth:
+      type: oauth2
+      x-tokenInfoUrl: 'https://oauth.example/token_info'
+      flows:
+        password:
+          tokenUrl: 'https://oauth.example/token'
+          scopes:
+            myscope: can do stuff

--- a/tests/fixtures/secure_endpoint/openapi.yaml
+++ b/tests/fixtures/secure_endpoint/openapi.yaml
@@ -1,0 +1,132 @@
+openapi: 3.0.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+paths:
+  '/byesecure/{name}':
+    get:
+      summary: Generate goodbye
+      description: Generates a goodbye message.
+      operationId: fakeapi.hello.get_bye_secure
+      security:
+        - oauth:
+            - myscope
+      responses:
+        '200':
+          description: goodbye response
+          content:
+            text/plain:
+              schema:
+                type: string
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to say bye.
+          required: true
+          schema:
+            type: string
+  /byesecure-from-flask:
+    get:
+      summary: Generate goodbye
+      description: ''
+      operationId: fakeapi.hello.get_bye_secure_from_flask
+      security:
+        - oauth:
+            - myscope
+      responses:
+        '200':
+          description: goodbye response
+          content:
+            text/plain:
+              schema:
+                type: string
+  /byesecure-from-connexion:
+    get:
+      summary: Generate goodbye
+      description: ''
+      operationId: fakeapi.hello.get_bye_secure_from_connexion
+      security:
+        - oauth:
+            - myscope
+      responses:
+        '200':
+          description: goodbye response
+          content:
+            text/plain:
+              schema:
+                type: string
+  '/byesecure-ignoring-context/{name}':
+    get:
+      summary: Generate goodbye
+      description: Generates a goodbye message.
+      operationId: fakeapi.hello.get_bye_secure_ignoring_context
+      security:
+        - oauth:
+            - myscope
+      responses:
+        '200':
+          description: goodbye response
+          content:
+            text/plain:
+              schema:
+                type: string
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to say bye.
+          required: true
+          schema:
+            type: string
+  /more-than-one-security-definition:
+    get:
+      summary: Some external call to API
+      description: External application call
+      operationId: fakeapi.hello.schema_list
+      security:
+        - oauth:
+            - myscope
+        - api_key: []
+      responses:
+        '200':
+          description: OK
+  /more-than-one-scope:
+    get:
+      summary: Test more than one scope
+      description: |
+        Test that connexion handles scopes properly by verifying that user has
+        all scopes necessary to call the endpoint.
+      operationId: fakeapi.hello.more_than_one_scope_defined
+      security:
+        - oauth:
+            - myscope
+            - otherscope
+      responses:
+        '200':
+          description: some response
+  /user-handled-security:
+    get:
+      summary: Some external call to API
+      description: External application call
+      operationId: fakeapi.hello.schema_map
+      security:
+        - api_key: []
+      responses:
+        '200':
+          description: OK
+servers:
+  - url: /v1.0
+components:
+  securitySchemes:
+    oauth:
+      type: oauth2
+      x-tokenInfoUrl: 'https://oauth.example/token_info'
+      flows:
+        password:
+          tokenUrl: 'https://oauth.example/token'
+          scopes:
+            myscope: can do stuff
+            otherscope: another scope
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -1,0 +1,842 @@
+openapi: 3.0.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+paths:
+  '/greeting/{name}':
+    post:
+      summary: Generate greeting
+      description: Generates a greeting message.
+      operationId: fakeapi.hello.post_greeting
+      responses:
+        '200':
+          description: greeting response
+          content:
+            'application/json':
+              schema:
+                type: object
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to greet.
+          required: true
+          schema:
+            type: string
+  '/greeting/{name}/{remainder}':
+    post:
+      summary: Generate greeting and collect the remainder of the url
+      description: Generates a greeting message and includes the rest of the url.
+      operationId: fakeapi.hello.post_greeting_url
+      responses:
+        '200':
+          description: greeting response with url
+          content:
+            'application/json':
+              schema:
+                type: object
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to greet.
+          required: true
+          schema:
+            type: string
+        - name: remainder
+          in: path
+          description: the rest of the url
+          required: true
+          schema:
+            type: string
+            format: path
+  '/greetings/{name}':
+    get:
+      summary: Generate greeting
+      description: Generates a greeting message with custom mimetype
+      operationId: fakeapi.hello.get_greetings
+      responses:
+        '200':
+          description: greeting response
+          content:
+            application/x.connexion+json:
+              schema:
+                type: object
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to greet.
+          required: true
+          schema:
+            type: string
+  '/bye/{name}':
+    get:
+      summary: Generate goodbye
+      description: Generates a goodbye message.
+      operationId: fakeapi.hello.get_bye
+      responses:
+        '200':
+          description: goodbye response
+          content:
+            text/plain:
+              schema:
+                type: string
+        default:
+          description: unexpected error
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to say bye.
+          required: true
+          schema:
+            type: string
+  /flask_response_tuple:
+    get:
+      summary: Return flask response tuple
+      description: Test returning a flask response tuple
+      operationId: fakeapi.hello.get_flask_response_tuple
+      responses:
+        '200':
+          description: json response
+          content:
+            application/json:
+              schema:
+                type: object
+  '/list/{name}':
+    get:
+      summary: Generate a greeting in a list
+      description: Generate a greeting in a list
+      operationId: fakeapi.hello.get_list
+      responses:
+        '200':
+          description: a greeting in a list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to say hello to.
+          required: true
+          schema:
+            type: string
+  /test_no_content_response:
+    get:
+      operationId: fakeapi.hello.test_no_content_response
+      responses:
+        '204':
+          description: No content returned
+  /multimime:
+    get:
+      summary: Has multiple content types
+      description: Has multiple content types
+      operationId: fakeapi.hello.multimime
+      responses:
+        '200':
+          description: goodbye response
+          content:
+            application/json:
+              schema:
+                type: string
+            application/xml:
+              schema:
+                type: string
+  /empty:
+    get:
+      summary: Returns empty response
+      description: Returns empty response
+      operationId: fakeapi.hello.empty
+      responses:
+        '204':
+          description: empty
+  /test-redirect-endpoint:
+    get:
+      summary: Tests handlers returning flask.Response objects
+      operationId: fakeapi.hello.test_redirect_endpoint
+      responses:
+        '302':
+          description: 302 Found
+  /test-redirect-response-endpoint:
+    get:
+      summary: Tests handlers returning flask.Response objects
+      operationId: fakeapi.hello.test_redirect_response_endpoint
+      responses:
+        '302':
+          description: 302 Found
+  /test-default-object-body:
+    post:
+      summary: Test if default object body param is passed to handler.
+      operationId: fakeapi.hello.test_default_object_body
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              x-body-name: stack
+              $ref: '#/components/schemas/new_stack'
+              default:
+                image_version: default_image
+  /test-default-integer-body:
+    post:
+      summary: Test if default integer body param is passed to handler.
+      operationId: fakeapi.hello.test_default_integer_body
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              x-body-name: stack_version
+              type: integer
+              format: int32
+              example: 1
+              default: 1
+  /resolver-test/method:
+    get:
+      summary: Test class instance method
+      operationId: fakeapi.hello.class_instance.test_method
+      responses:
+        '200':
+          description: OK
+  /resolver-test/classmethod:
+    get:
+      summary: Test class instance method
+      operationId: fakeapi.hello.DummyClass.test_classmethod
+      responses:
+        '200':
+          description: OK
+  /test_parameter_validation:
+    get:
+      operationId: fakeapi.hello.test_parameter_validation
+      parameters:
+        - name: date
+          in: query
+          schema:
+            type: string
+            format: date
+        - name: int
+          in: query
+          schema:
+            type: integer
+        - name: bool
+          in: query
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: OK
+  /test_required_query_param:
+    get:
+      operationId: fakeapi.hello.test_required_query_param
+      parameters:
+        - name: 'n'
+          in: query
+          required: true
+          schema:
+            type: number
+      responses:
+        '200':
+          description: OK
+  /test_array_csv_query_param:
+    get:
+      operationId: fakeapi.hello.test_array_csv_query_param
+      parameters:
+        - name: items
+          in: query
+          description: An comma separated array of items
+          style: form
+          schema:
+            type: array
+            default: ["squash", "banana"]
+            items:
+              type: string
+      responses:
+        '200':
+          description: OK
+  /test_array_pipes_query_param:
+    get:
+      operationId: fakeapi.hello.test_array_pipes_query_param
+      parameters:
+        - name: items
+          in: query
+          description: An pipe separated array of items
+          required: true
+          style: pipeDelimited
+          schema:
+            type: array
+            items:
+              type: integer
+      responses:
+        '200':
+          description: OK
+  /test_array_unsupported_query_param:
+    get:
+      operationId: fakeapi.hello.test_array_unsupported_query_param
+      parameters:
+        - name: items
+          in: query
+          description: An pipe separated array of items
+          required: true
+          style: pipeDelimited
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: OK
+  '/test-int-path/{someint}':
+    get:
+      summary: Test type casting of path parameter
+      operationId: fakeapi.hello.test_get_someint
+      parameters:
+        - name: someint
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+  '/test-float-path/{somefloat}':
+    get:
+      summary: Test type casting of path parameter
+      operationId: fakeapi.hello.test_get_somefloat
+      parameters:
+        - name: somefloat
+          in: path
+          required: true
+          schema:
+            type: number
+      responses:
+        '200':
+          description: OK
+  /test-default-query-parameter:
+    get:
+      summary: Test if default parameter is passed to function
+      operationId: fakeapi.hello.test_default_param
+      parameters:
+        - name: name
+          in: query
+          schema:
+            type: string
+            default: connexion
+      responses:
+        '200':
+          description: OK
+  /test-falsy-param:
+    get:
+      summary: Test if default value when argument is falsy.
+      operationId: fakeapi.hello.test_falsy_param
+      parameters:
+        - name: falsy
+          in: query
+          schema:
+            type: integer
+            default: 1
+      responses:
+        '200':
+          description: OK
+  /test-formData-param:
+    post:
+      summary: Test formData parameter
+      operationId: fakeapi.hello.test_formdata_param3
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                formData:
+                  type: string
+              required:
+                - formData
+  /test-formData-missing-param:
+    post:
+      summary: Test formData missing parameter in handler
+      operationId: fakeapi.hello.test_formdata_missing_param
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                missing_formData:
+                  type: string
+              required:
+                - missing_formData
+  /test-formData-file-upload:
+    post:
+      summary: 'Test formData with file type, for file upload'
+      operationId: fakeapi.hello.test_formdata_file_upload
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              x-body-name: formData
+              type: object
+              properties:
+                formData:
+                  type: string
+                  format: binary
+              required:
+                - formData
+  /test-formData-file-upload-missing-param:
+    post:
+      summary: 'Test formData with file type, missing parameter in handler'
+      operationId: fakeapi.hello.test_formdata_file_upload_missing_param
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                missing_formData:
+                  type: string
+                  format: binary
+              required:
+                - missing_formData
+  /test-bool-param:
+    get:
+      summary: Test usage of boolean default value
+      operationId: fakeapi.hello.test_bool_default_param
+      parameters:
+        - name: thruthiness
+          in: query
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: OK
+  /test-bool-array-param:
+    get:
+      summary: Test usage of an array of booleans value
+      operationId: fakeapi.hello.test_bool_array_param
+      parameters:
+        - name: thruthiness
+          in: query
+          schema:
+            type: array
+            items:
+              type: boolean
+      responses:
+        '200':
+          description: OK
+  /test-required-param:
+    get:
+      summary: Test required param without default value
+      operationId: fakeapi.hello.test_required_param
+      parameters:
+        - name: simple
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+  /parameters-in-root-path:
+    parameters:
+      - in: query
+        name: title
+        description: Some parameter in the path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Test the method GET with parameter from path
+      operationId: fakeapi.hello.path_parameters_in_get_method
+      responses:
+        '200':
+          description: OK
+  '/goodday/{name}':
+    post:
+      summary: Generate good day greeting
+      description: Generates a good day message.
+      operationId: fakeapi.hello.post_goodday
+      responses:
+        '201':
+          description: gooday response
+          headers:
+            Location:
+              description: The URI of the created resource
+              schema:
+                type: string
+          content:
+            'application/json':
+              schema:
+                type: object
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to greet.
+          required: true
+          schema:
+            type: string
+  /goodday/noheader:
+    post:
+      summary: Generate good day greeting
+      description: Generates a good day message.
+      operationId: fakeapi.hello.post_goodday_no_header
+      responses:
+        '201':
+          description: gooday response
+          headers:
+            Location:
+              description: The URI of the created resource
+              schema:
+                type: string
+          content:
+            'application/json':
+              schema:
+                type: object
+  '/goodevening/{name}':
+    post:
+      summary: Generate good evening
+      description: Generates a good evening message.
+      operationId: fakeapi.hello.post_goodevening
+      responses:
+        '201':
+          description: goodevening response
+          headers:
+            Location:
+              description: The URI of the created resource
+              schema:
+                type: string
+          content:
+            text/plain:
+              schema:
+                type: string
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to say good evening.
+          required: true
+          schema:
+            type: string
+  /test-204-with-headers:
+    get:
+      summary: Tests that response code 204 can have headers set
+      operationId: fakeapi.hello.test_204_with_headers
+      responses:
+        '204':
+          headers:
+            X-Something:
+              description: A value that might be send in the response
+              schema:
+                type: string
+          description: 204 no content
+  /test-204-with-headers-nocontent-obj:
+    get:
+      summary: Tests that response code 204 using NoContent obj can have headers set
+      operationId: fakeapi.hello.test_nocontent_obj_with_headers
+      responses:
+        '204':
+          headers:
+            X-Something:
+              description: A value that might be send in the response
+              schema:
+                type: string
+          description: 204 no content
+  '/test-array-in-path/{names}':
+    get:
+      operationId: fakeapi.hello.test_array_in_path
+      parameters:
+        - name: names
+          description: List of names.
+          in: path
+          required: true
+          style: simple
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+  /nullable-parameters:
+    post:
+      operationId: fakeapi.hello.test_nullable_param_post3
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                post_param:
+                  description: Just a testing parameter.
+                  type: number
+                  format: int32
+                  nullable: true
+              required:
+                - post_param
+    put:
+      operationId: fakeapi.hello.test_nullable_param_put
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              nullable: true
+              x-body-name: contents
+              type: object
+              properties:
+                name:
+                  type: string
+        description: Just a testing parameter.
+        required: true
+    get:
+      operationId: fakeapi.hello.test_nullable_parameters
+      parameters:
+        - name: time_start
+          description: Just a testing parameter.
+          in: query
+          required: true
+          schema:
+            nullable: true
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: OK
+  /custom-json-response:
+    get:
+      operationId: fakeapi.hello.test_custom_json_response
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  theResult:
+                    type: string
+                    description: the number we wanna test
+  /blob-response:
+    get:
+      operationId: fakeapi.hello.get_blob_data
+      responses:
+        '200':
+          description: Some blob response
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+  /binary-response:
+    get:
+      operationId: fakeapi.hello.get_data_as_binary
+      responses:
+        '200':
+          description: Everything is ok
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+  /query-params-as-kwargs:
+    get:
+      operationId: fakeapi.hello.test_args_kwargs
+      parameters:
+        - name: foo
+          description: Just a testing parameter.
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Return kwargs
+          content:
+            application/json:
+              schema:
+                type: object
+  /text-request:
+    post:
+      operationId: fakeapi.hello.get_data_as_text
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              x-body-name: post_param
+              type: string
+        description: Just a testing parameter.
+        required: true
+  /param-sanitization:
+    post:
+      operationId: fakeapi.hello.test_param_sanitization3
+      parameters:
+        - name: $query
+          description: Just a testing parameter with an invalid Python name
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Return parameters
+          content:
+            application/json:
+              schema:
+                type: object
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                'form$':
+                  description: Just a testing parameter in the form data
+                  type: string
+  /body-sanitization:
+    post:
+      operationId: fakeapi.hello.test_body_sanitization
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        $ref: '#/components/requestBodies/fakeapi.hello.test_body_sanitization_body'
+  /get_non_conforming_response:
+    get:
+      operationId: fakeapi.hello.get_empty_dict
+      responses:
+        '200':
+          description: OK
+          content:
+            'application/json':
+              schema:
+                type: object
+                required:
+                  - some
+                properties:
+                  some:
+                    type: string
+  /post_wrong_content_type:
+    post:
+      operationId: fakeapi.hello.post_wrong_content_type
+      responses:
+        '200':
+          description: OK
+        '215':
+          description: NOT-OK
+      requestBody:
+        $ref: '#/components/requestBodies/fakeapi.hello.test_body_sanitization_body'
+  /get_unicode_request:
+    get:
+      summary: Test if a unicode string in query parameter works properly in Python 2
+      operationId: fakeapi.hello.get_unicode_query
+      parameters:
+        - name: price
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+  /get_unicode_response:
+    get:
+      operationId: fakeapi.hello.get_unicode_data
+      responses:
+        '200':
+          description: Some unicode response
+          content:
+            application/json:
+              schema:
+                type: object
+  /get_enum_response:
+    get:
+      operationId: fakeapi.hello.get_enum_response
+      responses:
+        '200':
+          description: Some HTTPStatus response
+          content:
+            application/json:
+              schema:
+                type: object
+  /get_httpstatus_response:
+    get:
+      operationId: fakeapi.hello.get_httpstatus_response
+      responses:
+        '200':
+          description: Some HTTPStatus response
+          content:
+            application/json:
+              schema:
+                type: object
+  '/get_bad_default_response/{response_code}':
+    get:
+      operationId: fakeapi.hello.get_bad_default_response
+      parameters:
+        - name: response_code
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Some object response
+          content:
+            application/json:
+              schema:
+                type: object
+        default:
+          description: Some array response
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {}
+servers:
+  - url: /v1.0
+components:
+  requestBodies:
+    fakeapi.hello.test_body_sanitization_body:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              body1:
+                type: string
+              body2:
+                type: string
+      description: Just a testing parameter in the body
+      required: true
+  schemas:
+    new_stack:
+      type: object
+      properties:
+        image_version:
+          type: string
+          description: Docker image version to deploy
+      required:
+        - image_version

--- a/tests/fixtures/snake_case/openapi.yaml
+++ b/tests/fixtures/snake_case/openapi.yaml
@@ -1,0 +1,191 @@
+openapi: 3.0.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+paths:
+  '/test-get-path-snake/{SomeId}':
+    get:
+      summary: Test converting to snake_case in path
+      description: Test converting to snake_case in path
+      operationId: fakeapi.snake_case.get_path_snake
+      responses:
+        '200':
+          description: Success response
+          content:
+            application/json:
+              schema:
+                type: object
+      parameters:
+        - name: SomeId
+          in: path
+          description: SomeId parameter
+          required: true
+          schema:
+            type: integer
+  '/test-get-path-shadow/{id}':
+    get:
+      summary: Test converting to un-shadowed parameter in path
+      description: Test converting to un-shadowed parameter in path
+      operationId: fakeapi.snake_case.get_path_shadow
+      responses:
+        '200':
+          description: Success response
+          content:
+            application/json:
+              schema:
+                type: object
+      parameters:
+        - name: id
+          in: path
+          description: id parameter
+          required: true
+          schema:
+            type: integer
+  /test-get-query-snake:
+    get:
+      summary: Test converting to snake_case parameter in query
+      description: Test converting to snake_case parameter in query
+      operationId: fakeapi.snake_case.get_query_snake
+      responses:
+        '200':
+          description: Success response
+          content:
+            application/json:
+              schema:
+                type: object
+      parameters:
+        - name: someId
+          in: query
+          description: id parameter
+          required: true
+          schema:
+            type: integer
+  /test-get-query-shadow:
+    get:
+      summary: Test converting to un-shadowed parameter in query
+      description: est converting to un-shadowed parameter in query
+      operationId: fakeapi.snake_case.get_query_shadow
+      responses:
+        '200':
+          description: Success response
+          content:
+            application/json:
+              schema:
+                type: object
+      parameters:
+        - name: list
+          in: query
+          description: id parameter
+          required: true
+          schema:
+            type: integer
+  '/test-post-path-snake/{SomeId}':
+    post:
+      summary: Test converting to snake_case in path
+      description: Test converting to snake_case in path
+      operationId: fakeapi.snake_case.post_path_snake
+      responses:
+        '200':
+          description: greeting response
+          content:
+            'application/json':
+              schema:
+                type: object
+      parameters:
+        - name: SomeId
+          in: path
+          description: SomeId parameter
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              x-body-name: some_other_id
+              type: object
+        description: SomeOtherId parameter
+        required: true
+  '/test-post-path-shadow/{id}':
+    post:
+      summary: Test converting to un-shadowed in path
+      description: Test converting to un-shadowed in path
+      operationId: fakeapi.snake_case.post_path_shadow
+      responses:
+        '200':
+          description: greeting response
+          content:
+            'application/json':
+              schema:
+                type: object
+      parameters:
+        - name: id
+          in: path
+          description: id parameter
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              x-body-name: round_
+              type: object
+        description: round parameter
+        required: true
+  /test-post-query-snake:
+    post:
+      summary: Test converting to snake_case in query
+      description: Test converting to snake_case in query
+      operationId: fakeapi.snake_case.post_query_snake
+      responses:
+        '200':
+          description: greeting response
+          content:
+            'application/json':
+              schema:
+                type: object
+      parameters:
+        - name: someId
+          in: query
+          description: someId parameter
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              x-body-name: some_other_id
+              type: object
+        description: someOtherId parameter
+        required: true
+  /test-post-query-shadow:
+    post:
+      summary: Test converting to un-shadowed in query
+      description: Test converting to un-shadowed in query
+      operationId: fakeapi.snake_case.post_query_shadow
+      responses:
+        '200':
+          description: greeting response
+          content:
+            'application/json':
+              schema:
+                type: object
+      parameters:
+        - name: id
+          in: query
+          description: id parameter
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              x-body-name: next_
+              type: object
+        description: next parameter
+        required: true
+servers:
+  - url: /v1.0

--- a/tests/fixtures/unordered_definition/openapi.yaml
+++ b/tests/fixtures/unordered_definition/openapi.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+paths:
+  '/unordered-params/{path_param}':
+    get:
+      summary: Mixed parameters in swagger definition
+      operationId: fakeapi.hello.unordered_params_response
+      responses:
+        '200':
+          description: OK
+      parameters:
+        - name: first
+          in: query
+          description: First Param
+          schema:
+            type: integer
+        - name: path_param
+          in: path
+          required: true
+          description: Path Param
+          schema:
+            type: string
+        - name: second
+          in: query
+          description: Second Param
+          schema:
+            type: integer
+servers:
+  - url: /v1.0

--- a/tests/fixtures/user_module_loading_error/openapi.yaml
+++ b/tests/fixtures/user_module_loading_error/openapi.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+paths:
+  /welcome:
+    get:
+      operationId: fakeapi.module_with_exception.something
+      responses:
+        '200':
+          description: greeting response
+          content:
+            '*/*':
+              schema:
+                type: object
+servers:
+  - url: /v1.1


### PR DESCRIPTION
first piece of #420 

Changes proposed in this pull request:
 - add openapi.yaml test fixtures alongside swagger.yaml (converted with [swagger2openapi](https://github.com/Mermade/oas-kit/blob/master/packages/swagger2openapi/README.md) , some minor manual edits)
