### PR TITLE
Switch from swagger_spec_validator to openapi_spec_validator library

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,7 @@ New in Connexion 2.0:
   In situations when a query parameter is passed multiple times, and the collectionFormat is either csv or pipes, the right-most value will be used.
   For example, `?q=1,2,3&q=4,5,6` will result in `q = [4, 5, 6]`.
 - The spec validator library has changed from `swagger-spec-validator` to `openapi-spec-validator`.
+  Connexion now raises `OpenAPIValidationError` instead of `SwaggerValidationError`.
 
 How to Use
 ==========

--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,8 @@ New in Connexion 2.0:
   In situations when a query parameter is passed multiple times, and the collectionFormat is either csv or pipes, the right-most value will be used.
   For example, `?q=1,2,3&q=4,5,6` will result in `q = [4, 5, 6]`.
 - The spec validator library has changed from `swagger-spec-validator` to `openapi-spec-validator`.
-  Connexion now raises `OpenAPIValidationError` instead of `SwaggerValidationError`.
+- Errors that previously raised `SwaggerValidationError` now raise the `InvalidSpecification` exception.
+  All spec validation errors should be wrapped with `InvalidSpecification`.
 
 How to Use
 ==========

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,7 @@ New in Connexion 2.0:
 - Array parameter deserialization now follows the Swagger 2.0 spec more closely.
   In situations when a query parameter is passed multiple times, and the collectionFormat is either csv or pipes, the right-most value will be used.
   For example, `?q=1,2,3&q=4,5,6` will result in `q = [4, 5, 6]`.
+- The spec validator library has changed from `swagger-spec-validator` to `openapi-spec-validator`.
 
 How to Use
 ==========

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -139,7 +139,6 @@ class AbstractAPI(object):
             self.add_auth_on_not_found(self.security, self.security_definitions)
 
     def _validate_spec(self, spec):
-        logger.info('Using Swagger 2.0 specification')
         from openapi_spec_validator import validate_v2_spec as validate_spec
         validate_spec(spec)
 

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -8,7 +8,6 @@ from typing import AnyStr, List  # NOQA
 import jinja2
 import six
 import yaml
-from swagger_spec_validator.validator20 import validate_spec
 
 from ..exceptions import ResolverError
 from ..jsonref import resolve_refs
@@ -140,6 +139,8 @@ class AbstractAPI(object):
             self.add_auth_on_not_found(self.security, self.security_definitions)
 
     def _validate_spec(self, spec):
+        logger.info('Using Swagger 2.0 specification')
+        from openapi_spec_validator import validate_v2_spec as validate_spec
         validate_spec(spec)
 
     def _set_base_path(self, base_path):

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -8,7 +8,6 @@ from typing import AnyStr, List  # NOQA
 import jinja2
 import six
 import yaml
-
 from openapi_spec_validator import validate_v2_spec as validate_spec
 from openapi_spec_validator.exceptions import OpenAPIValidationError
 

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -9,7 +9,10 @@ import jinja2
 import six
 import yaml
 
-from ..exceptions import ResolverError
+from openapi_spec_validator import validate_v2_spec as validate_spec
+from openapi_spec_validator.exceptions import OpenAPIValidationError
+
+from ..exceptions import InvalidSpecification, ResolverError
 from ..jsonref import resolve_refs
 from ..operation import Swagger2Operation
 from ..options import ConnexionOptions
@@ -139,8 +142,10 @@ class AbstractAPI(object):
             self.add_auth_on_not_found(self.security, self.security_definitions)
 
     def _validate_spec(self, spec):
-        from openapi_spec_validator import validate_v2_spec as validate_spec
-        validate_spec(spec)
+        try:
+            validate_spec(spec)
+        except OpenAPIValidationError as e:
+            raise InvalidSpecification.create_from(e)
 
     def _set_base_path(self, base_path):
         # type: (AnyStr) -> None

--- a/connexion/exceptions.py
+++ b/connexion/exceptions.py
@@ -1,3 +1,4 @@
+from jsonschema.exceptions import ValidationError
 from werkzeug.exceptions import Forbidden, Unauthorized
 
 from .problem import problem
@@ -47,13 +48,14 @@ class ResolverError(LookupError):
         return '<ResolverError: {}>'.format(self.reason)
 
 
-class InvalidSpecification(ConnexionException):
-    def __init__(self, reason='Unknown Reason'):
+class InvalidSpecification(ConnexionException, ValidationError):
+    def __init__(self, message='Unknown Reason', *args, **kwargs):
         """
         :param reason: Reason why the specification is invalid
         :type reason: str
         """
-        self.reason = reason
+        self.reason = message  # for backwards compatability
+        ValidationError.__init__(self, message=message, *args, **kwargs)
 
     def __str__(self):  # pragma: no cover
         return '<InvalidSpecification: {}>'.format(self.reason)

--- a/connexion/exceptions.py
+++ b/connexion/exceptions.py
@@ -49,19 +49,13 @@ class ResolverError(LookupError):
 
 
 class InvalidSpecification(ConnexionException, ValidationError):
