### PR TITLE
fix link to odata

### DIFF
--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -88,7 +88,8 @@ under-score is encountered. As an example:
     'top'
 
 Without this sanitation it would e.g. be impossible to implement an
-[OData](http://www.odata.org) API.
+`OData
+<http://www.odata.org>`_ API.
 
 Parameter Variable Converters
 -----------------------------


### PR DESCRIPTION
Link has markdown syntax in a reStructuredText document.