### PR TITLE
Codacy skip assert warnings

### DIFF
--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,0 +1,2 @@
+skips:
+ - "B101"  # https://docs.openstack.org/bandit/latest/plugins/b101_assert_used.html


### PR DESCRIPTION
Codacy issues warning when the `assert` keyword is used.

The concern from the bandit linter is that people might use `assert` in production code as a way of checking function inputs or something (no idea why anyone would ever do this).

In the case of connexion, it spews warnings any time you add a unit test! This is pretty annoying, and gives a false sense of a PR's code quality.

This PR disables that warning.