### PR TITLE
Minor change in readme about non-required parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -247,9 +247,10 @@ function expects an argument named ``message`` and assigns the value
 of the endpoint parameter ``message`` to your view function.
 
 .. warning:: When you define a parameter at your endpoint as *not* required, and
-    your Python view has a non-named argument, you will get a "missing
-    positional argument" exception whenever you call this endpoint WITHOUT the
-    parameter.
+    this argument does not have default value in your Python view, you will get 
+    a "missing positional argument" exception whenever you call this endpoint 
+    WITHOUT the parameter. Provide a default value for a named argument or use
+    ``**kwargs`` dict.
 
 Type casting
 ^^^^^^^^^^^^


### PR DESCRIPTION
I think "non-named" word was ill-placed here (at least I did not understand what it meant). I tried to clarify this better and propose a solution to not get a exception.

Changes proposed in this pull request:
Slightly changed wording in README