### PR TITLE
remove ref resolution from mock code

### DIFF
--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -66,17 +66,7 @@ class MockResolver(Resolver):
         else:
             # No response example, check for schema example
             response_schema = response_definition.get('schema', {})
-            definitions = response_schema.get('definitions', {})
-            schema_example = None
-            ref = response_schema.get('$ref')
-            if ref:
-                # Referenced schema
-                ref = ref[ref.rfind('/')+1:] or ''
-                ref_schema = definitions.get(ref, {})
-                schema_example = ref_schema.get('example')
-            else:
-                # Inline schema
-                schema_example = response_schema.get('example')
+            schema_example = response_schema.get('example')
             if schema_example:
                 return schema_example, status_code
             else:

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -43,44 +43,7 @@ def test_mock_resolver():
     assert status_code == 200
     assert response == {'foo': 'bar'}
 
-def test_mock_resolver_ref_schema_example():
-    resolver = MockResolver(mock_all=True)
-
-    responses = {
-        'default': {
-            'schema': {
-                '$ref': '#/definitions/Schema'
-            }
-        }
-    }
-
-    operation = Operation(api=None,
-                          method='GET',
-                          path='endpoint',
-                          path_parameters=[],
-                          operation={
-                              'responses': responses
-                          },
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={
-                              'Schema': {
-                                  'example': {
-                                      'foo': 'bar'
-                                  }
-                              }
-                          },
-                          parameter_definitions={},
-                          resolver=resolver)
-    assert operation.operation_id == 'mock-1'
-
-    response, status_code = resolver.mock_operation(operation)
-    assert status_code == 200
-    assert response == {'foo': 'bar'}
-
-def test_mock_resolver_inline_schema_example():
+def test_mock_resolver_example():
     resolver = MockResolver(mock_all=True)
 
     responses = {


### PR DESCRIPTION
This case is no longer possible since jsonref resolution happens much earlier in api/abstract.py

Changes proposed in this pull request:
 - remove jsonref resolution code from mock code, tests
