### PR TITLE
Add some set attributes of Flask application like customer static_folder

### DIFF
--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -19,9 +19,12 @@ logger = logging.getLogger('connexion.app')
 class FlaskApp(AbstractApp):
     def __init__(self, import_name, server='flask', **kwargs):
         super(FlaskApp, self).__init__(import_name, FlaskApi, server=server, **kwargs)
-
+        self.flask_dict={}
+        for key value in kwargs.items():
+            self.flask_dict[key] = value
+            
     def create_app(self):
-        app = flask.Flask(self.import_name)
+        app = flask.Flask(self.import_name, **self.flask_dict)
         app.json_encoder = FlaskJSONEncoder
         return app
 

--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -20,7 +20,7 @@ class FlaskApp(AbstractApp):
     def __init__(self, import_name, server='flask', **kwargs):
         super(FlaskApp, self).__init__(import_name, FlaskApi, server=server, **kwargs)
         self.flask_dict={}
-        for key value in kwargs.items():
+        for key, value in kwargs.items():
             self.flask_dict[key] = value
             
     def create_app(self):


### PR DESCRIPTION
Fixes # .


Changes proposed in this pull request:

 I would like customer Flask app like:
```
connex_app = connexion.FlaskApp(__name__, static_folder="static/dist", \
    template_folder="static", specification_dir=basedir+'\\swagger')
```
But I found the connex_app.app do not change anything and I can not use specialization my personal static_folder and template_folder.

I want when I initialized the app I can use same Flask accept parameters to customer my Flask.

