### PR TITLE
Rename Operation to Swagger2Operation

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -12,7 +12,7 @@ from swagger_spec_validator.validator20 import validate_spec
 
 from ..exceptions import ResolverError
 from ..jsonref import resolve_refs
-from ..operation import Operation
+from ..operation import Swagger2Operation
 from ..options import ConnexionOptions
 from ..resolver import Resolver
 from ..utils import Jsonifier
@@ -185,25 +185,25 @@ class AbstractAPI(object):
         :type path: str
         :type swagger_operation: dict
         """
-        operation = Operation(self,
-                              method=method,
-                              path=path,
-                              path_parameters=path_parameters,
-                              operation=swagger_operation,
-                              app_produces=self.produces,
-                              app_consumes=self.consumes,
-                              app_security=self.security,
-                              security_definitions=self.security_definitions,
-                              definitions=self.definitions,
-                              parameter_definitions=self.parameter_definitions,
-                              response_definitions=self.response_definitions,
-                              validate_responses=self.validate_responses,
-                              validator_map=self.validator_map,
-                              strict_validation=self.strict_validation,
-                              resolver=self.resolver,
-                              pythonic_params=self.pythonic_params,
-                              uri_parser_class=self.options.uri_parser_class,
-                              pass_context_arg_name=self.pass_context_arg_name)
+        operation = Swagger2Operation(self,
+                                      method=method,
+                                      path=path,
+                                      path_parameters=path_parameters,
+                                      operation=swagger_operation,
+                                      app_produces=self.produces,
+                                      app_consumes=self.consumes,
+                                      app_security=self.security,
+                                      security_definitions=self.security_definitions,
+                                      definitions=self.definitions,
+                                      parameter_definitions=self.parameter_definitions,
+                                      response_definitions=self.response_definitions,
+                                      validate_responses=self.validate_responses,
+                                      validator_map=self.validator_map,
+                                      strict_validation=self.strict_validation,
+                                      resolver=self.resolver,
+                                      pythonic_params=self.pythonic_params,
+                                      uri_parser_class=self.options.uri_parser_class,
+                                      pass_context_arg_name=self.pass_context_arg_name)
         self._add_operation_internal(method, path, operation)
 
     @abc.abstractmethod

--- a/connexion/handlers.py
+++ b/connexion/handlers.py
@@ -1,6 +1,6 @@
 import logging
 
-from .operation import Operation, SecureOperation
+from .operation import Swagger2Operation, SecureOperation
 from .problem import problem
 
 logger = logging.getLogger('connexion.handlers')
@@ -52,7 +52,7 @@ class AuthErrorHandler(SecureOperation):
         return self.api.get_response(response)
 
 
-class ResolverErrorHandler(Operation):
+class ResolverErrorHandler(Swagger2Operation):
     """
     Handler for responding to ResolverError.
     """
@@ -60,7 +60,7 @@ class ResolverErrorHandler(Operation):
     def __init__(self, api, status_code, exception, *args, **kwargs):
         self.status_code = status_code
         self.exception = exception
-        Operation.__init__(self, api, *args, **kwargs)
+        Swagger2Operation.__init__(self, api, *args, **kwargs)
 
     @property
     def function(self):

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -131,7 +131,7 @@ class SecureOperation(object):
         return EndOfRequestLifecycleDecorator(self.api, self.get_mimetype())
 
 
-class Operation(SecureOperation):
+class Swagger2Operation(SecureOperation):
 
     """
     A single API operation on a path.

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -1,5 +1,5 @@
 from connexion.mock import MockResolver, partial
-from connexion.operation import Operation
+from connexion.operation import Swagger2Operation
 
 
 def test_partial():
@@ -23,20 +23,20 @@ def test_mock_resolver():
         }
     }
 
-    operation = Operation(api=None,
-                          method='GET',
-                          path='endpoint',
-                          path_parameters=[],
-                          operation={
-                              'responses': responses
-                          },
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions={},
-                          resolver=resolver)
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation={
+                                      'responses': responses
+                                  },
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions={},
+                                  resolver=resolver)
     assert operation.operation_id == 'mock-1'
 
     response, status_code = resolver.mock_operation(operation)
@@ -62,20 +62,20 @@ def test_mock_resolver_example():
         }
     }
 
