### PR TITLE
Nullable in definitions

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -5,7 +5,8 @@ import logging
 import sys
 
 import six
-from jsonschema import Draft4Validator, ValidationError, draft4_format_checker, validators
+from jsonschema import (Draft4Validator, ValidationError,
+                        draft4_format_checker, validators)
 from werkzeug import FileStorage
 
 from ..exceptions import ExtraParameterProblem
@@ -88,7 +89,8 @@ def extend_with_nullable_support(validator_class):
     def nullable_support(validator, properties, instance, schema):
         null_properties = {}
         for property_, subschema in six.iteritems(properties):
-            if property_ in instance and \
+            if isinstance(instance, collections.Iterable) and \
+                    property_ in instance and \
                     instance[property_] is None and \
                     subschema.get('x-nullable') is True:
                 # exclude from following validation
@@ -96,7 +98,8 @@ def extend_with_nullable_support(validator_class):
         for error in validate_properties(validator, properties, instance, schema):
             yield error
         # add null properties back
-        instance.update(null_properties)
+        if null_properties:
+            instance.update(null_properties)
     return validators.extend(validator_class, {'properties': nullable_support})
 
 

--- a/tests/decorators/test_uri_parsing.py
+++ b/tests/decorators/test_uri_parsing.py
@@ -1,5 +1,6 @@
-import pytest
 from werkzeug.datastructures import MultiDict
+
+import pytest
 from connexion.decorators.uri_parsing import (AlwaysMultiURIParser,
                                               FirstValueURIParser,
                                               Swagger2URIParser)

--- a/tests/decorators/test_validation.py
+++ b/tests/decorators/test_validation.py
@@ -1,5 +1,8 @@
-from connexion.decorators.validation import ParameterValidator
+from jsonschema import ValidationError
 from mock import MagicMock
+import pytest
+
+from connexion.decorators.validation import ParameterValidator, Draft4ValidatorSupportNullable
 
 
 def test_get_valid_parameter():
@@ -46,3 +49,23 @@ def test_invalid_type_value_error(monkeypatch):
     value = {'test': 1, 'second': 2}
     result = ParameterValidator.validate_parameter('formdata', value, {'type': 'boolean', 'name': 'foo'})
     assert result == "Wrong type, expected 'boolean' for formdata parameter 'foo'"
+
+def test_support_nullable_properties():
+    schema = {
+        "type": "object",
+        "properties": {"foo": {"type": "string", "x-nullable": True}},
+    }
+    try:
+        Draft4ValidatorSupportNullable(schema).validate({"foo": None})
+    except ValidationError:
+        pytest.fail("Shouldn't raise ValidationError")
+
+
+def test_support_nullable_properties_raises_validation_error():
+    schema = {
+        "type": "object",
+        "properties": {"foo": {"type": "string", "x-nullable": False}},
+    }
+
+    with pytest.raises(ValidationError):
+        Draft4ValidatorSupportNullable(schema).validate({"foo": None})

--- a/tests/decorators/test_validation.py
+++ b/tests/decorators/test_validation.py
@@ -1,8 +1,9 @@
 from jsonschema import ValidationError
-from mock import MagicMock
-import pytest
 
-from connexion.decorators.validation import ParameterValidator, Draft4ValidatorSupportNullable
+import pytest
+from connexion.decorators.validation import (Draft4ValidatorSupportNullable,
+                                             ParameterValidator)
+from mock import MagicMock
 
 
 def test_get_valid_parameter():
@@ -69,3 +70,12 @@ def test_support_nullable_properties_raises_validation_error():
 
     with pytest.raises(ValidationError):
         Draft4ValidatorSupportNullable(schema).validate({"foo": None})
+
+
+def test_support_nullable_properties_not_iterable():
+    schema = {
+        "type": "object",
+        "properties": {"foo": {"type": "string", "x-nullable": True}},
+    }
+    with pytest.raises(ValidationError):
+        Draft4ValidatorSupportNullable(schema).validate(12345)


### PR DESCRIPTION
Related to #439 , but against the dev-2.0 branch

Changes proposed in this pull request:
 - add x-nullable support in jsonschema validator