### PR TITLE
addition of x-openapi-router-controller param

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,9 +173,9 @@ identify which Python function should handle each URL.
 
 If you provide this path in your specification POST requests to
 ``http://MYHOST/hello_world``, it will be handled by the function
-``hello_world`` in the ``myapp.api`` module. Optionally, you can include
-``x-swagger-router-controller`` in your operation definition, making
-``operationId`` relative:
+``hello_world`` in the ``myapp.api`` module.Optionally, you can include
+``x-swagger-router-controller`` or ``x-openapi-router-controller``
+ in your operation definition, making ``operationId`` relative:
 
 .. code-block:: yaml
 

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -96,6 +96,7 @@ class AbstractOperation(SecureOperation):
         self._randomize_endpoint = randomize_endpoint
 
         self._router_controller = self._operation.get('x-swagger-router-controller')
+        self._router_controller = self._operation.get('x-openapi-router-controller')
 
         self._operation_id = self._operation.get("operationId")
         self._resolution = resolver.resolve(self)

--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -19,8 +19,8 @@ identify which Python function should handle each URL.
 If you provided this path in your specification POST requests to
 ``http://MYHOST/hello_world``, it would be handled by the function
 ``hello_world`` in ``myapp.api`` module. Optionally, you can include
-``x-swagger-router-controller`` in your operation definition, making
-``operationId`` relative:
+``x-swagger-router-controller`` or ``x-openapi-router-controller``
+ in your operation definition, making ``operationId`` relative:
 
 .. code-block:: yaml
 
@@ -68,10 +68,10 @@ the endpoints in your specification:
           # Implied operationId: api.foo.delete
 
 ``RestyResolver`` will give precedence to any ``operationId``
-encountered in the specification. It will also respect
-``x-swagger-router-controller``. You may import and extend
-``connexion.resolver.Resolver`` to implement your own ``operationId``
-(and function) resolution algorithm.
+encountered in the specification. It will also respect both
+``x-swagger-router-controller`` and ``x-openapi-router-controller``.
+ You may import and extend ``connexion.resolver.Resolver`` to implement
+  your own ``operationId`` (and function) resolution algorithm.
 
 Parameter Name Sanitation
 -------------------------

--- a/tests/test_resolver3.py
+++ b/tests/test_resolver3.py
@@ -19,7 +19,22 @@ def test_standard_resolve_x_router_controller():
         resolver=Resolver()
     )
     assert operation.operation_id == 'fakeapi.hello.post_greeting'
-
+    
+def test_standard_resolve_x_openapi_router_controller():
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='endpoint',
+        path_parameters=[],
+        operation={
+            'x-openapi-router-controller': 'fakeapi.hello',
+            'operationId': 'post_greeting',
+        },
+        app_security=[],
+        components=COMPONENTS,
+        resolver=Resolver()
+    )
+    assert operation.operation_id == 'fakeapi.hello.post_greeting'
 
 def test_resty_resolve_operation_id():
     operation = OpenAPIOperation(


### PR DESCRIPTION
Fixes #688.
Simple change adding a line to the operation abstract file that will allow use of x-openapi-router-controller to configure the routing. This should have no effect on how it behaves when x-swagger-router-controller is used.

The current implementation of this means that if both are given then x-openapi-router-controller will be used. 

Changes proposed in this pull request:

 - x-openapi-router-controller support
