### PR TITLE
Fix implied method

### DIFF
--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -55,7 +55,7 @@ the endpoints in your specification:
           # Implied operationId: api.get
      /foo:
        get:
-          # Implied operationId: api.foo.search
+          # Implied operationId: api.foo.get
        post:
           # Implied operationId: api.foo.post
 


### PR DESCRIPTION
Why it should match a `search` operationId?
