### PR TITLE
Support OpenAPI 3.0.0 specs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,7 @@ Other Sources/Mentions
 New in Connexion 2.0:
 ---------------------
 - App and Api options must be provided through the "options" argument (``old_style_options`` have been removed).
+- You must specify a form content-type in 'consumes' in order to consume form data.
 - The `Operation` interface has been formalized in the `AbstractOperation` class.
 - The `Operation` class has been renamed to `Swagger2Operation`.
 - Array parameter deserialization now follows the Swagger 2.0 spec more closely.

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -8,23 +8,40 @@ from typing import AnyStr, List  # NOQA
 import jinja2
 import six
 import yaml
-
-from openapi_spec_validator import validate_v2_spec as validate_spec
 from openapi_spec_validator.exceptions import OpenAPIValidationError
-from swagger_ui_bundle import swagger_ui_2_path
+from six.moves.urllib.parse import urlparse
 
 from ..exceptions import InvalidSpecification, ResolverError
 from ..jsonref import resolve_refs
-from ..operations import Swagger2Operation
+from ..operations import OpenAPIOperation, Swagger2Operation
 from ..options import ConnexionOptions
 from ..resolver import Resolver
 from ..utils import Jsonifier
 
 MODULE_PATH = pathlib.Path(__file__).absolute().parent.parent
-SWAGGER_UI_PATH = swagger_ui_2_path
 SWAGGER_UI_URL = 'ui'
+NO_SPEC_VERSION_ERR_MSG = """Unable to get the spec version.
+You are missing either '"swagger": "2.0"' or '"openapi": "3.0.0"'
+from the top level of your spec."""
 
 logger = logging.getLogger('connexion.apis.abstract')
+
+
+def _get_spec_version(spec):
+    try:
+        version_string = spec.get('openapi') or spec.get('swagger')
+    except AttributeError:
+        raise InvalidSpecification(NO_SPEC_VERSION_ERR_MSG)
+    if version_string is None:
+        raise InvalidSpecification(NO_SPEC_VERSION_ERR_MSG)
+    try:
+        version_tuple = tuple(map(int, version_string.split(".")))
+    except TypeError:
+        err = ('Unable to convert version string to semantic version tuple: '
+               '{version_string}.')
+        err = err.format(version_string=version_string)
+        raise InvalidSpecification(err)
+    return version_tuple
 
 
 class AbstractAPIMeta(abc.ABCMeta):
@@ -71,13 +88,6 @@ class AbstractAPI(object):
         self.validator_map = validator_map
         self.resolver_error_handler = resolver_error_handler
 
