### PR TITLE
update some names from swagger to openapi

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -72,13 +72,15 @@ class AbstractAPI(object):
 
         self.options = ConnexionOptions(options)
 
+        logger.debug('Options Loaded',
+                     extra={'swagger_ui': self.options.openapi_console_ui_available,
+                            'swagger_path': self.options.openapi_console_ui_from_dir,
+                            'swagger_url': self.options.openapi_console_ui_path})
+
         logger.debug('Loading specification: %s', specification,
                      extra={'swagger_yaml': specification,
                             'base_path': base_path,
                             'arguments': arguments,
-                            'swagger_ui': self.options.openapi_console_ui_available,
-                            'swagger_path': self.options.openapi_console_ui_from_dir,
-                            'swagger_url': self.options.openapi_console_ui_path,
                             'auth_all_paths': auth_all_paths})
 
         if isinstance(specification, dict):
@@ -91,9 +93,9 @@ class AbstractAPI(object):
         logger.debug('Read specification', extra={'spec': self.specification})
 
         # Avoid validator having ability to modify specification
-        spec = copy.deepcopy(self.specification)
-        self._validate_spec(spec)
-        self.specification = resolve_refs(spec)
+        self.raw_spec = copy.deepcopy(self.specification)
+        self._validate_spec(self.specification)
+        self.specification = resolve_refs(self.specification)
 
         # https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#fixed-fields
         # If base_path is not on provided then we try to read it from the swagger.yaml or use / by default
@@ -130,7 +132,7 @@ class AbstractAPI(object):
         self.pass_context_arg_name = pass_context_arg_name
 
         if self.options.openapi_spec_available:
-            self.add_swagger_json()
+            self.add_openapi_json()
 
         if self.options.openapi_console_ui_available:
             self.add_swagger_ui()
@@ -155,9 +157,10 @@ class AbstractAPI(object):
             self.specification['basePath'] = base_path
 
     @abc.abstractmethod
-    def add_swagger_json(self):
+    def add_openapi_json(self):
         """
-        Adds swagger json to {base_path}/swagger.json
+        Adds openapi spec to {base_path}/openapi.json
+             (or {base_path}/swagger.json for swagger2)
         """
 
     @abc.abstractmethod

--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -64,23 +64,25 @@ class AioHttpApi(AbstractAPI):
     def normalize_string(string):
         return re.sub(r'[^a-zA-Z0-9]', '_', string.strip('/'))
 
-    def add_swagger_json(self):
+    def add_openapi_json(self):
         """
-        Adds swagger json to {base_path}/swagger.json
+        Adds openapi json to {base_path}/openapi.json
+             (or {base_path}/swagger.json for swagger2)
         """
-        logger.debug('Adding swagger.json: %s/swagger.json', self.base_path)
+        logger.debug('Adding spec json: %s/%s', self.base_path,
+                     self.options.openapi_spec_path)
         self.subapp.router.add_route(
             'GET',
-            '/swagger.json',
-            self._get_swagger_json
+            self.options.openapi_spec_path,
+            self._get_openapi_json
         )
 
     @asyncio.coroutine
-    def _get_swagger_json(self, req):
+    def _get_openapi_json(self, req):
         return web.Response(
             status=200,
             content_type='application/json',
-            body=self.jsonifier.dumps(self.specification)
+            body=self.jsonifier.dumps(self.raw_spec)
         )
 
     def add_swagger_ui(self):
@@ -112,7 +114,8 @@ class AioHttpApi(AbstractAPI):
     @aiohttp_jinja2.template('index.j2')
     @asyncio.coroutine
     def _get_swagger_ui_home(self, req):
-        return {'openapi_spec_url': self.base_path + '/swagger.json'}
+        return {'openapi_spec_url': (self.base_path +
+                                     self.options.openapi_spec_path)}
 
     def add_auth_on_not_found(self, security, security_definitions):
         """

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -26,15 +26,17 @@ class FlaskApi(AbstractAPI):
         self.blueprint = flask.Blueprint(endpoint, __name__, url_prefix=self.base_path,
                                          template_folder=str(self.options.openapi_console_ui_from_dir))
 
-    def add_swagger_json(self):
+    def add_openapi_json(self):
         """
-        Adds swagger json to {base_path}/swagger.json
+        Adds spec json to {base_path}/swagger.json
+        or {base_path}/openapi.json (for oas3)
         """
-        logger.debug('Adding swagger.json: %s/swagger.json', self.base_path)
-        endpoint_name = "{name}_swagger_json".format(name=self.blueprint.name)
-        self.blueprint.add_url_rule('/swagger.json',
+        logger.debug('Adding spec json: %s/%s', self.base_path,
+                     self.options.openapi_spec_path)
+        endpoint_name = "{name}_openapi_json".format(name=self.blueprint.name)
+        self.blueprint.add_url_rule(self.options.openapi_spec_path,
                                     endpoint_name,
-                                    lambda: flask.jsonify(self.specification))
+                                    lambda: flask.jsonify(self.raw_spec))
 
     def add_swagger_ui(self):
         """
