### PR TITLE
missing server block doesn't cause error [oas3]

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -186,6 +186,8 @@ class AbstractAPI(object):
                     #      oas3 spec with different paths?
                     base_path = urlparse(server['url']).path
                     break
+                else:
+                    base_path = ''
         self.base_path = canonical_base_path(base_path)
 
     @abc.abstractmethod


### PR DESCRIPTION
Changes proposed in this pull request:
 - don't error if an oas3 spec doesn't contain a servers block