### PR TITLE
Add Daniel Grossmann-Kavanagh as maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,4 @@
 João Santos <joao.santos@zalando.de>
 Henning Jacobs <henning.jacobs@zalando.de>
 Rafael Caricio <rafael@caricio.com>
+Daniel Grossmann-Kavanagh <me@danielgk.com>


### PR DESCRIPTION
Add Daniel Grossmann-Kavanagh as an external contributor to Connexion.