### PR TITLE
Increase the code coverage

### DIFF
--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -2,9 +2,6 @@ import functools
 import logging
 from copy import deepcopy
 
-from jsonschema import ValidationError
-
-from .decorators import validation
 from .decorators.decorator import (BeginOfRequestLifecycleDecorator,
                                    EndOfRequestLifecycleDecorator)
 from .decorators.metrics import UWSGIMetricsCollector
@@ -15,8 +12,7 @@ from .decorators.security import (get_tokeninfo_func, get_tokeninfo_url,
                                   security_passthrough, verify_oauth_local,
                                   verify_oauth_remote)
 from .decorators.uri_parsing import AlwaysMultiURIParser
-from .decorators.validation import (ParameterValidator, RequestBodyValidator,
-                                    TypeValidationError)
+from .decorators.validation import ParameterValidator, RequestBodyValidator
 from .exceptions import InvalidSpecification
 from .utils import all_json, is_nullable
 
@@ -232,18 +228,6 @@ class Operation(SecureOperation):
         resolution = resolver.resolve(self)
         self.operation_id = resolution.operation_id
         self.__undecorated_function = resolution.function
-
-        self.validate_defaults()
-
-    def validate_defaults(self):
-        for param in self.parameters:
-            try:
-                if param['in'] == 'query' and 'default' in param:
-                    validation.validate_type(param, param['default'], 'query', param['name'])
-            except (TypeValidationError, ValidationError):
-                raise InvalidSpecification('The parameter \'{param_name}\' has a default value which is not of'
-                                           ' type \'{param_type}\''.format(param_name=param['name'],
-                                                                           param_type=param['type']))
 
     def resolve_reference(self, schema):
         schema = deepcopy(schema)  # avoid changing the original schema


### PR DESCRIPTION
- removed the validate_defaults method from Operation because the new swagger_spec_validation version do this validation;
- added tests for AbstractApi._handle_add_operation_error.