### PR TITLE
WIP: Fix travis build for python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ python:
   - "3.5"
   - "3.6"
 install:
-  - pip install "setuptools>=17.1" tox tox-travis coveralls
+  - pip install "setuptools>=17.1"
+  - pip install tox tox-travis coveralls
 script:
   - tox
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ python:
   - "3.5"
   - "3.6"
 install:
-  - pip install "setuptools>=17.1"
-  - pip install tox tox-travis coveralls
+  - pip install --upgrade setuptools tox tox-travis coveralls
 script:
   - tox
 after_success:


### PR DESCRIPTION
I got a stack trace building master on travis.ci with python 3.4 (below).

I think setuptools needs to be upgraded before trying to install tox.

Changes proposed in this pull request:
 - split setuptools installation from tox and travis in .travis.yml

stack trace:
```
$ python --version
Python 3.4.6
$ pip --version
pip 9.0.1 from /home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages (python 3.4)
install
6.15s$ pip install "setuptools>=17.1" tox tox-travis coveralls
Requirement already satisfied: setuptools>=17.1 in /home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages
Collecting tox
  Downloading https://files.pythonhosted.org/packages/f5/97/0fea3b7a7ac7be2cc12acb4187c232f744440b7ca902741919632fd351bb/tox-3.1.0-py2.py3-none-any.whl (61kB)
    100% |████████████████████████████████| 61kB 3.8MB/s 
Collecting tox-travis
  Downloading https://files.pythonhosted.org/packages/a0/f0/55a0d561161ceac9da512d221547cd0405f0cbf5dfba7352cd36d7bfdace/tox_travis-0.10-py2.py3-none-any.whl
Collecting coveralls
  Downloading https://files.pythonhosted.org/packages/6f/c0/cd0b33454c0192cdd63360f8ac2a96a6132f01b34fa70524220c06fd4743/coveralls-1.3.0-py2.py3-none-any.whl
Requirement already satisfied: packaging>=16.8 in /home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages (from setuptools>=17.1)
Requirement already satisfied: six>=1.6.0 in /home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages (from setuptools>=17.1)
Requirement already satisfied: appdirs>=1.4.0 in /home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages (from setuptools>=17.1)
Collecting virtualenv>=1.11.2 (from tox)
  Downloading https://files.pythonhosted.org/packages/b6/30/96a02b2287098b23b875bc8c2f58071c35d2efe84f747b64d523721dc2b5/virtualenv-16.0.0-py2.py3-none-any.whl (1.9MB)
    100% |████████████████████████████████| 1.9MB 753kB/s 
Requirement already satisfied: py<2,>=1.4.17 in /home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages (from tox)
Collecting pluggy<1,>=0.3.0 (from tox)
  Downloading https://files.pythonhosted.org/packages/ba/65/ded3bc40bbf8d887f262f150fbe1ae6637765b5c9534bd55690ed2c0b0f7/pluggy-0.6.0-py3-none-any.whl
Collecting requests>=1.0.0 (from coveralls)
  Downloading https://files.pythonhosted.org/packages/65/47/7e02164a2a3db50ed6d8a6ab1d6d60b69c4c3fdf57a284257925dfc12bda/requests-2.19.1-py2.py3-none-any.whl (91kB)
    100% |████████████████████████████████| 92kB 11.2MB/s 
Collecting docopt>=0.6.1 (from coveralls)
  Downloading https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz
Collecting coverage>=3.6 (from coveralls)
  Downloading https://files.pythonhosted.org/packages/28/9d/a35b5281e60ef3c8f42a29da5f60811cd2739c0a6f5bd5342d4115eede5e/coverage-4.5.1-cp34-cp34m-manylinux1_x86_64.whl (202kB)
    100% |████████████████████████████████| 204kB 6.6MB/s 
Requirement already satisfied: pyparsing in /home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages (from packaging>=16.8->setuptools>=17.1)
Collecting idna<2.8,>=2.5 (from requests>=1.0.0->coveralls)
  Downloading https://files.pythonhosted.org/packages/4b/2a/0276479a4b3caeb8a8c1af2f8e4355746a97fab05a372e4a2c6a6b876165/idna-2.7-py2.py3-none-any.whl (58kB)
    100% |████████████████████████████████| 61kB 10.8MB/s 
Collecting urllib3<1.24,>=1.21.1 (from requests>=1.0.0->coveralls)
  Downloading https://files.pythonhosted.org/packages/bd/c9/6fdd990019071a4a32a5e7cb78a1d92c53851ef4f56f62a3486e6a7d8ffb/urllib3-1.23-py2.py3-none-any.whl (133kB)
    100% |████████████████████████████████| 143kB 9.5MB/s 
Collecting certifi>=2017.4.17 (from requests>=1.0.0->coveralls)
  Downloading https://files.pythonhosted.org/packages/7c/e6/92ad559b7192d846975fc916b65f667c7b8c3a32bea7372340bfe9a15fa5/certifi-2018.4.16-py2.py3-none-any.whl (150kB)
    100% |████████████████████████████████| 153kB 7.5MB/s 
Collecting chardet<3.1.0,>=3.0.2 (from requests>=1.0.0->coveralls)
  Downloading https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl (133kB)
    100% |████████████████████████████████| 143kB 9.2MB/s 
Building wheels for collected packages: docopt
  Running setup.py bdist_wheel for docopt ... done
  Stored in directory: /home/travis/.cache/pip/wheels/9b/04/dd/7daf4150b6d9b12949298737de9431a324d4b797ffd63f526e
Successfully built docopt
Installing collected packages: virtualenv, pluggy, tox, tox-travis, idna, urllib3, certifi, chardet, requests, docopt, coverage, coveralls
Successfully installed certifi-2018.4.16 chardet-3.0.4 coverage-4.5.1 coveralls-1.3.0 docopt-0.6.2 idna-2.7 pluggy-0.6.0 requests-2.19.1 tox-3.1.0 tox-travis-0.10 urllib3-1.23 virtualenv-16.0.0
0.29s$ tox
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pluggy/__init__.py", line 397, in load_setuptools_entrypoints
    plugin = ep.load()
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2301, in load
    self.require(*args, **kwargs)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2324, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pkg_resources/__init__.py", line 859, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (packaging 16.8 (/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages), Requirement.parse('packaging>=17.1'), {'tox'})
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.4.6/bin/tox", line 11, in <module>
    sys.exit(cmdline())
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/tox/session.py", line 39, in cmdline
    main(args)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/tox/session.py", line 44, in main
    config = prepare(args)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/tox/session.py", line 26, in prepare
    config = parseconfig(args)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/tox/config.py", line 212, in parseconfig
    pm = get_plugin_manager(plugins)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/tox/config.py", line 46, in get_plugin_manager
    pm.load_setuptools_entrypoints("tox")
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pluggy/__init__.py", line 402, in load_setuptools_entrypoints
    "Plugin %r could not be loaded: %s!" % (ep.name, e))
pluggy.PluginValidationError: Plugin 'travis' could not be loaded: (packaging 16.8 (/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages), Requirement.parse('packaging>=17.1'), {'tox'})!
The command "tox" exited with 1.
Done. Your build exited with 1.
```

