### PR TITLE
parameterize tests

### DIFF
--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -8,13 +8,16 @@ import pytest
 from conftest import TEST_FOLDER, build_app_from_fixture
 from connexion import App
 
+SPECS = ["swagger.yaml"]
 
-def test_app_with_relative_path(simple_api_spec_dir):
+
+@pytest.mark.parametrize("spec", SPECS)
+def test_app_with_relative_path(simple_api_spec_dir, spec):
     # Create the app with a relative path and run the test_app testcase below.
     app = App(__name__, port=5001,
               specification_dir='..' / simple_api_spec_dir.relative_to(TEST_FOLDER),
               debug=True)
-    app.add_api('swagger.yaml')
+    app.add_api(spec)
 
     app_client = app.app.test_client()
     get_bye = app_client.get('/v1.0/bye/jsantos')  # type: flask.Response
@@ -22,13 +25,14 @@ def test_app_with_relative_path(simple_api_spec_dir):
     assert get_bye.data == b'Goodbye jsantos'
 
 
-def test_app_with_different_server_option(simple_api_spec_dir):
+@pytest.mark.parametrize("spec", SPECS)
+def test_app_with_different_server_option(simple_api_spec_dir, spec):
     # Create the app with a relative path and run the test_app testcase below.
     app = App(__name__, port=5001,
               server='gevent',
               specification_dir='..' / simple_api_spec_dir.relative_to(TEST_FOLDER),
               debug=True)
-    app.add_api('swagger.yaml')
+    app.add_api(spec)
 
     app_client = app.app.test_client()
     get_bye = app_client.get('/v1.0/bye/jsantos')  # type: flask.Response
@@ -53,47 +57,54 @@ def test_app_with_different_uri_parser(simple_api_spec_dir):
     assert j == ['d', 'e', 'f']
 
 
-def test_no_swagger_ui(simple_api_spec_dir):
+@pytest.mark.parametrize("spec", SPECS)
+def test_no_swagger_ui(simple_api_spec_dir, spec):
     options = {"swagger_ui": False}
     app = App(__name__, port=5001, specification_dir=simple_api_spec_dir,
               options=options, debug=True)
-    app.add_api('swagger.yaml')
+    app.add_api(spec)
 
     app_client = app.app.test_client()
     swagger_ui = app_client.get('/v1.0/ui/')  # type: flask.Response
     assert swagger_ui.status_code == 404
 
     app2 = App(__name__, port=5001, specification_dir=simple_api_spec_dir, debug=True)
-    app2.add_api('swagger.yaml', options={"swagger_ui": False})
+    app2.add_api(spec, options={"swagger_ui": False})
     app2_client = app2.app.test_client()
     swagger_ui2 = app2_client.get('/v1.0/ui/')  # type: flask.Response
     assert swagger_ui2.status_code == 404
 
 
-def test_swagger_json_app(simple_api_spec_dir):
-    """ Verify the swagger.json file is returned for default setting passed to app. """
+@pytest.mark.parametrize("spec", SPECS)
+def test_swagger_json_app(simple_api_spec_dir, spec):
+    """ Verify the spec json file is returned for default setting passed to app. """
     app = App(__name__, port=5001, specification_dir=simple_api_spec_dir, debug=True)
-    app.add_api('swagger.yaml')
-
+    app.add_api(spec)
     app_client = app.app.test_client()
-    swagger_json = app_client.get('/v1.0/swagger.json')  # type: flask.Response
-    assert swagger_json.status_code == 200
+    url = '/v1.0/{spec}'
+    url = url.format(spec=spec.replace("yaml", "json"))
+    spec_json = app_client.get(url)  # type: flask.Response
+    assert spec_json.status_code == 200
 
 
-def test_no_swagger_json_app(simple_api_spec_dir):
-    """ Verify the swagger.json file is not returned when set to False when creating app. """
+@pytest.mark.parametrize("spec", SPECS)
+def test_no_swagger_json_app(simple_api_spec_dir, spec):
+    """ Verify the spec json file is not returned when set to False when creating app. """
     options = {"swagger_json": False}
     app = App(__name__, port=5001, specification_dir=simple_api_spec_dir,
               options=options, debug=True)
-    app.add_api('swagger.yaml')
+    app.add_api(spec)
 
     app_client = app.app.test_client()
