### PR TITLE
resolve json references earlier, generically

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -10,8 +10,8 @@ import six
 import yaml
 from swagger_spec_validator.validator20 import validate_spec
 
-from ..exceptions import InvalidSpecification, ResolverError
-from ..jsonref import RefResolutionError, resolve_refs
+from ..exceptions import ResolverError
+from ..jsonref import resolve_refs
 from ..operation import Operation
 from ..options import ConnexionOptions
 from ..resolver import Resolver
@@ -89,10 +89,7 @@ class AbstractAPI(object):
         # Avoid validator having ability to modify specification
         spec = copy.deepcopy(self.specification)
         self._validate_spec(spec)
-        try:
-            self.specification = resolve_refs(spec)
-        except RefResolutionError as exc:
-            raise InvalidSpecification(repr(exc))
+        self.specification = resolve_refs(spec)
 
         # https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#fixed-fields
         # If base_path is not on provided then we try to read it from the swagger.yaml or use / by default

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -10,7 +10,8 @@ import six
 import yaml
 from swagger_spec_validator.validator20 import validate_spec
 
-from ..exceptions import ResolverError
+from ..exceptions import InvalidSpecification, ResolverError
+from ..jsonref import RefResolutionError, resolve_refs
 from ..operation import Operation
 from ..options import ConnexionOptions
 from ..resolver import Resolver
@@ -88,6 +89,10 @@ class AbstractAPI(object):
         # Avoid validator having ability to modify specification
         spec = copy.deepcopy(self.specification)
         self._validate_spec(spec)
+        try:
+            self.specification = resolve_refs(spec)
+        except RefResolutionError as exc:
+            raise InvalidSpecification(repr(exc))
 
         # https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#fixed-fields
         # If base_path is not on provided then we try to read it from the swagger.yaml or use / by default

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -34,7 +34,7 @@ class ResponseValidator(BaseDecorator):
         """
         response_definitions = self.operation.operation["responses"]
         response_definition = response_definitions.get(str(status_code), response_definitions.get("default", {}))
-        response_definition = self.operation.resolve_reference(response_definition)
+        response_definition = self.operation.with_definitions(response_definition)
 
         if self.is_json_schema_compatible(response_definition):
             schema = response_definition.get("schema")

--- a/connexion/jsonref.py
+++ b/connexion/jsonref.py
@@ -1,0 +1,48 @@
+import collections
+from copy import deepcopy
+
+from jsonschema import RefResolver
+from jsonschema.exceptions import RefResolutionError  # noqa
+
+from .utils import deep_get
+
+
+def resolve_refs(spec, defns=None, store=None):
+    """
+    Resolve JSON references like {"$ref": <some URI>} in a spec.
+    Optionally takes a defns dictionary to look up references.
+    If no defns dictionary is specified, references will be resolved within
+    the spec, or resolve remotely from the web. Passing defns is useful
+    if you have a namespace collision between your spec and definitions.
+    Optionally takes a store, which is a mapping from reference URLs to a
+    dereferenced objects. Prepopulating the store can avoid network calls.
+    """
+    spec = deepcopy(spec)
+    store = store or {}
+    if defns:
+        defns = deepcopy(defns)
+    resolver = RefResolver('', spec, store)
+
+    def _do_resolve(node):
+        if isinstance(node, collections.Mapping) and '$ref' in node:
+            path = node['$ref'][2:].split("/")
+            try:
+                # resolve known references
+                store = defns if defns else spec
+                node.update(deep_get(store, path))
+                del node['$ref']
+                return node
+            except KeyError:
+                # resolve external references
+                with resolver.resolving(node['$ref']) as resolved:
+                    return resolved
+        elif isinstance(node, collections.Mapping):
+            for k, v in node.items():
+                node[k] = _do_resolve(v)
+        elif isinstance(node, (list, tuple)):
+            for i in range(len(node)):
+                node[i] = _do_resolve(node[i])
+        return node
+
+    res = _do_resolve(spec)
+    return res

--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -59,7 +59,7 @@ class MockResolver(Resolver):
             status_code = int(status_code)
         except ValueError:
             status_code = 200
-        response_definition = operation.resolve_reference(response_definition)
+        response_definition = operation.with_definitions(response_definition)
         examples = response_definition.get('examples')
         if examples:
             return list(examples.values())[0], status_code

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -13,6 +13,15 @@ def deep_getattr(obj, attr):
     return functools.reduce(getattr, attr.split('.'), obj)
 
 
+def deep_get(obj, keys):
+    """
+    Recurses through a nested object get a leaf value.
+    """
+    if not keys:
+        return obj
+    return deep_get(obj[keys[0]], keys[1:])
+
+
 def get_function_from_name(function_name):
     """
     Tries to get function by fully qualified name (e.g. "mymodule.myobj.myfunc")

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -13,15 +13,6 @@ def deep_getattr(obj, attr):
     return functools.reduce(getattr, attr.split('.'), obj)
 
 