-        self.options = ConnexionOptions(options)
-
-        logger.debug('Options Loaded',
-                     extra={'swagger_ui': self.options.openapi_console_ui_available,
-                            'swagger_path': self.options.openapi_console_ui_from_dir,
-                            'swagger_url': self.options.openapi_console_ui_path})
-
         logger.debug('Loading specification: %s', specification,
                      extra={'swagger_yaml': specification,
                             'base_path': base_path,
@@ -92,6 +102,15 @@ class AbstractAPI(object):
 
         self.specification = compatibility_layer(self.specification)
         logger.debug('Read specification', extra={'spec': self.specification})
+
+        self.spec_version = _get_spec_version(self.specification)
+
+        self.options = ConnexionOptions(options, oas_version=self.spec_version)
+
+        logger.debug('Options Loaded',
+                     extra={'swagger_ui': self.options.openapi_console_ui_available,
+                            'swagger_path': self.options.openapi_console_ui_from_dir,
+                            'swagger_url': self.options.openapi_console_ui_path})
 
         # Avoid validator having ability to modify specification
         self.raw_spec = copy.deepcopy(self.specification)
@@ -115,6 +134,7 @@ class AbstractAPI(object):
         logger.debug('Security Definitions: %s', self.security_definitions)
 
         self.definitions = self.specification.get('definitions', {})
+        self.components = self.specification.get('components', {})
         self.parameter_definitions = self.specification.get('parameters', {})
         self.response_definitions = self.specification.get('responses', {})
 
@@ -144,6 +164,10 @@ class AbstractAPI(object):
             self.add_auth_on_not_found(self.security, self.security_definitions)
 
     def _validate_spec(self, spec):
+        if self.spec_version < (3, 0, 0):
+            from openapi_spec_validator import validate_v2_spec as validate_spec
+        else:
+            from openapi_spec_validator import validate_v3_spec as validate_spec
         try:
             validate_spec(spec)
         except OpenAPIValidationError as e:
@@ -152,10 +176,17 @@ class AbstractAPI(object):
     def _set_base_path(self, base_path):
         # type: (AnyStr) -> None
         if base_path is None:
-            self.base_path = canonical_base_path(self.specification.get('basePath', ''))
-        else:
-            self.base_path = canonical_base_path(base_path)
-            self.specification['basePath'] = base_path
+            if self.spec_version < (3, 0, 0):
+                base_path = self.specification.get('basePath', '')
+            else:
+                # TODO variable subsitution in urls for oas3
+                servers = self.specification.get('servers', [])
+                for server in servers:
+                    # TODO how to handle multiple servers in an
+                    #      oas3 spec with different paths?
+                    base_path = urlparse(server['url']).path
+                    break
+        self.base_path = canonical_base_path(base_path)
 
     @abc.abstractmethod
     def add_openapi_json(self):
@@ -193,25 +224,36 @@ class AbstractAPI(object):
         :type path: str
         :type swagger_operation: dict
         """
-        operation = Swagger2Operation(self,
-                                      method=method,
-                                      path=path,
-                                      path_parameters=path_parameters,
-                                      operation=swagger_operation,
-                                      app_produces=self.produces,
-                                      app_consumes=self.consumes,
-                                      app_security=self.security,
-                                      security_definitions=self.security_definitions,
-                                      definitions=self.definitions,
-                                      parameter_definitions=self.parameter_definitions,
-                                      response_definitions=self.response_definitions,
-                                      validate_responses=self.validate_responses,
-                                      validator_map=self.validator_map,
-                                      strict_validation=self.strict_validation,
-                                      resolver=self.resolver,
-                                      pythonic_params=self.pythonic_params,
-                                      uri_parser_class=self.options.uri_parser_class,
-                                      pass_context_arg_name=self.pass_context_arg_name)
+
+        shared_args = {
+            "method": method,
+            "path": path,
+            "path_parameters": path_parameters,
+            "operation": swagger_operation,
+            "app_security": self.security,
+            "validate_responses": self.validate_responses,
+            "validator_map": self.validator_map,
+            "strict_validation": self.strict_validation,
+            "resolver": self.resolver,
+            "pythonic_params": self.pythonic_params,
+            "uri_parser_class": self.options.uri_parser_class,
+            "pass_context_arg_name": self.pass_context_arg_name
+        }
+
+        if self.spec_version < (3, 0, 0):
+            operation = Swagger2Operation(self,
+                                          app_produces=self.produces,
+                                          app_consumes=self.consumes,
+                                          security_definitions=self.security_definitions,
+                                          definitions=self.definitions,
+                                          parameter_definitions=self.parameter_definitions,
+                                          response_definitions=self.response_definitions,
+                                          **shared_args)
+        else:
+            operation = OpenAPIOperation(self,
+                                         components=self.components,
+                                         **shared_args)
+
         self._add_operation_internal(method, path, operation)
 
     @abc.abstractmethod

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -8,6 +8,7 @@ from typing import AnyStr, List  # NOQA
 import jinja2
 import six
 import yaml
+
 from openapi_spec_validator import validate_v2_spec as validate_spec
 from openapi_spec_validator.exceptions import OpenAPIValidationError
 

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -11,6 +11,7 @@ import yaml
 
 from openapi_spec_validator import validate_v2_spec as validate_spec
 from openapi_spec_validator.exceptions import OpenAPIValidationError
+from swagger_ui_bundle import swagger_ui_2_path
 
 from ..exceptions import InvalidSpecification, ResolverError
 from ..jsonref import resolve_refs
@@ -20,6 +21,7 @@ from ..resolver import Resolver
 from ..utils import Jsonifier
 
 MODULE_PATH = pathlib.Path(__file__).absolute().parent.parent
+SWAGGER_UI_PATH = swagger_ui_2_path
 SWAGGER_UI_URL = 'ui'
 
 logger = logging.getLogger('connexion.apis.abstract')

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -98,10 +98,6 @@ def parameter_to_arg(operation, function, pythonic_params=False,
         else:
             request_body = request.body
 
-        # accept formData even even if mimetype is wrong for backwards
-        # compatability  :/
-        request_body = request_body or {sanitize(k): v for k, v in request.form.items()}
-
         try:
             query = request.query.to_dict(flat=False)
         except AttributeError:

--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -21,7 +21,7 @@ QUERY_STRING_DELIMITERS = {
 class AbstractURIParser(BaseDecorator):
     parsable_parameters = ["query", "path"]
 
-    def __init__(self, param_defns):
+    def __init__(self, param_defns, body_defn):
         """
         a URI parser is initialized with parameter definitions.
         When called with a request object, it handles array types in the URI
@@ -35,6 +35,8 @@ class AbstractURIParser(BaseDecorator):
         self._param_defns = {p["name"]: p
                              for p in param_defns
                              if p["in"] in self.parsable_parameters}
+        self._body_schema = body_defn.get("schema", {})
+        self._body_encoding = body_defn.get("encoding", {})
 
     @abc.abstractproperty
     def param_defns(self):
@@ -54,6 +56,11 @@ class AbstractURIParser(BaseDecorator):
         """
         return "<{classname}>".format(
             classname=self.__class__.__name__)  # pragma: no cover
+
+    @abc.abstractmethod
+    def resolve_form(self, form_data):
+        """ Resolve cases where form parameters are provided multiple times.
+        """
 
     @abc.abstractmethod
     def _resolve_param_duplicates(self, values, param_defn):
@@ -120,12 +127,71 @@ class AbstractURIParser(BaseDecorator):
             form = coerce_dict(request.form)
 
             request.query = self.resolve_params(query, resolve_duplicates=True)
-            request.form = self.resolve_params(form, resolve_duplicates=True)
             request.path_params = self.resolve_params(path_params)
+            request.form = self.resolve_form(form)
             response = function(request)
             return response
 
         return wrapper
+
+
+class OpenAPIURIParser(AbstractURIParser):
+
+    @property
+    def param_defns(self):
+        return self._param_defns
+
+    @property
+    def form_defns(self):
+        return {k: v for k, v in self._body_schema.get('properties', {}).items()}
+
+    @property
+    def param_schemas(self):
+        return {k: v.get('schema', {}) for k, v in self.param_defns.items()}
+
+    def resolve_form(self, form_data):
+        if self._body_schema is None or self._body_schema.get('type') != 'object':
+            return form_data
+        for k in form_data:
+            encoding = self._body_encoding.get(k, {"style": "form"})
+            defn = self.form_defns.get(k, {})
+            # TODO support more form encoding styles
+            form_data[k] = \
+                self._resolve_param_duplicates(form_data[k], encoding)
+            if defn and defn["type"] == "array":
+                form_data[k] = self._split(form_data[k], encoding)
+        return form_data
+
+    @staticmethod
+    def _resolve_param_duplicates(values, param_defn):
+        """ Resolve cases where query parameters are provided multiple times.
+            The default behavior is to use the first-defined value.
+            For example, if the query string is '?a=1,2,3&a=4,5,6' the value of
+            `a` would be "4,5,6".
+            However, if 'explode' is 'True' then the duplicate values
+            are concatenated together and `a` would be "1,2,3,4,5,6".
+        """
+        try:
+            style = param_defn['style']
+            delimiter = QUERY_STRING_DELIMITERS.get(style, ',')
+            is_form = (style == 'form')
+            explode = param_defn.get('explode', is_form)
+            if explode:
+                return delimiter.join(values)
+        except KeyError:
+            pass
+
+        # default to last defined value
+        return values[-1]
+
+    @staticmethod
+    def _split(value, param_defn):
+        try:
+            style = param_defn['style']
+            delimiter = QUERY_STRING_DELIMITERS.get(style, ',')
+            return value.split(delimiter)
+        except KeyError:
+            return value.split(',')
 
 
 class Swagger2URIParser(AbstractURIParser):
@@ -142,6 +208,9 @@ class Swagger2URIParser(AbstractURIParser):
     @property
     def param_schemas(self):
         return self._param_defns  # swagger2 conflates defn and schema
+
+    def resolve_form(self, form_data):
+        return self.resolve_params(form_data, resolve_duplicates=True)
 
     @staticmethod
     def _resolve_param_duplicates(values, param_defn):

--- a/connexion/operations/__init__.py
+++ b/connexion/operations/__init__.py
@@ -1,3 +1,4 @@
 from .abstract import AbstractOperation  # noqa
+from .openapi import OpenAPIOperation  # noqa
 from .swagger2 import Swagger2Operation  # noqa
 from .secure import SecureOperation  # noqa

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -198,21 +198,6 @@ class AbstractOperation(SecureOperation):
                 kwargs[key] = value
         return kwargs
 
-    def _get_body_argument(self, body, arguments, has_kwargs):
-        """
-        extract handler function arguments from the request body
-        argument can be renamed by setting the "x-body-name" extension
-        in the body schema, otherwise the body will be passed to the
-        handler function as an argument named "body".
-        """
-        body_schema = self.body_schema
-        if body_schema:
-            x_body_name = body_schema.get('x-body-name', 'body')
-            logger.debug('x-body-name is %s' % x_body_name)
-            if x_body_name in arguments or has_kwargs:
-                return {x_body_name: body}
-        return {}
-
     @abc.abstractproperty
     def parameters(self):
         """

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -198,6 +198,21 @@ class AbstractOperation(SecureOperation):
                 kwargs[key] = value
         return kwargs
 
+    def _get_body_argument(self, body, arguments, has_kwargs):
+        """
+        extract handler function arguments from the request body
+        argument can be renamed by setting the "x-body-name" extension
+        in the body schema, otherwise the body will be passed to the
+        handler function as an argument named "body".
+        """
+        body_schema = self.body_schema
+        if body_schema:
+            x_body_name = body_schema.get('x-body-name', 'body')
+            logger.debug('x-body-name is %s' % x_body_name)
+            if x_body_name in arguments or has_kwargs:
+                return {x_body_name: body}
+        return {}
+
     @abc.abstractproperty
     def parameters(self):
         """

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -1,0 +1,293 @@
+import logging
+from copy import deepcopy
+
+from connexion.operations.abstract import AbstractOperation
+
+from ..decorators.uri_parsing import OpenAPIURIParser
+from ..utils import deep_get, is_null, is_nullable, make_type
+
+logger = logging.getLogger("connexion.operations.openapi3")
+
+
+class OpenAPIOperation(AbstractOperation):
+
+    """
+    A single API operation on a path.
+    """
+
+    def __init__(self, api, method, path, operation, resolver, path_parameters=None,
+                 app_security=None, components=None, validate_responses=False,
+                 strict_validation=False, randomize_endpoint=None, validator_map=None,
+                 pythonic_params=False, uri_parser_class=None, pass_context_arg_name=None):
+        """
+        This class uses the OperationID identify the module and function that will handle the operation
+
+        From Swagger Specification:
+
+        **OperationID**
+
+        A friendly name for the operation. The id MUST be unique among all operations described in the API.
+        Tools and libraries MAY use the operation id to uniquely identify an operation.
+
+        :param method: HTTP method
+        :type method: str
+        :param path:
+        :type path: str
+        :param operation: swagger operation object
+        :type operation: dict
+        :param resolver: Callable that maps operationID to a function
+        :param path_parameters: Parameters defined in the path level
+        :type path_parameters: list
+        :param app_security: list of security rules the application uses by default
+        :type app_security: list
+        :param components: `Components Object
+            <https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#componentsObject>`_
+        :type components: dict
+        :param validate_responses: True enables validation. Validation errors generate HTTP 500 responses.
+        :type validate_responses: bool
+        :param strict_validation: True enables validation on invalid request parameters
+        :type strict_validation: bool
+        :param randomize_endpoint: number of random characters to append to operation name
+        :type randomize_endpoint: integer
+        :param validator_map: Custom validators for the types "parameter", "body" and "response".
+        :type validator_map: dict
+        :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended
+        to any shadowed built-ins
+        :type pythonic_params: bool
+        :param uri_parser_class: class to use for uri parseing
+        :type uri_parser_class: AbstractURIParser
+        :param pass_context_arg_name: If not None will try to inject the request context to the function using this
+        name.
+        :type pass_context_arg_name: str|None
+        """
+        self.components = components or {}
+
+        def component_get(oas3_name):
+            return self.components.get(oas3_name, {})
+
+        # operation overrides globals
+        security_schemes = component_get('securitySchemes')
+        app_security = operation.get('security', app_security)
+        uri_parser_class = uri_parser_class or OpenAPIURIParser
+
+        super(OpenAPIOperation, self).__init__(
+            api=api,
+            method=method,
+            path=path,
+            operation=operation,
+            resolver=resolver,
+            app_security=app_security,
+            security_schemes=security_schemes,
+            validate_responses=validate_responses,
+            strict_validation=strict_validation,
+            randomize_endpoint=randomize_endpoint,
+            validator_map=validator_map,
+            pythonic_params=pythonic_params,
+            uri_parser_class=uri_parser_class,
+            pass_context_arg_name=pass_context_arg_name
+        )
+
+        self._definitions_map = {
+            'components': {
+                'schemas': component_get('schemas'),
+                'examples': component_get('examples'),
+                'requestBodies': component_get('requestBodies'),
+                'parameters': component_get('parameters'),
+                'securitySchemes': component_get('securitySchemes'),
+                'responses': component_get('responses'),
+                'headers': component_get('headers'),
+            }
+        }
+
+        self._request_body = operation.get('requestBody')
+
+        self._parameters = operation.get('parameters', [])
+        if path_parameters:
+            self._parameters += path_parameters
+
+        self._responses = operation.get('responses', {})
+
+        # TODO figure out how to support multiple mimetypes
+        # NOTE we currently just combine all of the possible mimetypes,
+        #      but we need to refactor to support mimetypes by response code
+        response_codes = operation.get('responses', {})
+        response_content_types = []
+        for _, defn in response_codes.items():
+            response_content_types += defn.get('content', {}).keys()
+        self._produces = response_content_types or ['application/json']
+
+        request_content = operation.get('requestBody', {}).get('content', {})
+        self._consumes = list(request_content.keys()) or ['application/json']
+
+        logger.debug('consumes: %s' % self.consumes)
+        logger.debug('produces: %s' % self.produces)
+
+    @property
+    def request_body(self):
+        return self._request_body
+
+    @property
+    def parameters(self):
+        return self._parameters
+
+    @property
+    def responses(self):
+        return self._responses
+
+    @property
+    def consumes(self):
+        return self._consumes
+
+    @property
+    def produces(self):
+        return self._produces
+
+    @property
+    def _spec_definitions(self):
+        return self._definitions_map
+
+    def with_definitions(self, schema):
+        if self.components:
+            schema['schema']['components'] = self.components
+        return schema
+
+    def response_schema(self, status_code=None, content_type=None):
+        response_definition = self.response_definition(
+            status_code, content_type
+        )
+        content_definition = response_definition.get("content", response_definition)
+        content_definition = content_definition.get(content_type, content_definition)
+        if "schema" in content_definition:
+            return self.with_definitions(content_definition).get("schema", {})
+        return {}
+
+    def example_response(self, status_code=None, content_type=None):
+        """
+        Returns example response from spec
+        """
+        # simply use the first/lowest status code, this is probably 200 or 201
+        status_code = status_code or sorted(self._responses.keys())[0]
+
+        content_type = content_type or self.get_mimetype()
+        examples_path = [str(status_code), 'content', content_type, 'examples']
+        example_path = [str(status_code), 'content', content_type, 'example']
+        schema_example_path = [
+            str(status_code), 'content', content_type, 'schema', 'example'
+        ]
+
+        try:
+            status_code = int(status_code)
+        except ValueError:
+            status_code = 200
+        try:
+            # TODO also use example header?
+            return (
+                list(deep_get(self._responses, examples_path).values())[0],
+                status_code
+            )
+        except (KeyError, IndexError):
+            pass
+        try:
+            return (deep_get(self._responses, example_path), status_code)
+        except KeyError:
+            pass
+        try:
+            return (deep_get(self._responses, schema_example_path),
+                    status_code)
+        except KeyError:
+            return (None, status_code)
+
+    def get_path_parameter_types(self):
+        types = {}
+        path_parameters = (p for p in self.parameters if p["in"] == "path")
+        for path_defn in path_parameters:
+            path_schema = path_defn["schema"]
+            if path_schema.get('type') == 'string' and path_schema.get('format') == 'path':
+                # path is special case for type 'string'
+                path_type = 'path'
+            else:
+                path_type = path_schema.get('type')
+            types[path_defn['name']] = path_type
+        return types
+
+    @property
+    def body_schema(self):
+        """
+        The body schema definition for this operation.
+        """
+        return self.body_definition.get('schema', {})
+
+    @property
+    def body_definition(self):
+        """
+        The body complete definition for this operation.
+
+        **There can be one "body" parameter at most.**
+
+        :rtype: dict
+        """
+        if self._request_body:
+            if len(self.consumes) > 1:
+                logger.warning(
+                    'this operation accepts multiple content types, using %s',
+                    self.consumes[0])
+            res = self._request_body.get('content', {}).get(self.consumes[0], {})
+            return self.with_definitions(res)
+        return {}
+
+    def _get_body_argument(self, body, arguments, has_kwargs, sanitize):
+
+        x_body_name = self.body_schema.get('x-body-name', 'body')
+        if is_nullable(self.body_schema) and is_null(body):
+            return {x_body_name: None}
+
+        default_body = self.body_schema.get('default', {})
+        body_props = {sanitize(k): {"schema": v} for k, v
+                      in self.body_schema.get("properties", {}).items()}
+
+        body = body or default_body
+
+        if self.body_schema.get("type") != "object":
+            if x_body_name in arguments or has_kwargs:
+                return {x_body_name: body}
+            return {}
+
+        body_arg = deepcopy(default_body)
+        body_arg.update(body or {})
+
+        res = {}
+        if body_props:
+            for key, value in body_arg.items():
+                key = sanitize(key)
+                try:
+                    prop_defn = body_props[key]
+                    res[key] = self._get_val_from_param(value, prop_defn)
+                except KeyError:  # pragma: no cover
+                    logger.error("Body property '{}' not defined in body schema".format(key))
+        if x_body_name in arguments or has_kwargs:
+            return {x_body_name: res}
+        return {}
+
+    def _get_query_arguments(self, query, arguments, has_kwargs, sanitize):
+        query_defns = {sanitize(p["name"]): p
+                       for p in self.parameters
+                       if p["in"] == "query"}
+        default_query_params = {k: v["schema"]['default']
+                                for k, v in query_defns.items()
+                                if 'default' in v["schema"]}
+
+        query_arguments = deepcopy(default_query_params)
+        query_arguments.update(query)
+        return self._query_args_helper(query_defns, query_arguments,
+                                       arguments, has_kwargs, sanitize)
+
+    def _get_val_from_param(self, value, query_defn):
+        query_schema = query_defn["schema"]
+
+        if is_nullable(query_schema) and is_null(value):
+            return None
+
+        if query_schema["type"] == "array":
+            return [make_type(part, query_schema["items"]["type"]) for part in value]
+        else:
+            return make_type(value, query_schema["type"])

--- a/connexion/options.py
+++ b/connexion/options.py
@@ -1,6 +1,7 @@
 import logging
 import pathlib
 from typing import Optional  # NOQA
+from swagger_ui_bundle import swagger_ui_2_path
 
 try:
     from swagger_ui_bundle import swagger_ui_2_path

--- a/connexion/options.py
+++ b/connexion/options.py
@@ -1,12 +1,12 @@
 import logging
 import pathlib
 from typing import Optional  # NOQA
-from swagger_ui_bundle import swagger_ui_2_path
 
 try:
-    from swagger_ui_bundle import swagger_ui_2_path
+    from swagger_ui_bundle import (swagger_ui_2_path,
+                                   swagger_ui_3_path)
 except ImportError:
-    swagger_ui_2_path = None
+    swagger_ui_2_path = swagger_ui_3_path = None
 
 MODULE_PATH = pathlib.Path(__file__).absolute().parent
 NO_UI_MSG = """The swagger_ui directory could not be found.
@@ -22,8 +22,12 @@ class ConnexionOptions(object):
     def __init__(self, options=None, oas_version=(2,)):
         self._options = {}
         self.oas_version = oas_version
-        self.openapi_spec_name = '/swagger.json'
-        self.swagger_ui_local_path = swagger_ui_2_path
+        if self.oas_version >= (3, 0, 0):
+            self.openapi_spec_name = '/openapi.json'
+            self.swagger_ui_local_path = swagger_ui_3_path
+        else:
+            self.openapi_spec_name = '/swagger.json'
+            self.swagger_ui_local_path = swagger_ui_2_path
 
         if options:
             self._options.update(filter_values(options))

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ install_requires = [
     'PyYAML>=3.11',
     'requests>=2.9.1',
     'six>=1.9',
+    'swagger-ui-bundle==0.0.1',
     'inflection>=0.3.1',
     'pathlib>=1.0.1; python_version < "3.4"',
     'typing>=3.6.1; python_version < "3.6"',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ install_requires = [
     'PyYAML>=3.11',
     'requests>=2.9.1',
     'six>=1.9',
-    'swagger-ui-bundle==0.0.1',
     'inflection>=0.3.1',
     'pathlib>=1.0.1; python_version < "3.4"',
     'typing>=3.6.1; python_version < "3.6"',

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -9,7 +9,7 @@ from conftest import TEST_FOLDER, build_app_from_fixture
 from connexion import App
 from connexion.exceptions import InvalidSpecification
 
-SPECS = ["swagger.yaml"]
+SPECS = ["swagger.yaml", "openapi.yaml"]
 
 
 @pytest.mark.parametrize("spec", SPECS)
@@ -150,11 +150,11 @@ def test_no_swagger_json_api(simple_api_spec_dir, spec):
     assert swagger_json.status_code == 404
 
 
-@pytest.mark.parametrize("spec", SPECS)
-def test_swagger_json_content_type(simple_app, spec):
+def test_swagger_json_content_type(simple_app):
     app_client = simple_app.app.test_client()
+    spec = simple_app._spec_file
     url = '/v1.0/{spec}'.format(spec=spec.replace("yaml", "json"))
-    response = app_client.get(url, data={})  # type: flask.Response
+    response = app_client.get(url)  # type: flask.Response
     assert response.status_code == 200
     assert response.content_type == 'application/json'
 

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -62,6 +62,10 @@ def test_array_query_param(simple_app):
     response = app_client.get(url, headers=headers)
     array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [str] multi array with csv format
     assert array_response == ['D', 'E', 'F']
+    url = '/v1.0/test_array_multi_query_param?items=A&items=B&items=C&items=D,E,F'
+    response = app_client.get(url, headers=headers)
+    array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [str] multi array with csv format
+    assert array_response == ['A', 'B', 'C', 'D', 'E', 'F']
     url = '/v1.0/test_array_pipes_query_param?items=4&items=5&items=6&items=7|8|9'
     response = app_client.get(url, headers=headers)
     array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [int] multi array with pipes format
@@ -168,7 +172,10 @@ def test_formdata_bad_request(simple_app):
     resp = app_client.post('/v1.0/test-formData-param')
     assert resp.status_code == 400
     response = json.loads(resp.data.decode('utf-8', 'replace'))
-    assert response['detail'] == "Missing formdata parameter 'formData'"
+    assert response['detail'] in [
+        "Missing formdata parameter 'formData'",
+        "'formData' is a required property" # OAS3
+    ]
 
 
 def test_formdata_missing_param(simple_app):
@@ -210,7 +217,10 @@ def test_formdata_file_upload_bad_request(simple_app):
     resp = app_client.post('/v1.0/test-formData-file-upload')
     assert resp.status_code == 400
     response = json.loads(resp.data.decode('utf-8', 'replace'))
-    assert response['detail'] == "Missing formdata parameter 'formData'"
+    assert response['detail'] in [
+        "Missing formdata parameter 'formData'",
+        "'formData' is a required property" # OAS3
+    ]
 
 
 def test_formdata_file_upload_missing_param(simple_app):
@@ -313,10 +323,11 @@ def test_nullable_parameter(simple_app):
     resp = app_client.post('/v1.0/nullable-parameters', data={"post_param": 'null'})
     assert json.loads(resp.data.decode('utf-8', 'replace')) == 'it was None'
 
-    resp = app_client.put('/v1.0/nullable-parameters', data="null")
+    headers = {"Content-Type": "application/json"}
+    resp = app_client.put('/v1.0/nullable-parameters', data="null", headers=headers)
     assert json.loads(resp.data.decode('utf-8', 'replace')) == 'it was None'
 
-    resp = app_client.put('/v1.0/nullable-parameters', data="None")
+    resp = app_client.put('/v1.0/nullable-parameters', data="None", headers=headers)
     assert json.loads(resp.data.decode('utf-8', 'replace')) == 'it was None'
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ logging.basicConfig(level=logging.DEBUG)
 TEST_FOLDER = pathlib.Path(__file__).parent
 FIXTURES_FOLDER = TEST_FOLDER / 'fixtures'
 SPEC_FOLDER = TEST_FOLDER / "fakeapi"
-SPECS = ["swagger.yaml"]
+SPECS = ["swagger.yaml", "openapi.yaml"]
 
 
 class FakeResponse(object):
@@ -88,7 +88,7 @@ def default_param_error_spec_dir():
     return FIXTURES_FOLDER / 'default_param_error'
 
 
-def build_app_from_fixture(api_spec_folder, spec_file='swagger.yaml', **kwargs):
+def build_app_from_fixture(api_spec_folder, spec_file='openapi.yaml', **kwargs):
     debug = True
     if 'debug' in kwargs:
         debug = kwargs['debug']

--- a/tests/decorators/test_uri_parsing.py
+++ b/tests/decorators/test_uri_parsing.py
@@ -40,7 +40,8 @@ def test_uri_parser_query_params(parser_class, expected, query_in, collection_fo
          "items": {"type": "string"},
          "collectionFormat": collection_format}
     ]
-    p = parser_class(parameters)
+    body_defn = {}
+    p = parser_class(parameters, body_defn)
     res = p(lambda x: x)(request)
     assert res.query["letters"] == expected
 
@@ -69,7 +70,8 @@ def test_uri_parser_form_params(parser_class, expected, query_in, collection_for
          "items": {"type": "string"},
          "collectionFormat": collection_format}
     ]
-    p = parser_class(parameters)
+    body_defn = {}
+    p = parser_class(parameters, body_defn)
     res = p(lambda x: x)(request)
     assert res.form["letters"] == expected
 
@@ -95,6 +97,7 @@ def test_uri_parser_path_params(parser_class, expected, query_in, collection_for
          "items": {"type": "string"},
          "collectionFormat": collection_format}
     ]
-    p = parser_class(parameters)
+    body_defn = {}
+    p = parser_class(parameters, body_defn)
     res = p(lambda x: x)(request)
     assert res.path_params["letters"] == expected

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -37,6 +37,10 @@ def post_greeting(name, **kwargs):
     data = {'greeting': 'Hello {name}'.format(name=name)}
     return data
 
+def post_greeting3(body, **kwargs):
+    data = {'greeting': 'Hello {name}'.format(name=body["name"])}
+    return data
+
 def post_greeting_url(name, remainder, **kwargs):
     data = {'greeting': 'Hello {name} thanks for {remainder}'.format(name=name,remainder=remainder)}
     return data
@@ -210,11 +214,23 @@ def test_array_csv_query_param(items):
     return items
 
 
+def test_array_pipes_form_param3(items):
+    return items['items']
+
+
+def test_array_csv_form_param3(items):
+    return items['items']
+
+
 def test_array_pipes_form_param(items):
     return items
 
 
 def test_array_csv_form_param(items):
+    return items
+
+
+def test_array_multi_query_param(items):
     return items
 
 
@@ -260,6 +276,9 @@ def test_default_integer_body(stack_version):
 
 def test_falsy_param(falsy):
     return falsy
+
+def test_formdata_param3(body):
+    return body["formData"]
 
 
 def test_formdata_param(formData):
@@ -341,6 +360,14 @@ def test_nullable_param_post(post_param):
     return post_param
 
 
+def test_nullable_param_post3(body):
+    if body is None:
+        return 'it was None'
+    if body["post_param"] is None:
+        return 'it was None'
+    return body["post_param"]
+
+
 def test_nullable_param_put(contents):
     if contents is None:
         return 'it was None'
@@ -396,12 +423,25 @@ def test_args_kwargs(*args, **kwargs):
     return kwargs
 
 
+def test_args_kwargs3(body=None, *args, **kwargs):
+    return kwargs
+
+
 def test_param_sanitization(query=None, form=None):
     result = {}
     if query:
         result['query'] = query
     if form:
         result['form'] = form
+    return result
+
+
+def test_param_sanitization3(query=None, body=None):
+    result = {}
+    if query:
+        result['query'] = query
+    if body:
+        result['form'] = body["form"]
     return result
 
 

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -241,6 +241,53 @@ paths:
       responses:
         '200':
           description: OK
+
+  /test_array_csv_form_param:
+    post:
+      operationId: fakeapi.hello.test_array_csv_form_param3
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              default:
+                items: ["squash", "banana"]
+              x-body-name: items
+              properties:
+                items:
+                  type: array
+                  items:
+                    type: string
+            encoding:
+              items:
+                style: simple
+      responses:
+        200:
+          description: OK
+
+  /test_array_pipes_form_param:
+    post:
+      operationId: fakeapi.hello.test_array_pipes_form_param3
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              x-body-name: items
+              properties:
+                items:
+                  type: array
+                  items:
+                    type: integer
+              required:
+              - items
+            encoding:
+              items:
+                style: pipeDelimited
+      responses:
+        200:
+          description: OK
+
   /test_array_csv_query_param:
     get:
       operationId: fakeapi.hello.test_array_csv_query_param
@@ -248,7 +295,26 @@ paths:
         - name: items
           in: query
           description: An comma separated array of items
-          style: form
+          style: simple
+          schema:
+            type: array
+            default: ["squash", "banana"]
+            items:
+              type: string
+      responses:
+        '200':
+          description: OK
+
+
+  /test_array_multi_query_param:
+    get:
+      operationId: fakeapi.hello.test_array_multi_query_param
+      parameters:
+        - name: items
+          in: query
+          description: An comma separated array of items
+          style: csv
+          explode: true
           schema:
             type: array
             default: ["squash", "banana"]
@@ -497,7 +563,7 @@ paths:
       operationId: fakeapi.hello.post_goodday_no_header
       responses:
         '201':
-          description: gooday response
+          description: goodday response
           headers:
             Location:
               description: The URI of the created resource
@@ -524,6 +590,9 @@ paths:
             text/plain:
               schema:
                 type: string
+              examples:
+                justAnExample:
+                  $ref: '#/components/examples/justAnExample'
       parameters:
         - name: name
           in: path
@@ -588,6 +657,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               type: object
+              nullable: true
               properties:
                 post_param:
                   description: Just a testing parameter.
@@ -664,7 +734,7 @@ paths:
                 type: string
   /query-params-as-kwargs:
     get:
-      operationId: fakeapi.hello.test_args_kwargs
+      operationId: fakeapi.hello.test_args_kwargs3
       parameters:
         - name: foo
           description: Just a testing parameter.
@@ -831,6 +901,10 @@ components:
                 type: string
       description: Just a testing parameter in the body
       required: true
+  examples:
+    justAnExample:
+      summary: a basic example.
+      value: Good evening, doctor.
   schemas:
     new_stack:
       type: object

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -247,6 +247,8 @@ paths:
   /test_array_csv_form_param:
     post:
       operationId: fakeapi.hello.test_array_csv_form_param
+      consumes:
+        - application/x-www-form-urlencoded
       parameters:
         - name: items
           in: formData
@@ -263,6 +265,8 @@ paths:
   /test_array_pipes_form_param:
     post:
       operationId: fakeapi.hello.test_array_pipes_form_param
+      consumes:
+        - application/x-www-form-urlencoded
       parameters:
         - name: items
           in: formData
@@ -287,6 +291,21 @@ paths:
             type: string
           collectionFormat: csv
           default: ["squash", "banana"]
+      responses:
+        200:
+          description: OK
+
+  /test_array_multi_query_param:
+    get:
+      operationId: fakeapi.hello.test_array_multi_query_param
+      parameters:
+        - name: items
+          in: query
+          description: An comma separated array of items
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
       responses:
         200:
           description: OK
@@ -377,6 +396,8 @@ paths:
 
   /test-formData-param:
     post:
+      consumes:
+        - application/x-www-form-urlencoded
       summary: Test formData parameter
       operationId: fakeapi.hello.test_formdata_param
       parameters:
@@ -596,6 +617,8 @@ paths:
   /nullable-parameters:
     post:
       operationId: fakeapi.hello.test_nullable_param_post
+      consumes:
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:

--- a/tests/test_mock3.py
+++ b/tests/test_mock3.py
@@ -1,0 +1,141 @@
+from connexion.mock import MockResolver
+from connexion.operations import OpenAPIOperation
+
+
+def test_mock_resolver():
+    resolver = MockResolver(mock_all=True)
+
+    responses = {
+        'default': {
+            'content': {
+                'application/json': {
+                    'examples': {
+                        "super_cool_example": {
+                            'foo': 'bar'
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='endpoint',
+        path_parameters=[],
+        operation={
+            'responses': responses
+        },
+        app_security=[],
+        resolver=resolver
+    )
+    assert operation.operation_id == 'mock-1'
+
+    response, status_code = resolver.mock_operation(operation)
+    assert status_code == 200
+    assert response == {'foo': 'bar'}
+
+
+def test_mock_resolver_inline_schema_example():
+    resolver = MockResolver(mock_all=True)
+
+    responses = {
+        'default': {
+            'content': {
+                'application/json': {
+                    'schema': {
+                        'type': 'object',
+                        'properties': {
+                            'foo': {
+                                'schema': {
+                                    'type': 'string'
+                                }
+                            }
+                        }
+                    },
+                    'example': {
+                        'foo': 'bar'
+                    }
+                }
+            }
+        }
+    }
+
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='endpoint',
+        path_parameters=[],
+        operation={
+            'responses': responses
+        },
+        app_security=[],
+        resolver=resolver
+    )
+    assert operation.operation_id == 'mock-1'
+
+    response, status_code = resolver.mock_operation(operation)
+    assert status_code == 200
+    assert response == {'foo': 'bar'}
+
+def test_mock_resolver_no_examples():
+    resolver = MockResolver(mock_all=True)
+
+    responses = {
+        '418': {}
+    }
+
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='endpoint',
+        path_parameters=[],
+        operation={
+            'responses': responses
+        },
+        app_security=[],
+        resolver=resolver
+    )
+    assert operation.operation_id == 'mock-1'
+
+    response, status_code = resolver.mock_operation(operation)
+    assert status_code == 418
+    assert response == 'No example response was defined.'
+
+def test_mock_resolver_notimplemented():
+    resolver = MockResolver(mock_all=False)
+
+    responses = {
+        '418': {}
+    }
+
+    # do not mock the existent functions
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='endpoint',
+        path_parameters=[],
+        operation={
+            'operationId': 'fakeapi.hello.get'
+        },
+        app_security=[],
+        resolver=resolver
+    )
+    assert operation.operation_id == 'fakeapi.hello.get'
+
+    # mock only the nonexistent ones
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='endpoint',
+        path_parameters=[],
+        operation={
+            'operationId': 'fakeapi.hello.nonexistent_function',
+            'responses': responses
+        },
+        app_security=[],
+        resolver=resolver
+    )
+    # check if it is using the mock function
+    assert operation._resolution.function() == ('No example response was defined.', 418)

--- a/tests/test_resolver3.py
+++ b/tests/test_resolver3.py
@@ -1,0 +1,180 @@
+from connexion.operations import OpenAPIOperation
+from connexion.resolver import Resolver, RestyResolver
+
+COMPONENTS = {'parameters': {'myparam': {'in': 'path', 'schema': {'type': 'integer'}}}}
+
+
+def test_standard_resolve_x_router_controller():
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='endpoint',
+        path_parameters=[],
+        operation={
+            'x-swagger-router-controller': 'fakeapi.hello',
+            'operationId': 'post_greeting',
+        },
+        app_security=[],
+        components=COMPONENTS,
+        resolver=Resolver()
+    )
+    assert operation.operation_id == 'fakeapi.hello.post_greeting'
+
+
+def test_resty_resolve_operation_id():
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='endpoint',
+        path_parameters=[],
+        operation={
+            'operationId': 'fakeapi.hello.post_greeting',
+        },
+        app_security=[],
+        components=COMPONENTS,
+        resolver=RestyResolver('fakeapi')
+    )
+    assert operation.operation_id == 'fakeapi.hello.post_greeting'
+
+
+def test_resty_resolve_x_router_controller_with_operation_id():
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='endpoint',
+        path_parameters=[],
+        operation={
+            'x-swagger-router-controller': 'fakeapi.hello',
+            'operationId': 'post_greeting',
+        },
+        app_security=[],
+        components=COMPONENTS,
+        resolver=RestyResolver('fakeapi')
+    )
+    assert operation.operation_id == 'fakeapi.hello.post_greeting'
+
+
+def test_resty_resolve_x_router_controller_without_operation_id():
+    operation = OpenAPIOperation(api=None,
+                          method='GET',
+                          path='/hello/{id}',
+                          path_parameters=[],
+                          operation={'x-swagger-router-controller': 'fakeapi.hello'},
+                          app_security=[],
+                          components=COMPONENTS,
+                          resolver=RestyResolver('fakeapi'))
+    assert operation.operation_id == 'fakeapi.hello.get'
+
+
+def test_resty_resolve_with_default_module_name():
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='/hello/{id}',
+        path_parameters=[],
+        operation={},
+        app_security=[],
+        components=COMPONENTS,
+        resolver=RestyResolver('fakeapi')
+    )
+    assert operation.operation_id == 'fakeapi.hello.get'
+
+
+def test_resty_resolve_with_default_module_name_lowercase_verb():
+    operation = OpenAPIOperation(
+        api=None,
+        method='get',
+        path='/hello/{id}',
+        path_parameters=[],
+        operation={},
+        app_security=[],
+        components=COMPONENTS,
+        resolver=RestyResolver('fakeapi')
+    )
+    assert operation.operation_id == 'fakeapi.hello.get'
+
+
+def test_resty_resolve_with_default_module_name_will_translate_dashes_in_resource_name():
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='/foo-bar',
+        path_parameters=[],
+        operation={},
+        app_security=[],
+        components=COMPONENTS,
+        resolver=RestyResolver('fakeapi')
+    )
+    assert operation.operation_id == 'fakeapi.foo_bar.search'
+
+
+def test_resty_resolve_with_default_module_name_can_resolve_api_root():
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='/',
+        path_parameters=[],
+        operation={},
+        app_security=[],
+        components=COMPONENTS,
+        resolver=RestyResolver('fakeapi')
+    )
+    assert operation.operation_id == 'fakeapi.get'
+
+
+def test_resty_resolve_with_default_module_name_will_resolve_resource_root_get_as_search():
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='/hello',
+        path_parameters=[],
+        operation={},
+        app_security=[],
+        components=COMPONENTS,
+        resolver=RestyResolver('fakeapi')
+    )
+    assert operation.operation_id == 'fakeapi.hello.search'
+
+
+def test_resty_resolve_with_default_module_name_and_x_router_controller_will_resolve_resource_root_get_as_search():
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='/hello',
+        path_parameters=[],
+        operation={
+            'x-swagger-router-controller': 'fakeapi.hello',
+        },
+        app_security=[],
+        components=COMPONENTS,
+        resolver=RestyResolver('fakeapi')
+    )
+    assert operation.operation_id == 'fakeapi.hello.search'
+
+
+def test_resty_resolve_with_default_module_name_will_resolve_resource_root_as_configured():
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='/hello',
+        path_parameters=[],
+        operation={},
+        app_security=[],
+        components=COMPONENTS,
+        resolver=RestyResolver('fakeapi', 'api_list')
+    )
+    assert operation.operation_id == 'fakeapi.hello.api_list'
+
+
+def test_resty_resolve_with_default_module_name_will_resolve_resource_root_post_as_post():
+    operation = OpenAPIOperation(
+        api=None,
+        method='POST',
+        path='/hello',
+        path_parameters=[],
+        operation={},
+        app_security=[],
+        components=COMPONENTS,
+        resolver=RestyResolver('fakeapi')
+    )
+    assert operation.operation_id == 'fakeapi.hello.post'


### PR DESCRIPTION
Fixes #420 

Changes proposed in this pull request:
 - support openapi version 3

Architecture:
 - creates an AbstractOperation class, which defines the interface for what an Operation is
 - Implements this interface with Swagger2Operation and OpenAPIOperation classes
 - apis/abstract.py uses the correct operation class based on the version of the spec
