### PR TITLE
Fix bad parsing of query params for AioHttp

### DIFF
--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -167,7 +167,7 @@ class AioHttpApi(AbstractAPI):
         logger.debug('Getting data and status code',
                      extra={'has_body': req.has_body, 'url': url})
 
-        query = {k: ','.join(v) for k, v in parse_qs(req.rel_url.query_string).items()}
+        query = {query_key: query_values for query_key, query_values in parse_qs(req.rel_url.query_string).items()}
         headers = {k.decode(): v.decode() for k, v in req.raw_headers}
         body = None
         if req.can_read_body:

--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -167,7 +167,7 @@ class AioHttpApi(AbstractAPI):
         logger.debug('Getting data and status code',
                      extra={'has_body': req.has_body, 'url': url})
 
-        query = {query_key: query_values for query_key, query_values in parse_qs(req.rel_url.query_string).items()}
+        query = parse_qs(req.rel_url.query_string)
         headers = {k.decode(): v.decode() for k, v in req.raw_headers}
         body = None
         if req.can_read_body:

--- a/tests/aiohttp/test_aiohttp_simple_api.py
+++ b/tests/aiohttp/test_aiohttp_simple_api.py
@@ -226,35 +226,51 @@ def test_access_request_context(test_client, aiohttp_app):
 
 @asyncio.coroutine
 def test_query_parsing_simple(test_client, aiohttp_app):
+    expected_query = 'query'
+
     app_client = yield from test_client(aiohttp_app.app)
     resp = yield from app_client.get(
         '/v1.0/aiohttp_query_parsing_str',
         params={
-            'query': 'query',
+            'query': expected_query,
         },
     )
-    assert resp.status == 204
+    assert resp.status == 200
+
+    json_data = yield from resp.json()
+    assert json_data == {'query': expected_query}
 
 
 @asyncio.coroutine
 def test_query_parsing_array(test_client, aiohttp_app):
+    expected_query = ['queryA', 'queryB']
+
     app_client = yield from test_client(aiohttp_app.app)
     resp = yield from app_client.get(
         '/v1.0/aiohttp_query_parsing_array',
         params={
-            'query': 'queryA,queryB',
+            'query': ','.join(expected_query),
         },
     )
-    assert resp.status == 204
+    assert resp.status == 200
+
+    json_data = yield from resp.json()
+    assert json_data == {'query': expected_query}
 
 
 @asyncio.coroutine
 def test_query_parsing_array_multi(test_client, aiohttp_app):
+    expected_query = ['queryA', 'queryB', 'queryC']
+    query_str = '&'.join(['query=%s' % q for q in expected_query])
+
     app_client = yield from test_client(aiohttp_app.app)
     resp = yield from app_client.get(
-        '/v1.0/aiohttp_query_parsing_array_multi?query=queryA&query=queryB&query=queryC',
+        '/v1.0/aiohttp_query_parsing_array_multi?%s' % query_str,
     )
-    assert resp.status == 204
+    assert resp.status == 200
+
+    json_data = yield from resp.json()
+    assert json_data == {'query': expected_query}
 
 
 if sys.version_info[0:2] >= (3, 5):

--- a/tests/aiohttp/test_aiohttp_simple_api.py
+++ b/tests/aiohttp/test_aiohttp_simple_api.py
@@ -224,6 +224,39 @@ def test_access_request_context(test_client, aiohttp_app):
     assert resp.status == 204
 
 
+@asyncio.coroutine
+def test_query_parsing_simple(test_client, aiohttp_app):
+    app_client = yield from test_client(aiohttp_app.app)
+    resp = yield from app_client.get(
+        '/v1.0/aiohttp_query_parsing_str',
+        params={
+            'query': 'query',
+        },
+    )
+    assert resp.status == 204
+
+
+@asyncio.coroutine
+def test_query_parsing_array(test_client, aiohttp_app):
+    app_client = yield from test_client(aiohttp_app.app)
+    resp = yield from app_client.get(
+        '/v1.0/aiohttp_query_parsing_array',
+        params={
+            'query': 'queryA,queryB',
+        },
+    )
+    assert resp.status == 204
+
+
+@asyncio.coroutine
+def test_query_parsing_array_multi(test_client, aiohttp_app):
+    app_client = yield from test_client(aiohttp_app.app)
+    resp = yield from app_client.get(
+        '/v1.0/aiohttp_query_parsing_array_multi?query=queryA&query=queryB&query=queryC',
+    )
+    assert resp.status == 204
+
+
 if sys.version_info[0:2] >= (3, 5):
     @pytest.fixture
     def aiohttp_app_async_def(aiohttp_api_spec_dir):

--- a/tests/fakeapi/aiohttp_handlers.py
+++ b/tests/fakeapi/aiohttp_handlers.py
@@ -47,20 +47,17 @@ def aiohttp_access_request_context(request_ctx):
 
 @asyncio.coroutine
 def aiohttp_query_parsing_str(query):
-    assert query == 'query'
-    return ConnexionResponse(status_code=204)
+    return ConnexionResponse(body={'query': query})
 
 
 @asyncio.coroutine
 def aiohttp_query_parsing_array(query):