-    operation = Operation(api=None,
-                          method='GET',
-                          path='endpoint',
-                          path_parameters=[],
-                          operation={
-                              'responses': responses
-                          },
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions={},
-                          resolver=resolver)
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation={
+                                      'responses': responses
+                                  },
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions={},
+                                  resolver=resolver)
     assert operation.operation_id == 'mock-1'
 
     response, status_code = resolver.mock_operation(operation)
@@ -89,20 +89,20 @@ def test_mock_resolver_no_examples():
         '418': {}
     }
 
-    operation = Operation(api=None,
-                          method='GET',
-                          path='endpoint',
-                          path_parameters=[],
-                          operation={
-                              'responses': responses
-                          },
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions={},
-                          resolver=resolver)
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation={
+                                      'responses': responses
+                                  },
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions={},
+                                  resolver=resolver)
     assert operation.operation_id == 'mock-1'
 
     response, status_code = resolver.mock_operation(operation)
@@ -118,38 +118,38 @@ def test_mock_resolver_notimplemented():
     }
 
     # do not mock the existent functions
-    operation = Operation(api=None,
-                          method='GET',
-                          path='endpoint',
-                          path_parameters=[],
-                          operation={
-                              'operationId': 'fakeapi.hello.get'
-                          },
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions={},
-                          resolver=resolver)
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation={
+                                      'operationId': 'fakeapi.hello.get'
+                                  },
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions={},
+                                  resolver=resolver)
     assert operation.operation_id == 'fakeapi.hello.get'
 
     # mock only the nonexistent ones
-    operation = Operation(api=None,
-                          method='GET',
-                          path='endpoint',
-                          path_parameters=[],
-                          operation={
-                              'operationId': 'fakeapi.hello.nonexistent_function',
-                              'responses': responses
-                          },
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions={},
-                          resolver=resolver)
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation={
+                                      'operationId': 'fakeapi.hello.nonexistent_function',
+                                      'responses': responses
+                                  },
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions={},
+                                  resolver=resolver)
 
     # check if it is using the mock function
-    assert operation._Operation__undecorated_function() == ('No example response was defined.', 418)
+    assert operation._Swagger2Operation__undecorated_function() == ('No example response was defined.', 418)

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -11,7 +11,7 @@ from connexion.decorators.security import (security_passthrough,
                                            verify_oauth_remote)
 from connexion.exceptions import InvalidSpecification
 from connexion.jsonref import resolve_refs
-from connexion.operation import Operation
+from connexion.operation import Swagger2Operation
 from connexion.resolver import Resolver
 
 TEST_FOLDER = pathlib.Path(__file__).parent
@@ -247,18 +247,18 @@ def make_operation(op, definitions=True, parameters=True):
 
 def test_operation(api):
     op_spec = make_operation(OPERATION1)
-    operation = Operation(api=api,
-                          method='GET',
-                          path='endpoint',
-                          path_parameters=[],
-                          operation=op_spec,
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions=SECURITY_DEFINITIONS_REMOTE,
-                          definitions=DEFINITIONS,
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=Resolver())
+    operation = Swagger2Operation(api=api,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation=op_spec,
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions=SECURITY_DEFINITIONS_REMOTE,
+                                  definitions=DEFINITIONS,
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=Resolver())
     assert isinstance(operation.function, types.FunctionType)
     # security decorator should be a partial with verify_oauth_remote as the function and token url and scopes as arguments.
     # See https://docs.python.org/2/library/functools.html#partial-objects
@@ -277,18 +277,18 @@ def test_operation(api):
 
 def test_operation_array(api):
     op_spec = make_operation(OPERATION7)
-    operation = Operation(api=api,
-                          method='GET',
-                          path='endpoint',
-                          path_parameters=[],
-                          operation=op_spec,
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions=SECURITY_DEFINITIONS_REMOTE,
-                          definitions=DEFINITIONS,
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=Resolver())
+    operation = Swagger2Operation(api=api,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation=op_spec,
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions=SECURITY_DEFINITIONS_REMOTE,
+                                  definitions=DEFINITIONS,
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=Resolver())
     assert isinstance(operation.function, types.FunctionType)
     # security decorator should be a partial with verify_oauth_remote as the function and token url
     #  and scopes as arguments.