-    def __init__(self, message='Unknown Reason', *args, **kwargs):
+    def __init__(self, reason='Unknown Reason', *args, **kwargs):
         """
         :param reason: Reason why the specification is invalid
         :type reason: str
         """
-        self.reason = message  # for backwards compatability
-        ValidationError.__init__(self, message=message, *args, **kwargs)
-
-    def __str__(self):  # pragma: no cover
-        return '<InvalidSpecification: {}>'.format(self.reason)
-
-    def __repr__(self):  # pragma: no cover
-        return '<InvalidSpecification: {}>'.format(self.reason)
+        self.reason = reason  # for backwards compatability
+        ValidationError.__init__(self, message=reason, *args, **kwargs)
 
 
 class NonConformingResponse(ConnexionException):

--- a/connexion/exceptions.py
+++ b/connexion/exceptions.py
@@ -49,13 +49,7 @@ class ResolverError(LookupError):
 
 
 class InvalidSpecification(ConnexionException, ValidationError):
-    def __init__(self, reason='Unknown Reason', *args, **kwargs):
-        """
-        :param reason: Reason why the specification is invalid
-        :type reason: str
-        """
-        self.reason = reason  # for backwards compatability
-        ValidationError.__init__(self, message=reason, *args, **kwargs)
+    pass
 
 
 class NonConformingResponse(ConnexionException):

--- a/connexion/operation.py
+++ b/connexion/operation.py
@@ -1,9 +1,6 @@
 import functools
 import logging
 
-from jsonschema import ValidationError
-
-from .decorators import validation
 from .decorators.decorator import (BeginOfRequestLifecycleDecorator,
                                    EndOfRequestLifecycleDecorator)
 from .decorators.metrics import UWSGIMetricsCollector
@@ -14,8 +11,7 @@ from .decorators.security import (get_tokeninfo_func, get_tokeninfo_url,
                                   security_passthrough, verify_oauth_local,
                                   verify_oauth_remote)
 from .decorators.uri_parsing import Swagger2URIParser
-from .decorators.validation import (ParameterValidator, RequestBodyValidator,
-                                    TypeValidationError)
+from .decorators.validation import ParameterValidator, RequestBodyValidator
 from .exceptions import InvalidSpecification
 from .utils import all_json, is_nullable
 
@@ -226,18 +222,6 @@ class Swagger2Operation(SecureOperation):
         resolution = resolver.resolve(self)
         self.operation_id = resolution.operation_id
         self.__undecorated_function = resolution.function
-
-        self.validate_defaults()
-
-    def validate_defaults(self):
-        for param in self.parameters:
-            try:
-                if param['in'] == 'query' and 'default' in param:
-                    validation.validate_type(param, param['default'], 'query', param['name'])
-            except (TypeValidationError, ValidationError):
-                raise InvalidSpecification('The parameter \'{param_name}\' has a default value which is not of'
-                                           ' type \'{param_type}\''.format(param_name=param['name'],
-                                                                           param_type=param['type']))
 
     def with_definitions(self, schema):
         if 'schema' in schema:

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,10 @@ install_requires = [
     'PyYAML>=3.11',
     'requests>=2.9.1',
     'six>=1.9',
-    'swagger-spec-validator>=2.3.1',
     'inflection>=0.3.1',
     'pathlib>=1.0.1; python_version < "3.4"',
     'typing>=3.6.1; python_version < "3.6"',
+    'openapi-spec-validator>=0.2.4',
 ]
 
 swagger_ui_require = 'swagger-ui-bundle>=0.0.2'

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -2,7 +2,7 @@ import json
 
 import jinja2
 import yaml
-from swagger_spec_validator.common import SwaggerValidationError
+from openapi_spec_validator.exceptions import OpenAPIValidationError
 
 import pytest
 from conftest import TEST_FOLDER, build_app_from_fixture
