### PR TITLE
bugfix: get securitySchemes in openapi 3 APIs (thanks @cziebuhr)

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -128,12 +128,17 @@ class AbstractAPI(object):
         # API calls.
         self.consumes = self.specification.get('consumes', ['application/json'])  # type: List[str]
 
-        self.security = self.specification.get('security')
-        self.security_definitions = self.specification.get('securityDefinitions', dict())
-        logger.debug('Security Definitions: %s', self.security_definitions)
-
         self.definitions = self.specification.get('definitions', {})
         self.components = self.specification.get('components', {})
+
+        self.security = self.specification.get('security', dict())
+        _security_schemes = self.components.get('securitySchemes', dict())
+        self.security_definitions = self.specification.get(
+            'securityDefinitions',
+            _security_schemes
+        )
+        logger.debug('Security Definitions: %s', self.security_definitions)
+
         self.parameter_definitions = self.specification.get('parameters', {})
         self.response_definitions = self.specification.get('responses', {})
 

--- a/tests/api/test_secure_api.py
+++ b/tests/api/test_secure_api.py
@@ -3,14 +3,8 @@ import json
 from connexion import FlaskApp
 
 
-def test_security_over_nonexistent_endpoints(oauth_requests, secure_api_spec_dir):
-    options = {"swagger_ui": False}
-    app1 = FlaskApp(__name__, port=5001, specification_dir=secure_api_spec_dir,
-                    options=options, debug=True, auth_all_paths=True)
-    app1.add_api('swagger.yaml')
-    assert app1.port == 5001
-
-    app_client = app1.app.test_client()
+def test_security_over_nonexistent_endpoints(oauth_requests, secure_api_app):
+    app_client = secure_api_app.app.test_client()
     headers = {"Authorization": "Bearer 300"}
     get_inexistent_endpoint = app_client.get('/v1.0/does-not-exist-invalid-token',
                                              headers=headers)  # type: flask.Response

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,7 +154,9 @@ def secure_endpoint_app(request):
 
 @pytest.fixture(scope="session", params=SPECS)
 def secure_api_app(request):
-    return build_app_from_fixture('secure_api', request.param)
+    options = {"swagger_ui": False}
+    return build_app_from_fixture('secure_api', request.param,
+                                  options=options, auth_all_paths=True)
 
 
 @pytest.fixture(scope="session", params=SPECS)


### PR DESCRIPTION
bugfix: get securitySchemes in openapi 3 APIs
Fixes #711 

Extracts just the bugfix from #703 
Thanks @cziebuhr

Changes proposed in this pull request:
 - include securitySchemes in self.security_definitions
 - ensures test runs on both swagger 2 and openapi 3