@@ -310,18 +310,18 @@ def test_operation_array(api):
 
 def test_operation_composed_definition(api):
     op_spec = make_operation(OPERATION8)
-    operation = Operation(api=api,
-                          method='GET',
-                          path='endpoint',
-                          path_parameters=[],
-                          operation=op_spec,
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions=SECURITY_DEFINITIONS_REMOTE,
-                          definitions=DEFINITIONS,
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=Resolver())
+    operation = Swagger2Operation(api=api,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation=op_spec,
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions=SECURITY_DEFINITIONS_REMOTE,
+                                  definitions=DEFINITIONS,
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=Resolver())
     assert isinstance(operation.function, types.FunctionType)
     # security decorator should be a partial with verify_oauth_remote as the function and
     # token url and scopes as arguments.
@@ -340,18 +340,18 @@ def test_operation_composed_definition(api):
 
 def test_operation_local_security_oauth2(api):
     op_spec = make_operation(OPERATION8)
-    operation = Operation(api=api,
-                          method='GET',
-                          path='endpoint',
-                          path_parameters=[],
-                          operation=op_spec,
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions=SECURITY_DEFINITIONS_LOCAL,
-                          definitions=DEFINITIONS,
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=Resolver())
+    operation = Swagger2Operation(api=api,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation=op_spec,
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions=SECURITY_DEFINITIONS_LOCAL,
+                                  definitions=DEFINITIONS,
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=Resolver())
     assert isinstance(operation.function, types.FunctionType)
     # security decorator should be a partial with verify_oauth_remote as the function and
     # token url and scopes as arguments.
@@ -371,18 +371,18 @@ def test_operation_local_security_oauth2(api):
 
 def test_operation_local_security_duplicate_token_info(api):
     op_spec = make_operation(OPERATION8)
-    operation = Operation(api=api,
-                          method='GET',
-                          path='endpoint',
-                          path_parameters=[],
-                          operation=op_spec,
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions=SECURITY_DEFINITIONS_BOTH,
-                          definitions=DEFINITIONS,
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=Resolver())
+    operation = Swagger2Operation(api=api,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation=op_spec,
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions=SECURITY_DEFINITIONS_BOTH,
+                                  definitions=DEFINITIONS,
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=Resolver())
     assert isinstance(operation.function, types.FunctionType)
     # security decorator should be a partial with verify_oauth_remote as the function and
     # token url and scopes as arguments.
@@ -403,18 +403,18 @@ def test_operation_local_security_duplicate_token_info(api):
 def test_multi_body(api):
     with pytest.raises(InvalidSpecification) as exc_info:  # type: py.code.ExceptionInfo
         op_spec = make_operation(OPERATION2)
-        operation = Operation(api=api,
-                              method='GET',
-                              path='endpoint',
-                              path_parameters=[],
-                              operation=op_spec,
-                              app_produces=['application/json'],
-                              app_consumes=['application/json'],
-                              app_security=[],
-                              security_definitions={},
-                              definitions=DEFINITIONS,
-                              parameter_definitions=PARAMETER_DEFINITIONS,
-                              resolver=Resolver())
+        operation = Swagger2Operation(api=api,
+                                      method='GET',
+                                      path='endpoint',
+                                      path_parameters=[],
+                                      operation=op_spec,
+                                      app_produces=['application/json'],
+                                      app_consumes=['application/json'],
+                                      app_security=[],
+                                      security_definitions={},
+                                      definitions=DEFINITIONS,
+                                      parameter_definitions=PARAMETER_DEFINITIONS,
+                                      resolver=Resolver())
         operation.body_schema
 
     exception = exc_info.value
@@ -424,18 +424,18 @@ def test_multi_body(api):
 
 def test_no_token_info(api):
     op_spec = make_operation(OPERATION1)
-    operation = Operation(api=api,
-                          method='GET',
-                          path='endpoint',
-                          path_parameters=[],
-                          operation=op_spec,
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=SECURITY_DEFINITIONS_WO_INFO,
-                          security_definitions=SECURITY_DEFINITIONS_WO_INFO,
-                          definitions=DEFINITIONS,
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=Resolver())
+    operation = Swagger2Operation(api=api,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation=op_spec,
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=SECURITY_DEFINITIONS_WO_INFO,
+                                  security_definitions=SECURITY_DEFINITIONS_WO_INFO,
+                                  definitions=DEFINITIONS,
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=Resolver())
     assert isinstance(operation.function, types.FunctionType)
     assert operation.security_decorator is security_passthrough
 