-def deep_get(obj, keys):
-    """
-    Recurses through a nested object get a leaf value.
-    """
-    if not keys:
-        return obj
-    return deep_get(obj[keys[0]], keys[1:])
-
-
 def get_function_from_name(function_name):
     """
     Tries to get function by fully qualified name (e.g. "mymodule.myobj.myfunc")

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -9,6 +9,7 @@ from connexion.decorators.security import (security_passthrough,
                                            verify_oauth_local,
                                            verify_oauth_remote)
 from connexion.exceptions import InvalidSpecification
+from connexion.jsonref import resolve_refs
 from connexion.operation import Operation
 from connexion.resolver import Resolver
 
@@ -29,7 +30,8 @@ DEFINITIONS = {'new_stack': {'required': ['image_version', 'keep_stacks', 'new_t
                                                             'Percentage of the traffic'}}},
                'composed': {'required': ['test'],
                             'type': 'object',
-                            'properties': {'test': {'schema': {'$ref': '#/definitions/new_stack'}}}}}
+                            'properties': {'test': {'schema': {'$ref': '#/definitions/new_stack'}}}},
+               'problem': {"not": "defined"}}
 PARAMETER_DEFINITIONS = {'myparam': {'in': 'path', 'type': 'integer'}}
 
 OPERATION1 = {'description': 'Adds a new stack to be created by lizzy and returns the '
@@ -43,7 +45,7 @@ OPERATION1 = {'description': 'Adds a new stack to be created by lizzy and return
                                   'CloudFormation Stack creation can '
                                   "still fail if it's rejected by senza "
                                   'or AWS CF.',
-                                  'schema': {'$ref': '#/definitions/stack'}},
+                                  'schema': {'$ref': '#/definitions/new_stack'}},
                             400: {'description': 'Stack was not created because request '
                                   'was invalid',
                                   'schema': {'$ref': '#/definitions/problem'}},
@@ -69,7 +71,7 @@ OPERATION2 = {'description': 'Adds a new stack to be created by lizzy and return
                                   'CloudFormation Stack creation can '
                                   "still fail if it's rejected by senza "
                                   'or AWS CF.',
-                                  'schema': {'$ref': '#/definitions/stack'}},
+                                  'schema': {'$ref': '#/definitions/new_stack'}},
                             400: {'description': 'Stack was not created because request '
                                   'was invalid',
                                   'schema': {'$ref': '#/definitions/problem'}},
@@ -80,35 +82,10 @@ OPERATION2 = {'description': 'Adds a new stack to be created by lizzy and return
               'security': [{'oauth': ['uid']}],
               'summary': 'Create new stack'}
 
-OPERATION3 = {'description': 'Adds a new stack to be created by lizzy and returns the '
-              'information needed to keep track of deployment',
-              'operationId': 'fakeapi.hello.post_greeting',
-              'parameters': [{'in': 'body',
-                              'name': 'new_stack',
-                              'required': True,
-                              'schema': {'$ref': '#/notdefinitions/new_stack'}}],
-              'responses': {201: {'description': 'Stack to be created. The '
-                                  'CloudFormation Stack creation can '
-                                  "still fail if it's rejected by senza "
-                                  'or AWS CF.',
-                                  'schema': {'$ref': '#/definitions/stack'}},
-                            400: {'description': 'Stack was not created because request '
-                                  'was invalid',
-                                  'schema': {'$ref': '#/definitions/problem'}},
-                            401: {'description': 'Stack was not created because the '
-                                  'access token was not provided or was '
-                                  'not valid for this operation',
-                                  'schema': {'$ref': '#/definitions/problem'}}},
-              'security': [{'oauth': ['uid']}],
-              'summary': 'Create new stack'}
-
-OPERATION4 = {'operationId': 'fakeapi.hello.post_greeting',
+OPERATION3 = {'operationId': 'fakeapi.hello.post_greeting',
               'parameters': [{'$ref': '#/parameters/myparam'}]}
 
-OPERATION5 = {'operationId': 'fakeapi.hello.post_greeting',
-              'parameters': [{'$ref': '/parameters/fail'}]}
-
-OPERATION6 = {'description': 'Adds a new stack to be created by lizzy and returns the '
+OPERATION4 = {'description': 'Adds a new stack to be created by lizzy and returns the '
               'information needed to keep track of deployment',
               'operationId': 'fakeapi.hello.post_greeting',
               'parameters': [
@@ -129,7 +106,7 @@ OPERATION6 = {'description': 'Adds a new stack to be created by lizzy and return
                                   'CloudFormation Stack creation can '
                                   "still fail if it's rejected by senza "
                                   'or AWS CF.',
-                                  'schema': {'$ref': '#/definitions/stack'}},
+                                  'schema': {'$ref': '#/definitions/new_stack'}},
                             400: {'description': 'Stack was not created because request '
                                   'was invalid',
                                   'schema': {'$ref': '#/definitions/problem'}},
@@ -139,7 +116,7 @@ OPERATION6 = {'description': 'Adds a new stack to be created by lizzy and return
                                   'schema': {'$ref': '#/definitions/problem'}}},
               'summary': 'Create new stack'}
 
-OPERATION7 = {
+OPERATION5 = {
     'description': 'Adds a new stack to be created by lizzy and returns the '
     'information needed to keep track of deployment',
     'operationId': 'fakeapi.hello.post_greeting',
@@ -156,7 +133,7 @@ OPERATION7 = {
                           'CloudFormation Stack creation can '
                           "still fail if it's rejected by senza "
                           'or AWS CF.',
-                          'schema': {'$ref': '#/definitions/stack'}},
+                          'schema': {'$ref': '#/definitions/new_stack'}},
                   '400': {'description': 'Stack was not created because request '
                           'was invalid',
                           'schema': {'$ref': '#/definitions/problem'}},
@@ -168,7 +145,7 @@ OPERATION7 = {
     'summary': 'Create new stack'
 }
 
-OPERATION8 = {
+OPERATION6 = {
     'operationId': 'fakeapi.hello.schema',
     'parameters': [
         {
@@ -185,7 +162,7 @@ OPERATION8 = {
     'summary': 'Create new stack'
 }
 
-OPERATION9 = {'description': 'Adds a new stack to be created by lizzy and returns the '
+OPERATION7 = {'description': 'Adds a new stack to be created by lizzy and returns the '
               'information needed to keep track of deployment',
               'operationId': 'fakeapi.hello.post_greeting',
               'parameters': [{'in': 'body',
@@ -196,7 +173,7 @@ OPERATION9 = {'description': 'Adds a new stack to be created by lizzy and return
                                     'CloudFormation Stack creation can '
                                     "still fail if it's rejected by senza "
                                     'or AWS CF.',
-                                    'schema': {'$ref': '#/definitions/stack'}},
+                                    'schema': {'$ref': '#/definitions/new_stack'}},
                             '400': {'description': 'Stack was not created because request '
                                     'was invalid',
                                     'schema': {'$ref': '#/definitions/problem'}},
@@ -207,7 +184,7 @@ OPERATION9 = {'description': 'Adds a new stack to be created by lizzy and return
               'security': [{'oauth': ['uid']}],
               'summary': 'Create new stack'}
 
-OPERATION10 = {'description': 'Adds a new stack to be created by lizzy and returns the '
+OPERATION8 = {'description': 'Adds a new stack to be created by lizzy and returns the '
                'information needed to keep track of deployment',
                'operationId': 'fakeapi.hello.post_greeting',
                'parameters': [{'in': 'body',
@@ -218,7 +195,7 @@ OPERATION10 = {'description': 'Adds a new stack to be created by lizzy and retur
                                      'CloudFormation Stack creation can '
                                      "still fail if it's rejected by senza "
                                      'or AWS CF.',
-                                     'schema': {'$ref': '#/definitions/stack'}},
+                                     'schema': {'$ref': '#/definitions/new_stack'}},
                              '400': {'description': 'Stack was not created because request '
                                      'was invalid',
                                      'schema': {'$ref': '#/definitions/problem'}},
@@ -256,11 +233,15 @@ def api():
 
 
 def test_operation(api):
+    op_spec = resolve_refs(OPERATION1, {
+        "definitions": DEFINITIONS,
+        "parameters": PARAMETER_DEFINITIONS
+    })
     operation = Operation(api=api,
                           method='GET',
                           path='endpoint',
                           path_parameters=[],
-                          operation=OPERATION1,
+                          operation=op_spec,
                           app_produces=['application/json'],
                           app_consumes=['application/json'],
                           app_security=[],
@@ -279,19 +260,21 @@ def test_operation(api):
     assert operation.consumes == ['application/json']
     assert operation.security == [{'oauth': ['uid']}]
 
-    expected_body_schema = {
-        '$ref': '#/definitions/new_stack',
-        'definitions': DEFINITIONS
-    }
+    expected_body_schema = {'definitions': DEFINITIONS}
+    expected_body_schema.update(DEFINITIONS["new_stack"])
     assert operation.body_schema == expected_body_schema
 
 
 def test_operation_array(api):
+    op_spec = resolve_refs(OPERATION7, {
+        "definitions": DEFINITIONS,
+        "parameters": PARAMETER_DEFINITIONS
+    })
     operation = Operation(api=api,
                           method='GET',
                           path='endpoint',
                           path_parameters=[],
-                          operation=OPERATION9,
+                          operation=op_spec,
                           app_produces=['application/json'],
                           app_consumes=['application/json'],
                           app_security=[],
@@ -312,18 +295,22 @@ def test_operation_array(api):
     assert operation.security == [{'oauth': ['uid']}]
     expected_body_schema = {
         'type': 'array',
-        'items': {'$ref': '#/definitions/new_stack'},
+        'items': DEFINITIONS["new_stack"],
         'definitions': DEFINITIONS
     }
     assert operation.body_schema == expected_body_schema
 
 
 def test_operation_composed_definition(api):
+    op_spec = resolve_refs(OPERATION8, {
+        "definitions": DEFINITIONS,
+        "parameters": PARAMETER_DEFINITIONS
+    })
     operation = Operation(api=api,
                           method='GET',
                           path='endpoint',
                           path_parameters=[],
-                          operation=OPERATION10,
+                          operation=op_spec,
                           app_produces=['application/json'],
                           app_consumes=['application/json'],
                           app_security=[],
@@ -342,19 +329,21 @@ def test_operation_composed_definition(api):
     assert operation.produces == ['application/json']
     assert operation.consumes == ['application/json']
     assert operation.security == [{'oauth': ['uid']}]
-    expected_body_schema = {
-        '$ref': '#/definitions/composed',
-        'definitions': DEFINITIONS
-    }
+    expected_body_schema = {'definitions': DEFINITIONS}
+    expected_body_schema.update(DEFINITIONS["composed"])
     assert operation.body_schema == expected_body_schema
 
 
 def test_operation_local_security_oauth2(api):
+    op_spec = resolve_refs(OPERATION8, {
+        "definitions": DEFINITIONS,
+        "parameters": PARAMETER_DEFINITIONS
+    })
     operation = Operation(api=api,
                           method='GET',
                           path='endpoint',
                           path_parameters=[],
-                          operation=OPERATION10,
+                          operation=op_spec,
                           app_produces=['application/json'],
                           app_consumes=['application/json'],
                           app_security=[],
@@ -374,19 +363,21 @@ def test_operation_local_security_oauth2(api):
     assert operation.produces == ['application/json']
     assert operation.consumes == ['application/json']
     assert operation.security == [{'oauth': ['uid']}]
-    expected_body_schema = {
-        '$ref': '#/definitions/composed',
-        'definitions': DEFINITIONS
-    }
+    expected_body_schema = {'definitions': DEFINITIONS}
+    expected_body_schema.update(DEFINITIONS["composed"])
     assert operation.body_schema == expected_body_schema
 
 
 def test_operation_local_security_duplicate_token_info(api):
+    op_spec = resolve_refs(OPERATION8, {
+        "definitions": DEFINITIONS,
+        "parameters": PARAMETER_DEFINITIONS
+    })
     operation = Operation(api=api,
                           method='GET',
                           path='endpoint',
                           path_parameters=[],
-                          operation=OPERATION10,
+                          operation=op_spec,
                           app_produces=['application/json'],
                           app_consumes=['application/json'],
                           app_security=[],
@@ -406,40 +397,22 @@ def test_operation_local_security_duplicate_token_info(api):
     assert operation.produces == ['application/json']
     assert operation.consumes == ['application/json']
     assert operation.security == [{'oauth': ['uid']}]
-    expected_body_schema = {
-        '$ref': '#/definitions/composed',
-        'definitions': DEFINITIONS
-    }
+    expected_body_schema = {'definitions': DEFINITIONS}
+    expected_body_schema.update(DEFINITIONS["composed"])
     assert operation.body_schema == expected_body_schema
-
-def test_non_existent_reference(api):
-    with pytest.raises(InvalidSpecification) as exc_info:  # type: py.code.ExceptionInfo
-        operation = Operation(api=api,
-                              method='GET',
-                              path='endpoint',
-                              path_parameters=[],
-                              operation=OPERATION1,
-                              app_produces=['application/json'],
-                              app_consumes=['application/json'],
-                              app_security=[],
-                              security_definitions={},
-                              definitions={},
-                              parameter_definitions={},
-                              resolver=Resolver())
-        operation.body_schema
-
-    exception = exc_info.value
-    assert str(exception) == "<InvalidSpecification: GET endpoint Definition 'new_stack' not found>"
-    assert repr(exception) == "<InvalidSpecification: GET endpoint Definition 'new_stack' not found>"
 
 
 def test_multi_body(api):
     with pytest.raises(InvalidSpecification) as exc_info:  # type: py.code.ExceptionInfo
+        op_spec = resolve_refs(OPERATION2, {
+            "definitions": DEFINITIONS,
+            "parameters": PARAMETER_DEFINITIONS
+        })
         operation = Operation(api=api,
                               method='GET',
                               path='endpoint',
                               path_parameters=[],
-                              operation=OPERATION2,
+                              operation=op_spec,
                               app_produces=['application/json'],
                               app_consumes=['application/json'],
                               app_security=[],
@@ -454,33 +427,16 @@ def test_multi_body(api):
     assert repr(exception) == "<InvalidSpecification: GET endpoint There can be one 'body' parameter at most>"
 
 
-def test_invalid_reference(api):
-    with pytest.raises(InvalidSpecification) as exc_info:  # type: py.code.ExceptionInfo
-        operation = Operation(api=api,
-                              method='GET',
-                              path='endpoint',
-                              path_parameters=[],
-                              operation=OPERATION3,
-                              app_produces=['application/json'],
-                              app_consumes=['application/json'],
-                              app_security=[],
-                              security_definitions={},
-                              definitions=DEFINITIONS,
-                              parameter_definitions=PARAMETER_DEFINITIONS,
-                              resolver=Resolver())
-        operation.body_schema
-
-    exception = exc_info.value
-    assert str(exception).startswith("<InvalidSpecification: GET endpoint $ref")
-    assert repr(exception).startswith("<InvalidSpecification: GET endpoint $ref")
-
-
 def test_no_token_info(api):
+    op_spec = resolve_refs(OPERATION1, {
+        "definitions": DEFINITIONS,
+        "parameters": PARAMETER_DEFINITIONS
+    })
     operation = Operation(api=api,
                           method='GET',
                           path='endpoint',
                           path_parameters=[],
-                          operation=OPERATION1,
+                          operation=op_spec,
                           app_produces=['application/json'],
                           app_consumes=['application/json'],
                           app_security=SECURITY_DEFINITIONS_WO_INFO,
@@ -496,19 +452,20 @@ def test_no_token_info(api):
     assert operation.consumes == ['application/json']
     assert operation.security == [{'oauth': ['uid']}]
 
-    expected_body_schema = {
-        '$ref': '#/definitions/new_stack',
-        'definitions': DEFINITIONS
-    }
+    expected_body_schema = {'definitions': DEFINITIONS}
+    expected_body_schema.update(DEFINITIONS["new_stack"])
     assert operation.body_schema == expected_body_schema
 
 
 def test_parameter_reference(api):
+    op_spec = resolve_refs(OPERATION3, {
+        "parameters": PARAMETER_DEFINITIONS
+    })
     operation = Operation(api=api,
                           method='GET',
                           path='endpoint',
                           path_parameters=[],
-                          operation=OPERATION4,
+                          operation=op_spec,
                           app_produces=['application/json'],
                           app_consumes=['application/json'],
                           app_security=[],
@@ -519,42 +476,52 @@ def test_parameter_reference(api):
     assert operation.parameters == [{'in': 'path', 'type': 'integer'}]
 
 
-def test_resolve_invalid_reference(api):
-    with pytest.raises(InvalidSpecification) as exc_info:
-        Operation(api=api, method='GET', path='endpoint', path_parameters=[],
-                  operation=OPERATION5, app_produces=['application/json'],
-                  app_consumes=['application/json'], app_security=[],
-                  security_definitions={}, definitions={},
-                  parameter_definitions=PARAMETER_DEFINITIONS, resolver=Resolver())
-
-    exception = exc_info.value  # type: InvalidSpecification
-    assert exception.reason == "GET endpoint '$ref' needs to start with '#/'"
-
-
 def test_default(api):
-    op = OPERATION6.copy()
-    op['parameters'][1]['default'] = 1
-    Operation(api=api, method='GET', path='endpoint', path_parameters=[], operation=op,
-              app_produces=['application/json'], app_consumes=['application/json'],
-              app_security=[], security_definitions={}, definitions=DEFINITIONS,
-              parameter_definitions=PARAMETER_DEFINITIONS,
-              resolver=Resolver())
-    op = OPERATION8.copy()
-    op['parameters'][0]['default'] = {
-        'keep_stacks': 1, 'image_version': 'one', 'senza_yaml': 'senza.yaml', 'new_traffic': 100
+    op_spec = resolve_refs(OPERATION4, {
+        "definitions": DEFINITIONS,
+        "parameters": PARAMETER_DEFINITIONS
+    })
+    op_spec['parameters'][1]['default'] = 1
+    Operation(
+        api=api, method='GET', path='endpoint', path_parameters=[],
+        operation=op_spec, app_produces=['application/json'],
+        app_consumes=['application/json'], app_security=[],
+        security_definitions={}, definitions=DEFINITIONS,
+        parameter_definitions=PARAMETER_DEFINITIONS, resolver=Resolver()
+    )
+    op_spec = resolve_refs(OPERATION6, {
+        "definitions": DEFINITIONS
+    })
+    op_spec['parameters'][0]['default'] = {
+        'keep_stacks': 1,
+        'image_version': 'one',
+        'senza_yaml': 'senza.yaml',
+        'new_traffic': 100
     }
-    Operation(api=api, method='POST', path='endpoint', path_parameters=[], operation=op,
-              app_produces=['application/json'], app_consumes=['application/json'], app_security=[],
-              security_definitions={}, definitions=DEFINITIONS, parameter_definitions={}, resolver=Resolver())
+    Operation(
+        api=api, method='POST', path='endpoint', path_parameters=[],
+        operation=op_spec, app_produces=['application/json'],
+        app_consumes=['application/json'], app_security=[],
+        security_definitions={}, definitions=DEFINITIONS,
+        parameter_definitions={}, resolver=Resolver()
+    )
 
 
 def test_get_path_parameter_types(api):
-    op = OPERATION1.copy()
-    op['parameters'] = [{'in': 'path', 'type': 'int', 'name': 'int_path'},
-                        {'in': 'path', 'type': 'string', 'name': 'string_path'},
-                        {'in': 'path', 'type': 'string', 'format': 'path', 'name': 'path_path'}]
+    op_spec = resolve_refs(OPERATION1, {
+        "definitions": DEFINITIONS
+    })
+    op_spec['parameters'] = [
+        {'in': 'path', 'type': 'int', 'name': 'int_path'},
+        {'in': 'path', 'type': 'string', 'name': 'string_path'},
+        {'in': 'path', 'type': 'string', 'format': 'path', 'name': 'path_path'}
+    ]
 
-    operation = Operation(api=api, method='GET', path='endpoint', path_parameters=[], operation=op,
-                          app_produces=['application/json'], app_consumes=['application/json'], resolver=Resolver())
+    operation = Operation(
+        api=api, method='GET', path='endpoint', path_parameters=[],
+        operation=op_spec, app_produces=['application/json'],
+        app_consumes=['application/json'],
+        definitions=DEFINITIONS, resolver=Resolver()
+    )
 
     assert {'int_path': 'int', 'string_path': 'string', 'path_path': 'path'} == operation.get_path_parameter_types()

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -233,13 +233,15 @@ def api():
   return mock.MagicMock(jsonifier=Jsonifier)
 
 
-def make_operation(op):
+def make_operation(op, definitions=True, parameters=True):
     """ note the wrapper because definitions namespace and
         operation namespace collide
     """
     new_op = {"wrapper": copy.deepcopy(op)}
-    new_op.update({"definitions": DEFINITIONS})
-    new_op.update({"parameters": PARAMETER_DEFINITIONS})
+    if definitions:
+        new_op.update({"definitions": DEFINITIONS})
+    if parameters:
+        new_op.update({"parameters": PARAMETER_DEFINITIONS})
     return resolve_refs(new_op)["wrapper"]
 
 
@@ -448,7 +450,7 @@ def test_no_token_info(api):
 
 
 def test_parameter_reference(api):
-    op_spec = make_operation(OPERATION3)
+    op_spec = make_operation(OPERATION3, definitions=False)
     operation = Operation(api=api,
                           method='GET',
                           path='endpoint',
@@ -474,7 +476,7 @@ def test_default(api):
         security_definitions={}, definitions=DEFINITIONS,
         parameter_definitions=PARAMETER_DEFINITIONS, resolver=Resolver()
     )
-    op_spec = make_operation(OPERATION6)
+    op_spec = make_operation(OPERATION6, parameters=False)
     op_spec['parameters'][0]['default'] = {
         'keep_stacks': 1,
         'image_version': 'one',
@@ -491,7 +493,7 @@ def test_default(api):
 
 
 def test_get_path_parameter_types(api):
-    op_spec = make_operation(OPERATION1)
+    op_spec = make_operation(OPERATION1, parameters=False)
     op_spec['parameters'] = [
         {'in': 'path', 'type': 'int', 'name': 'int_path'},
         {'in': 'path', 'type': 'string', 'name': 'string_path'},

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,0 +1,114 @@
+import mock
+import pytest
+from connexion.apis.flask_api import Jsonifier
+from connexion.jsonref import RefResolutionError, resolve_refs
+from connexion.operation import Operation
+
+DEFINITIONS = {
+    'new_stack': {
+        'required': [
+            'image_version',
+            'keep_stacks',
+            'new_traffic',
+            'senza_yaml'
+        ],
+        'type': 'object',
+        'properties': {
+            'keep_stacks': {
+                'type': 'integer',
+                'description': 'Number of older stacks to keep'
+            },
+            'image_version': {
+                'type': 'string',
+                'description': 'Docker image version to deploy'
+            },
+            'senza_yaml': {
+                'type': 'string',
+                'description': 'YAML to provide to senza'
+            },
+            'new_traffic': {
+                'type': 'integer',
+                'description': 'Percentage of the traffic'
+            }
+        }
+    },
+    'composed': {
+        'required': ['test'],
+        'type': 'object',
+        'properties': {
+            'test': {
+                'schema': {'$ref': '#/definitions/new_stack'}
+            }
+        }
+    },
+    'problem': {"some": "thing"}
+}
+PARAMETER_DEFINITIONS = {'myparam': {'in': 'path', 'type': 'integer'}}
+
+
+@pytest.fixture
+def api():
+  return mock.MagicMock(jsonifier=Jsonifier)
+
+
+def test_non_existent_reference(api):
+    op_spec = {
+        'parameters': [{
+            'in': 'body',
+            'name': 'new_stack',
+            'required': True,
+            'schema': {'$ref': '#/definitions/new_stack'}
+        }]
+    }
+    with pytest.raises(RefResolutionError) as exc_info:  # type: py.code.ExceptionInfo
+        resolve_refs(op_spec, {})
+
+    exception = exc_info.value
+    assert "definitions/new_stack" in str(exception)
+
+
+def test_invalid_reference(api):
+    op_spec = {
+        'parameters': [{
+            'in': 'body',
+            'name': 'new_stack',
+            'required': True,
+            'schema': {'$ref': '#/notdefinitions/new_stack'}
+        }]
+    }
+
+    with pytest.raises(RefResolutionError) as exc_info:  # type: py.code.ExceptionInfo
+        resolve_refs(op_spec, {
+            "definitions": DEFINITIONS,
+            "parameters": PARAMETER_DEFINITIONS
+        })
+
+    exception = exc_info.value
+    assert "notdefinitions/new_stack" in str(exception)
+
+
+def test_resolve_invalid_reference(api):
+    op_spec = {
+        'operationId': 'fakeapi.hello.post_greeting',
+        'parameters': [{'$ref': '/parameters/fail'}]
+    }
+
+    with pytest.raises(RefResolutionError) as exc_info:
+        resolve_refs(op_spec, {
+            "parameters": PARAMETER_DEFINITIONS
+        })
+
+    exception = exc_info.value
+    assert "parameters/fail" in str(exception)
+
+
+def test_resolve_web_reference(api):
+    op_spec = {
+        'parameters': [{'$ref': 'https://reallyfake.asd/parameters.json'}]
+    }
+    store = {
+        "https://reallyfake.asd/parameters.json": {"name": "test"}
+    }
+
+    spec = resolve_refs(op_spec, store=store)
+    assert spec["parameters"][0]["name"] == "test"


### PR DESCRIPTION
relates to #624 

This branch factors out reference resolution, and applies it to the spec immediately after it is validated.
Previously this behavior was (1) in operation.py, and (2) tied to the swagger spec implementation.

Changes proposed in this pull request:
 - make reference resolver general purpose
 - resolve references eagerly in `apis/abstract.py` once instead of many times within `operation.py`

Note that the resolve_references function had two main features:
1. resolving references
2. attaching the definitions for use by the validator (this was useful for recursive definitions).

There is now a `with_definitions()` function that attached the definitions to a schema, to be used with the jsonschema validator.
This allows for both eager evaluation, and recursive definitions.