-    assert query == ['queryA', 'queryB']
-    return ConnexionResponse(status_code=204)
+    return ConnexionResponse(body={'query': query})
 
 
 @asyncio.coroutine
 def aiohttp_query_parsing_array_multi(query):
-    assert query == ['queryA', 'queryB', 'queryC']
-    return ConnexionResponse(status_code=204)
+    return ConnexionResponse(body={'query': query})
 
 
 USERS = [

--- a/tests/fakeapi/aiohttp_handlers.py
+++ b/tests/fakeapi/aiohttp_handlers.py
@@ -45,6 +45,24 @@ def aiohttp_access_request_context(request_ctx):
     return ConnexionResponse(status_code=204)
 
 
+@asyncio.coroutine
+def aiohttp_query_parsing_str(query):
+    assert query == 'query'
+    return ConnexionResponse(status_code=204)
+
+
+@asyncio.coroutine
+def aiohttp_query_parsing_array(query):
+    assert query == ['queryA', 'queryB']
+    return ConnexionResponse(status_code=204)
+
+
+@asyncio.coroutine
+def aiohttp_query_parsing_array_multi(query):
+    assert query == ['queryA', 'queryB', 'queryC']
+    return ConnexionResponse(status_code=204)
+
+
 USERS = [
     {"id": 1, "name": "John Doe"},
     {"id": 2, "name": "Nick Carlson"}

--- a/tests/fixtures/aiohttp/swagger_simple.yaml
+++ b/tests/fixtures/aiohttp/swagger_simple.yaml
@@ -123,8 +123,6 @@ paths:
       summary: Test proper parsing of query parameters
       description: Tests proper parsing
       operationId: fakeapi.aiohttp_handlers.aiohttp_query_parsing_str
-      produces:
-        - text/plain
       parameters:
         - in: query
           name: query
@@ -132,16 +130,16 @@ paths:
           type: string
           required: true
       responses:
-        204:
-          description: success no content.
+        200:
+          description: Query parsing result
+          schema:
+            $ref: '#/definitions/SimpleQuery'
 
   /aiohttp_query_parsing_array:
     get:
       summary: Test proper parsing of query parameters
       description: Tests proper parsing
       operationId: fakeapi.aiohttp_handlers.aiohttp_query_parsing_array
-      produces:
-        - text/plain
       parameters:
         - in: query
           name: query
@@ -151,16 +149,16 @@ paths:
             type: string
           required: true
       responses:
-        204:
-          description: success no content.
+        200:
+          description: Query parsing result
+          schema:
+            $ref: '#/definitions/MultiQuery'
 
   /aiohttp_query_parsing_array_multi:
     get:
       summary: Test proper parsing of query parameters
       description: Tests proper parsing
       operationId: fakeapi.aiohttp_handlers.aiohttp_query_parsing_array_multi
-      produces:
-        - text/plain
       parameters:
         - in: query
           name: query
@@ -171,11 +169,29 @@ paths:
           collectionFormat: multi
           required: true
       responses:
-        204:
-          description: success no content.
+        200:
+          description: Query parsing result
+          schema:
+            $ref: '#/definitions/MultiQuery'
 
 
 definitions:
+  SimpleQuery:
+    type: object
+    required:
+      - query
+    properties:
+      query:
+        type: string
+  MultiQuery:
+    type: object
+    required:
+      - query
+    properties:
+      query:
+        type: array
+        items:
+          type: string
   User:
     type: object
     required:

--- a/tests/fixtures/aiohttp/swagger_simple.yaml
+++ b/tests/fixtures/aiohttp/swagger_simple.yaml
@@ -118,6 +118,62 @@ paths:
           schema:
             $ref: '#/definitions/User'
 
+  /aiohttp_query_parsing_str:
+    get:
+      summary: Test proper parsing of query parameters
+      description: Tests proper parsing
+      operationId: fakeapi.aiohttp_handlers.aiohttp_query_parsing_str
+      produces:
+        - text/plain
+      parameters:
+        - in: query
+          name: query
+          description: Simple query param
+          type: string
+          required: true
+      responses:
+        204:
+          description: success no content.
+
+  /aiohttp_query_parsing_array:
+    get:
+      summary: Test proper parsing of query parameters
+      description: Tests proper parsing
+      operationId: fakeapi.aiohttp_handlers.aiohttp_query_parsing_array
+      produces:
+        - text/plain
+      parameters:
+        - in: query
+          name: query
+          description: Array like query param
+          type: array
+          items:
+            type: string
+          required: true
+      responses:
+        204:
+          description: success no content.
+
+  /aiohttp_query_parsing_array_multi:
+    get:
+      summary: Test proper parsing of query parameters
+      description: Tests proper parsing
+      operationId: fakeapi.aiohttp_handlers.aiohttp_query_parsing_array_multi
+      produces:
+        - text/plain
+      parameters:
+        - in: query
+          name: query
+          description: Array like query param
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+          required: true
+      responses:
+        204:
+          description: success no content.
+
 
 definitions:
   User:


### PR DESCRIPTION
Fixes #696 .

Changes proposed in this pull request:
- do not join query parameters values with `,` for AioHttpApi. `connexion.decorators.uri_parsing.AbstractURIParser` requires those to be an array, given the code (i.e. `{'queryParam': ['aValue']}`). However the dictionary that reaches the parses always have single string as value for each key.