@@ -281,7 +283,7 @@ class InternalHandlers(object):
         """
         return flask.render_template(
             'index.j2',
-            openapi_spec_url=(self.base_path + '/swagger.json')
+            openapi_spec_url=(self.base_path + self.options.openapi_spec_path)
         )
 
     def console_ui_static_files(self, filename):

--- a/connexion/options.py
+++ b/connexion/options.py
@@ -52,14 +52,12 @@ class ConnexionOptions(object):
 
         Default: True
         """
-        serve_spec = self._options.get('serve_spec', False)
+        deprecated_option = self._options.get('swagger_json', True)
+        serve_spec = self._options.get('serve_spec', deprecated_option)
         if 'swagger_json' in self._options:
             deprecation_warning = ("The 'swagger_json' option is deprecated. "
                                    "Please use 'serve_spec' instead")
             logger.warning(deprecation_warning)
-            serve_spec = serve_spec or self._options.get('swagger_json')
-        # override if swagger UI is enabled
-        serve_spec = serve_spec or self.openapi_console_ui_available
         return serve_spec
 
     @property
@@ -67,9 +65,7 @@ class ConnexionOptions(object):
         # type: () -> bool
         """
         Whether to make the OpenAPI Console UI available under the path
-        defined in `openapi_console_ui_path` option. Note that if enabled,
-        this overrides the `openapi_spec_available` option since the specification
-        is required to be available via a HTTP endpoint to display the console UI.
+        defined in `openapi_console_ui_path` option.
 
         Default: True
         """

--- a/connexion/options.py
+++ b/connexion/options.py
@@ -52,7 +52,13 @@ class ConnexionOptions(object):
 
         Default: True
         """
-        return self._options.get('swagger_json', True)
+        serve_spec = self._options.get('serve_spec', False)
+        if 'swagger_json' in self._options:
+            deprecation_warning = ("The 'swagger_json' option is deprecated. "
+                                   "Please use 'serve_spec' instead")
+            logger.warning(deprecation_warning)
+            serve_spec = serve_spec or self._options.get('swagger_json')
+        return serve_spec
 
     @property
     def openapi_console_ui_available(self):

--- a/connexion/options.py
+++ b/connexion/options.py
@@ -58,6 +58,8 @@ class ConnexionOptions(object):
                                    "Please use 'serve_spec' instead")
             logger.warning(deprecation_warning)
             serve_spec = serve_spec or self._options.get('swagger_json')
+        # override if swagger UI is enabled
+        serve_spec = serve_spec or self.openapi_console_ui_available
         return serve_spec
 
     @property

--- a/tests/aiohttp/test_aiohttp_simple_api.py
+++ b/tests/aiohttp/test_aiohttp_simple_api.py
@@ -57,7 +57,7 @@ def test_swagger_json(aiohttp_api_spec_dir, test_client):
     json_ = yield from swagger_json.read()
 
     assert swagger_json.status == 200
-    assert api.specification == json.loads(json_)
+    assert api.raw_spec == json.loads(json_)
 
 
 @asyncio.coroutine

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -90,7 +90,7 @@ def test_swagger_json_app(simple_api_spec_dir, spec):
 @pytest.mark.parametrize("spec", SPECS)
 def test_no_swagger_json_app(simple_api_spec_dir, spec):
     """ Verify the spec json file is not returned when set to False when creating app. """
-    options = {"swagger_json": False}
+    options = {"serve_spec": False}
     app = App(__name__, port=5001, specification_dir=simple_api_spec_dir,
               options=options, debug=True)
     app.add_api(spec)
@@ -141,7 +141,7 @@ def test_swagger_json_api(simple_api_spec_dir, spec):
 def test_no_swagger_json_api(simple_api_spec_dir, spec):
     """ Verify the spec json file is not returned when set to False when adding api. """
     app = App(__name__, port=5001, specification_dir=simple_api_spec_dir, debug=True)
-    app.add_api(spec, options={"swagger_json": False})
+    app.add_api(spec, options={"serve_spec": False})
 
     app_client = app.app.test_client()
     url = '/v1.0/{spec}'.format(spec=spec.replace("yaml", "json"))


### PR DESCRIPTION
another chunk of #639 

Changes proposed in this pull request:
 - rename references to the "swagger json" to "openapi json"
 - ensure we serve up the spec as it exists on disk ("raw_spec"), not the resolved spec.

Note that the UI component is actually called "swagger-ui".
> ```
> The easiest way to understand the difference is:
> OpenAPI = Specification
> Swagger = Tools for implementing the specification
> ```

More information on naming here: https://swagger.io/blog/api-strategy/difference-between-swagger-and-openapi/
