### PR TITLE
Add validator kind to error logs extra in validators

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -141,7 +141,8 @@ class RequestBodyValidator(object):
             self.validator.validate(data)
         except ValidationError as exception:
             logger.error("{url} validation error: {error}".format(url=url,
-                                                                  error=exception.message))
+                                                                  error=exception.message),
+                         extra={'validator': 'body'})
             return problem(400, 'Bad Request', str(exception.message))
 
         return None
@@ -164,7 +165,8 @@ class ResponseBodyValidator(object):
             self.validator.validate(data)
         except ValidationError as exception:
             logger.error("{url} validation error: {error}".format(url=url,
-                                                                  error=exception))
+                                                                  error=exception),
+                         extra={'validator': 'response'})
             six.reraise(*sys.exc_info())
 
         return None


### PR DESCRIPTION
To easily discern response and request validation errors logs
programmatically (e.g. in logging filter).