-    swagger_json = app_client.get('/v1.0/swagger.json')  # type: flask.Response
-    assert swagger_json.status_code == 404
+    url = '/v1.0/{spec}'
+    url = url.format(spec=spec.replace("yaml", "json"))
+    spec_json = app_client.get(url)  # type: flask.Response
+    assert spec_json.status_code == 404
 
 
-def test_dict_as_yaml_path(simple_api_spec_dir):
-    swagger_yaml_path = simple_api_spec_dir / 'swagger.yaml'
+@pytest.mark.parametrize("spec", SPECS)
+def test_dict_as_yaml_path(simple_api_spec_dir, spec):
+    swagger_yaml_path = simple_api_spec_dir / spec
 
     with swagger_yaml_path.open(mode='rb') as swagger_yaml:
         contents = swagger_yaml.read()
@@ -109,35 +120,40 @@ def test_dict_as_yaml_path(simple_api_spec_dir):
     app.add_api(specification)
 
     app_client = app.app.test_client()
-    swagger_json = app_client.get('/v1.0/swagger.json')  # type: flask.Response
+    url = '/v1.0/{spec}'.format(spec=spec.replace("yaml", "json"))
+    swagger_json = app_client.get(url)  # type: flask.Response
     assert swagger_json.status_code == 200
 
 
-def test_swagger_json_api(simple_api_spec_dir):
-    """ Verify the swagger.json file is returned for default setting passed to api. """
+@pytest.mark.parametrize("spec", SPECS)
+def test_swagger_json_api(simple_api_spec_dir, spec):
+    """ Verify the spec json file is returned for default setting passed to api. """
     app = App(__name__, port=5001, specification_dir=simple_api_spec_dir, debug=True)
-    app.add_api('swagger.yaml')
+    app.add_api(spec)
 
     app_client = app.app.test_client()
-    swagger_json = app_client.get('/v1.0/swagger.json')  # type: flask.Response
+    url = '/v1.0/{spec}'.format(spec=spec.replace("yaml", "json"))
+    swagger_json = app_client.get(url)  # type: flask.Response
     assert swagger_json.status_code == 200
 
 
-def test_no_swagger_json_api(simple_api_spec_dir):
-    """ Verify the swagger.json file is not returned when set to False when adding api. """
+@pytest.mark.parametrize("spec", SPECS)
+def test_no_swagger_json_api(simple_api_spec_dir, spec):
+    """ Verify the spec json file is not returned when set to False when adding api. """
     app = App(__name__, port=5001, specification_dir=simple_api_spec_dir, debug=True)
-    app.add_api('swagger.yaml', options={"swagger_json": False})
+    app.add_api(spec, options={"swagger_json": False})
 
     app_client = app.app.test_client()
-    swagger_json = app_client.get('/v1.0/swagger.json')  # type: flask.Response
+    url = '/v1.0/{spec}'.format(spec=spec.replace("yaml", "json"))
+    swagger_json = app_client.get(url)  # type: flask.Response
     assert swagger_json.status_code == 404
 
 
-def test_swagger_json_content_type(simple_app):
+@pytest.mark.parametrize("spec", SPECS)
+def test_swagger_json_content_type(simple_app, spec):
     app_client = simple_app.app.test_client()
-
-    response = app_client.get('/v1.0/swagger.json',
-                              data={})  # type: flask.Response
+    url = '/v1.0/{spec}'.format(spec=spec.replace("yaml", "json"))
+    response = app_client.get(url, data={})  # type: flask.Response
     assert response.status_code == 200
     assert response.content_type == 'application/json'
 
@@ -179,9 +195,10 @@ def test_resolve_classmethod(simple_app):
     assert resp.data.decode('utf-8', 'replace') == '"DummyClass"\n'
 
 
-def test_add_api_with_function_resolver_function_is_wrapped(simple_api_spec_dir):
+@pytest.mark.parametrize("spec", SPECS)
+def test_add_api_with_function_resolver_function_is_wrapped(simple_api_spec_dir, spec):
     app = App(__name__, specification_dir=simple_api_spec_dir)
-    api = app.add_api('swagger.yaml', resolver=lambda oid: (lambda foo: 'bar'))
+    api = app.add_api(spec, resolver=lambda oid: (lambda foo: 'bar'))
     assert api.resolver.resolve_function_from_operation_id('faux')('bah') == 'bar'
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ logging.basicConfig(level=logging.DEBUG)
 TEST_FOLDER = pathlib.Path(__file__).parent
 FIXTURES_FOLDER = TEST_FOLDER / 'fixtures'
 SPEC_FOLDER = TEST_FOLDER / "fakeapi"
+SPECS = ["swagger.yaml"]
 
 
 class FakeResponse(object):