@@ -204,5 +204,5 @@ def test_add_api_with_function_resolver_function_is_wrapped(simple_api_spec_dir,
 
 def test_default_query_param_does_not_match_defined_type(
         default_param_error_spec_dir):
-    with pytest.raises(SwaggerValidationError):
+    with pytest.raises(OpenAPIValidationError):
         build_app_from_fixture(default_param_error_spec_dir, validate_responses=True, debug=False)

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -2,11 +2,11 @@ import json
 
 import jinja2
 import yaml
-from openapi_spec_validator.exceptions import OpenAPIValidationError
 
 import pytest
 from conftest import TEST_FOLDER, build_app_from_fixture
 from connexion import App
+from connexion.exceptions import InvalidSpecification
 
 SPECS = ["swagger.yaml"]
 
@@ -204,5 +204,5 @@ def test_add_api_with_function_resolver_function_is_wrapped(simple_api_spec_dir,
 
 def test_default_query_param_does_not_match_defined_type(
         default_param_error_spec_dir):
-    with pytest.raises(OpenAPIValidationError):
+    with pytest.raises(InvalidSpecification):
         build_app_from_fixture(default_param_error_spec_dir, validate_responses=True, debug=False)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,13 +3,12 @@
 import pathlib
 import tempfile
 
-from openapi_spec_validator.exceptions import OpenAPIValidationError
 from yaml import YAMLError
 
 import pytest
 from connexion import FlaskApi
 from connexion.apis.abstract import canonical_base_path
-from connexion.exceptions import ResolverError
+from connexion.exceptions import InvalidSpecification, ResolverError
 from mock import MagicMock
 
 TEST_FOLDER = pathlib.Path(__file__).parent
@@ -86,13 +85,13 @@ def test_invalid_operation_does_not_stop_application_in_debug_mode():
 
 def test_other_errors_stop_application_to_setup():
     # Errors should still result exceptions!
-    with pytest.raises(OpenAPIValidationError):
+    with pytest.raises(InvalidSpecification):
         FlaskApi(TEST_FOLDER / "fixtures/bad_specs/swagger.yaml",
                  base_path="/api/v1.0", arguments={'title': 'OK'})
 
 
 def test_invalid_schema_file_structure():
-    with pytest.raises(OpenAPIValidationError):
+    with pytest.raises(InvalidSpecification):
         FlaskApi(TEST_FOLDER / "fixtures/invalid_schema/swagger.yaml",
                  base_path="/api/v1.0", arguments={'title': 'OK'}, debug=True)
 
@@ -111,12 +110,12 @@ def test_use_of_safe_load_for_yaml_swagger_specs():
             f.flush()
             try:
                 FlaskApi(pathlib.Path(f.name), base_path="/api/v1.0")
-            except OpenAPIValidationError:
+            except InvalidSpecification:
                 pytest.fail("Could load invalid YAML file, use yaml.safe_load!")
 
 
 def test_validation_error_on_completely_invalid_swagger_spec():
-    with pytest.raises(OpenAPIValidationError):
+    with pytest.raises(InvalidSpecification):
         with tempfile.NamedTemporaryFile() as f:
             f.write('[1]\n'.encode())
             f.flush()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,13 +3,13 @@
 import pathlib
 import tempfile
 
-from swagger_spec_validator.common import SwaggerValidationError
+from openapi_spec_validator.exceptions import OpenAPIValidationError
 from yaml import YAMLError
 
 import pytest
 from connexion import FlaskApi
 from connexion.apis.abstract import canonical_base_path
-from connexion.exceptions import InvalidSpecification, ResolverError
+from connexion.exceptions import ResolverError
 from mock import MagicMock
 
 TEST_FOLDER = pathlib.Path(__file__).parent
@@ -86,13 +86,13 @@ def test_invalid_operation_does_not_stop_application_in_debug_mode():
 
 def test_other_errors_stop_application_to_setup():
     # Errors should still result exceptions!
-    with pytest.raises(SwaggerValidationError):
+    with pytest.raises(OpenAPIValidationError):
         FlaskApi(TEST_FOLDER / "fixtures/bad_specs/swagger.yaml",
                  base_path="/api/v1.0", arguments={'title': 'OK'})
 
 
 def test_invalid_schema_file_structure():
-    with pytest.raises(SwaggerValidationError):
+    with pytest.raises(OpenAPIValidationError):
         FlaskApi(TEST_FOLDER / "fixtures/invalid_schema/swagger.yaml",
                  base_path="/api/v1.0", arguments={'title': 'OK'}, debug=True)
 
@@ -111,12 +111,12 @@ def test_use_of_safe_load_for_yaml_swagger_specs():
             f.flush()
             try:
                 FlaskApi(pathlib.Path(f.name), base_path="/api/v1.0")
-            except SwaggerValidationError:
+            except OpenAPIValidationError:
                 pytest.fail("Could load invalid YAML file, use yaml.safe_load!")
 
 
 def test_validation_error_on_completely_invalid_swagger_spec():
-    with pytest.raises(SwaggerValidationError):
+    with pytest.raises(OpenAPIValidationError):
         with tempfile.NamedTemporaryFile() as f:
             f.write('[1]\n'.encode())
             f.flush()

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -418,8 +418,8 @@ def test_multi_body(api):
         operation.body_schema
 
     exception = exc_info.value
-    assert str(exception) == "<InvalidSpecification: GET endpoint There can be one 'body' parameter at most>"
-    assert repr(exception) == "<InvalidSpecification: GET endpoint There can be one 'body' parameter at most>"
+    assert str(exception) == "GET endpoint There can be one 'body' parameter at most"
+    assert repr(exception) == """<InvalidSpecification: "GET endpoint There can be one 'body' parameter at most">"""
 
 
 def test_no_token_info(api):


### PR DESCRIPTION
related to #420 and #639 , this switches to a library that can validate both swagger 2.0 and openapi 3 specs.

Changes proposed in this pull request:
 - Change validation library from swagger_spec_validator to openapi_spec_validator