@@ -451,25 +451,25 @@ def test_no_token_info(api):
 
 def test_parameter_reference(api):
     op_spec = make_operation(OPERATION3, definitions=False)
-    operation = Operation(api=api,
-                          method='GET',
-                          path='endpoint',
-                          path_parameters=[],
-                          operation=op_spec,
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=Resolver())
+    operation = Swagger2Operation(api=api,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation=op_spec,
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=Resolver())
     assert operation.parameters == [{'in': 'path', 'type': 'integer'}]
 
 
 def test_default(api):
     op_spec = make_operation(OPERATION4)
     op_spec['parameters'][1]['default'] = 1
-    Operation(
+    Swagger2Operation(
         api=api, method='GET', path='endpoint', path_parameters=[],
         operation=op_spec, app_produces=['application/json'],
         app_consumes=['application/json'], app_security=[],
@@ -483,7 +483,7 @@ def test_default(api):
         'senza_yaml': 'senza.yaml',
         'new_traffic': 100
     }
-    Operation(
+    Swagger2Operation(
         api=api, method='POST', path='endpoint', path_parameters=[],
         operation=op_spec, app_produces=['application/json'],
         app_consumes=['application/json'], app_security=[],
@@ -500,7 +500,7 @@ def test_get_path_parameter_types(api):
         {'in': 'path', 'type': 'string', 'format': 'path', 'name': 'path_path'}
     ]
 
-    operation = Operation(
+    operation = Swagger2Operation(
         api=api, method='GET', path='endpoint', path_parameters=[],
         operation=op_spec, app_produces=['application/json'],
         app_consumes=['application/json'],

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -2,7 +2,6 @@ import mock
 import pytest
 from connexion.apis.flask_api import Jsonifier
 from connexion.jsonref import RefResolutionError, resolve_refs
-from connexion.operation import Operation
 
 DEFINITIONS = {
     'new_stack': {

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,7 +1,7 @@
 import connexion.apps
 import pytest
 from connexion.exceptions import ResolverError
-from connexion.operation import Operation
+from connexion.operation import Swagger2Operation
 from connexion.resolver import Resolver, RestyResolver
 
 PARAMETER_DEFINITIONS = {'myparam': {'in': 'path', 'type': 'integer'}}
@@ -36,202 +36,202 @@ def test_bad_operation_id():
 
 
 def test_standard_resolve_x_router_controller():
-    operation = Operation(api=None,
-                          method='GET',
-                          path='endpoint',
-                          path_parameters=[],
-                          operation={
-                              'x-swagger-router-controller': 'fakeapi.hello',
-                              'operationId': 'post_greeting',
-                          },
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=Resolver())
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation={
+                                      'x-swagger-router-controller': 'fakeapi.hello',
+                                      'operationId': 'post_greeting',
+                                  },
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=Resolver())
     assert operation.operation_id == 'fakeapi.hello.post_greeting'
 
 
 def test_resty_resolve_operation_id():
-    operation = Operation(api=None,
-                          method='GET',
-                          path='endpoint',
-                          path_parameters=[],
-                          operation={
-                              'operationId': 'fakeapi.hello.post_greeting',
-                          },
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=RestyResolver('fakeapi'))
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation={
+                                      'operationId': 'fakeapi.hello.post_greeting',
+                                  },
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.post_greeting'
 
 
 def test_resty_resolve_x_router_controller_with_operation_id():
-    operation = Operation(api=None,
-                          method='GET',
-                          path='endpoint',
-                          path_parameters=[],
-                          operation={
-                              'x-swagger-router-controller': 'fakeapi.hello',
-                              'operationId': 'post_greeting',
-                          },
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=RestyResolver('fakeapi'))
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation={
+                                      'x-swagger-router-controller': 'fakeapi.hello',
+                                      'operationId': 'post_greeting',
+                                  },
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.post_greeting'
 
 
 def test_resty_resolve_x_router_controller_without_operation_id():
-    operation = Operation(api=None,
-                          method='GET',
-                          path='/hello/{id}',
-                          path_parameters=[],
-                          operation={'x-swagger-router-controller': 'fakeapi.hello'},
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=RestyResolver('fakeapi'))
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='/hello/{id}',
+                                  path_parameters=[],
+                                  operation={'x-swagger-router-controller': 'fakeapi.hello'},
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.get'
 
 
 def test_resty_resolve_with_default_module_name():
-    operation = Operation(api=None,
-                          method='GET',
-                          path='/hello/{id}',
-                          path_parameters=[],
-                          operation={},
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=RestyResolver('fakeapi'))
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='/hello/{id}',
+                                  path_parameters=[],
+                                  operation={},
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.get'
 
 
 def test_resty_resolve_with_default_module_name_lowercase_verb():
-    operation = Operation(api=None,
-                          method='get',
-                          path='/hello/{id}',
-                          path_parameters=[],
-                          operation={},
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=RestyResolver('fakeapi'))
+    operation = Swagger2Operation(api=None,
+                                  method='get',
+                                  path='/hello/{id}',
+                                  path_parameters=[],
+                                  operation={},
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.get'
 
 
 def test_resty_resolve_with_default_module_name_will_translate_dashes_in_resource_name():
-    operation = Operation(api=None,
-                          method='GET',
-                          path='/foo-bar',
-                          path_parameters=[],
-                          operation={},
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=RestyResolver('fakeapi'))
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='/foo-bar',
+                                  path_parameters=[],
+                                  operation={},
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.foo_bar.search'
 
 
 def test_resty_resolve_with_default_module_name_can_resolve_api_root():
-    operation = Operation(api=None,
-                          method='GET',
-                          path='/',
-                          path_parameters=[],
-                          operation={},
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=RestyResolver('fakeapi'))
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='/',
+                                  path_parameters=[],
+                                  operation={},
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.get'
 
 
 def test_resty_resolve_with_default_module_name_will_resolve_resource_root_get_as_search():
-    operation = Operation(api=None,
-                          method='GET',
-                          path='/hello',
-                          path_parameters=[],
-                          operation={},
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=RestyResolver('fakeapi'))
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='/hello',
+                                  path_parameters=[],
+                                  operation={},
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.search'
 
 
 def test_resty_resolve_with_default_module_name_and_x_router_controller_will_resolve_resource_root_get_as_search():
-    operation = Operation(api=None,
-                          method='GET',
-                          path='/hello',
-                          path_parameters=[],
-                          operation={
-                              'x-swagger-router-controller': 'fakeapi.hello',
-                          },
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=RestyResolver('fakeapi'))
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='/hello',
+                                  path_parameters=[],
+                                  operation={
+                                      'x-swagger-router-controller': 'fakeapi.hello',
+                                  },
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.search'
 
 
 def test_resty_resolve_with_default_module_name_will_resolve_resource_root_as_configured():
-    operation = Operation(api=None,
-                          method='GET',
-                          path='/hello',
-                          path_parameters=[],
-                          operation={},
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=RestyResolver('fakeapi', 'api_list'))
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='/hello',
+                                  path_parameters=[],
+                                  operation={},
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=RestyResolver('fakeapi', 'api_list'))
     assert operation.operation_id == 'fakeapi.hello.api_list'
 
 
 def test_resty_resolve_with_default_module_name_will_resolve_resource_root_post_as_post():
-    operation = Operation(api=None,
-                          method='POST',
-                          path='/hello',
-                          path_parameters=[],
-                          operation={},
-                          app_produces=['application/json'],
-                          app_consumes=['application/json'],
-                          app_security=[],
-                          security_definitions={},
-                          definitions={},
-                          parameter_definitions=PARAMETER_DEFINITIONS,
-                          resolver=RestyResolver('fakeapi'))
+    operation = Swagger2Operation(api=None,
+                                  method='POST',
+                                  path='/hello',
+                                  path_parameters=[],
+                                  operation={},
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.post'


### PR DESCRIPTION
This is an attempt to shrink #639 to make it easier to review.
Many of the lines changed in #639 are purely because of the name change from `Operation` to `Swagger2Operation`.

The idea of this PR is to have this PR be _purely_ a name change with no changes in functionality at all.
Then, #639 can be rebased on this PR, and reviewed for functionality changes without the extra overhead of all of the name changes.

Let me know what you think.

Changes proposed in this pull request:
 - Rename Operation to Swagger2Operation
