### PR TITLE
disable threading in sqlalchemy demo (in-memory db)

### DIFF
--- a/examples/sqlalchemy/app.py
+++ b/examples/sqlalchemy/app.py
@@ -60,4 +60,7 @@ def shutdown_session(exception=None):
 
 
 if __name__ == '__main__':
-    app.run(port=8080)
+    app.run(
+        port=8080,
+        threaded=False  # in-memory database isn't shared across threads
+    )


### PR DESCRIPTION
disable threading in sqlalchemy demo because it uses an in-memory database, which is not shared across threads.

Fixes #706 

Changes proposed in this pull request:
 - disable threading in sqlalchemy demo
