### PR TITLE
remove test that relies on log output

### DIFF
--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -22,22 +22,3 @@ def test_injection():
 
     parameter_to_arg({}, [], handler, pass_context_arg_name='framework_request_ctx')(request)
     func.assert_called_with(p1='123', framework_request_ctx=request.context)
-
-
-def test_query_sanitazion(query_sanitazion):
-    app_client = query_sanitazion.app.test_client()
-    l = LogCapture()
-
-    url = '/v1.0/greeting'
-    response = app_client.post(url, data={'name': 'Jane Doe'})
-    # This is ugly. The reason for asserting the logging in this way
-    # is that in order to use LogCapture().check, we'd have to assert that
-    # a specific sequence of logging has occurred. This is too restricting
-    # for future development, and we are really only interested in the fact
-    # a single message is logged.
-    messages = [x.strip() for x in str(l).split("\n")]
-    assert "FormData parameter 'name' in function arguments" in messages
-    assert "Query Parameter 'name' in function arguments" not in messages
-    assert "Function argument 'name' not defined in specification" not in messages
-    assert response.status_code == 200
-    l.uninstall()


### PR DESCRIPTION
Changes proposed in this pull request:
 - remove test that relies on log output
