### PR TITLE
skip codacy warnings about the use of assert in unit tests

### DIFF
--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,0 +1,2 @@
+skips:
+ - "B101"  # https://docs.openstack.org/bandit/latest/plugins/b101_assert_used.html


### PR DESCRIPTION
The `assert` keyword is used in unit tests, but codacy flags this as an error.
This results in bad codacy grades for PRs that add unit tests.

Changes proposed in this pull request:
 - skip codacy warning/errors from using the `assert` keyword