@@ -87,7 +88,7 @@ def default_param_error_spec_dir():
     return FIXTURES_FOLDER / 'default_param_error'
 
 
-def build_app_from_fixture(api_spec_folder, **kwargs):
+def build_app_from_fixture(api_spec_folder, spec_file='swagger.yaml', **kwargs):
     debug = True
     if 'debug' in kwargs:
         debug = kwargs['debug']
@@ -97,60 +98,71 @@ def build_app_from_fixture(api_spec_folder, **kwargs):
                   port=5001,
                   specification_dir=FIXTURES_FOLDER / api_spec_folder,
                   debug=debug)
-    cnx_app.add_api('swagger.yaml', **kwargs)
+
+    cnx_app.add_api(spec_file, **kwargs)
+    cnx_app._spec_file = spec_file
     return cnx_app
 
 
-@pytest.fixture(scope="session")
-def simple_app():
-    return build_app_from_fixture('simple', validate_responses=True)
+@pytest.fixture(scope="session", params=SPECS)
+def simple_app(request):
+    return build_app_from_fixture('simple', request.param, validate_responses=True)
 
 
-@pytest.fixture(scope="session")
-def snake_case_app():
-    return build_app_from_fixture('snake_case', validate_responses=True, pythonic_params=True)
+@pytest.fixture(scope="session", params=SPECS)
+def snake_case_app(request):
+    return build_app_from_fixture('snake_case', request.param,
+                                  validate_responses=True,
+                                  pythonic_params=True)
 
 
-@pytest.fixture(scope="session")
-def invalid_resp_allowed_app():
-    return build_app_from_fixture('simple', validate_responses=False)
+@pytest.fixture(scope="session", params=SPECS)
+def invalid_resp_allowed_app(request):
+    return build_app_from_fixture('simple', request.param,
+                                  validate_responses=False)
 
 
-@pytest.fixture(scope="session")
-def strict_app():
-    return build_app_from_fixture('simple', validate_responses=True, strict_validation=True)
+@pytest.fixture(scope="session", params=SPECS)
+def strict_app(request):
+    return build_app_from_fixture('simple', request.param,
+                                  validate_responses=True,
+                                  strict_validation=True)
 
 
-@pytest.fixture(scope="session")
-def problem_app():
-    return build_app_from_fixture('problem', validate_responses=True)
+@pytest.fixture(scope="session", params=SPECS)
+def problem_app(request):
+    return build_app_from_fixture('problem', request.param,
+                                  validate_responses=True)
 
 
-@pytest.fixture(scope="session")
-def schema_app():
-    return build_app_from_fixture('different_schemas', validate_responses=True)
+@pytest.fixture(scope="session", params=SPECS)
+def schema_app(request):
+    return build_app_from_fixture('different_schemas', request.param,
+                                  validate_responses=True)
 
 
-@pytest.fixture(scope="session")
-def secure_endpoint_app():
-    return build_app_from_fixture('secure_endpoint', validate_responses=True)
+@pytest.fixture(scope="session", params=SPECS)
+def secure_endpoint_app(request):
+    return build_app_from_fixture('secure_endpoint', request.param,
+                                  validate_responses=True)
 
 
-@pytest.fixture(scope="session")
-def secure_api_app():
-    return build_app_from_fixture('secure_api')
+@pytest.fixture(scope="session", params=SPECS)
+def secure_api_app(request):
+    return build_app_from_fixture('secure_api', request.param)
 
 
-@pytest.fixture(scope="session")
-def unordered_definition_app():
-    return build_app_from_fixture('unordered_definition')
+@pytest.fixture(scope="session", params=SPECS)
+def unordered_definition_app(request):
+    return build_app_from_fixture('unordered_definition', request.param)
 
 
-@pytest.fixture(scope="session")
-def bad_operations_app():
-    return build_app_from_fixture('bad_operations', resolver_error=501)
+@pytest.fixture(scope="session", params=SPECS)
+def bad_operations_app(request):
+    return build_app_from_fixture('bad_operations', request.param,
+                                  resolver_error=501)
 
 
-@pytest.fixture(scope="session")
-def query_sanitazion():
-    return build_app_from_fixture('query_sanitazion')
+@pytest.fixture(scope="session", params=SPECS)
+def query_sanitazion(request):
+    return build_app_from_fixture('query_sanitazion', request.param)


### PR DESCRIPTION
related to #420 
This includes some of the changes to tests from #639 
I've broken them out because they could be reviewed separately.

Changes proposed in this pull request:
 - add test parameterization for different spec files (i.e. swagger.yaml, openapi.yaml)