### PR TITLE
simplify Operation class construction

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -1,33 +1,19 @@
 import abc
-import copy
 import logging
 import pathlib
 import sys
-from typing import AnyStr, List  # NOQA
 
-import jinja2
 import six
-import yaml
-from openapi_spec_validator.exceptions import OpenAPIValidationError
-from six.moves.urllib.parse import urlsplit
 
-from ..exceptions import InvalidSpecification, ResolverError
-from ..json_schema import resolve_refs
-from ..operations import OpenAPIOperation, Swagger2Operation, make_operation
+from ..exceptions import ResolverError
+from ..operations import make_operation
 from ..options import ConnexionOptions
 from ..resolver import Resolver
-from ..utils import Jsonifier, deep_get
-
-try:
-    import collections.abc as collections_abc  # python 3.3+
-except ImportError:
-    import collections as collections_abc
+from ..spec import Specification
+from ..utils import Jsonifier
 
 MODULE_PATH = pathlib.Path(__file__).absolute().parent.parent
 SWAGGER_UI_URL = 'ui'
-NO_SPEC_VERSION_ERR_MSG = """Unable to get the spec version.
-You are missing either '"swagger": "2.0"' or '"openapi": "3.0.0"'
-from the top level of your spec."""
 
 logger = logging.getLogger('connexion.apis.abstract')
 
@@ -37,230 +23,6 @@ class AbstractAPIMeta(abc.ABCMeta):
     def __init__(cls, name, bases, attrs):
         abc.ABCMeta.__init__(cls, name, bases, attrs)
         cls._set_jsonifier()
-
-
-class Specification(collections_abc.Mapping):
-
-    def __init__(self, raw_spec):
-        self._raw_spec = copy.deepcopy(raw_spec)
-        self._set_defaults(raw_spec)
-        self._validate_spec(raw_spec)
-        self._spec = resolve_refs(raw_spec)
-
-    @classmethod
-    @abc.abstractmethod
-    def _set_defaults(cls, spec):
-        """ set some default values in the spec
-        """
-
-    @classmethod
-    @abc.abstractmethod
-    def _validate_spec(cls, spec):
-        """ validate spec against schema
-        """
-
-    def get_path_params(self, path):
-        return deep_get(self._spec, ["paths", path]).get("parameters", [])
-
-    def get_operation(self, path, method):
-        return deep_get(self._spec, ["paths", path, method])
-
-    @property
-    def raw(self):
-        return self._raw_spec
-
-    @property
-    def version(self):
-        return self._get_spec_version(self._spec)
-
-    @property
-    def security(self):
-        return self._spec.get('security')
-
-    def __getitem__(self, k):
-        return self._spec[k]
-
-    def __iter__(self):
-        return self._spec.__iter__()
-
-    def __len__(self):
-        return self._spec.__len__()
-
-    @staticmethod
-    def _load_spec_from_file(arguments, specification):
-        """
-        Loads a YAML specification file, optionally rendering it with Jinja2.
-        Takes:
-          arguments - passed to Jinja2 renderer
-          specification - path to specification
-        """
-        arguments = arguments or {}
-
-        with specification.open(mode='rb') as openapi_yaml:
-            contents = openapi_yaml.read()
-            try:
-                openapi_template = contents.decode()
-            except UnicodeDecodeError:
-                openapi_template = contents.decode('utf-8', 'replace')
-
-            openapi_string = jinja2.Template(openapi_template).render(**arguments)
-            return yaml.safe_load(openapi_string)
-
-    @classmethod
-    def from_file(cls, spec, arguments=None):
-        """
-        Takes in a path to a YAML file, and returns a Specification
-        """
-        specification_path = pathlib.Path(spec)
-        spec = cls._load_spec_from_file(arguments, specification_path)
-        return cls.from_dict(spec)
-
-    @staticmethod
-    def _get_spec_version(spec):
-        try:
-            version_string = spec.get('openapi') or spec.get('swagger')
-        except AttributeError:
-            raise InvalidSpecification(NO_SPEC_VERSION_ERR_MSG)
-        if version_string is None:
-            raise InvalidSpecification(NO_SPEC_VERSION_ERR_MSG)
-        try:
-            version_tuple = tuple(map(int, version_string.split(".")))
-        except TypeError:
-            err = ('Unable to convert version string to semantic version tuple: '
-                   '{version_string}.')
-            err = err.format(version_string=version_string)
-            raise InvalidSpecification(err)
-        return version_tuple
-
-    @classmethod
-    def from_dict(cls, spec):
-        """
-        Takes in a dictionary, and returns a Specification
-        """
-        def enforce_string_keys(obj):
-            # YAML supports integer keys, but JSON does not
-            if isinstance(obj, dict):
-                return {
-                    str(k): enforce_string_keys(v)
-                    for k, v
-                    in six.iteritems(obj)
-                }
-            return obj
-
-        spec = enforce_string_keys(spec)
-        version = cls._get_spec_version(spec)
-        if version < (3, 0, 0):
-            return Swagger2Specification(spec)
-        return OpenAPISpecification(spec)
-
-    @classmethod
-    def load(cls, spec, arguments=None):
-        if not isinstance(spec, dict):
-            return cls.from_file(spec, arguments=arguments)
-        return cls.from_dict(spec)
-
-
-class Swagger2Specification(Specification):
-    yaml_name = 'swagger.yaml'
-    operation_cls = Swagger2Operation
-
-    @classmethod
-    def _set_defaults(cls, spec):
-        spec.setdefault('produces', [])
-        spec.setdefault('consumes', ['application/json'])  # type: List[str]
-        spec.setdefault('definitions', {})
-        spec.setdefault('parameters', {})
-        spec.setdefault('responses', {})
-
-    @property
-    def produces(self):
-        return self._spec['produces']
-
-    @property
-    def consumes(self):
-        return self._spec['consumes']
-
-    @property
-    def definitions(self):
-        return self._spec['definitions']
-
-    @property
-    def parameter_definitions(self):
-        return self._spec['parameters']
-
-    @property
-    def response_definitions(self):
-        return self._spec['responses']
-
-    @property
-    def security_definitions(self):
-        return self._spec.get('securityDefinitions', {})
-
-    @property
-    def base_path(self):
-        return canonical_base_path(self._spec.get('basePath', ''))
-
-    @base_path.setter
-    def base_path(self, base_path):
-        base_path = canonical_base_path(base_path)
-        self._raw_spec['basePath'] = base_path
-        self._spec['basePath'] = base_path
-
-    @classmethod
-    def _validate_spec(cls, spec):
-        from openapi_spec_validator import validate_v2_spec as validate_spec
-        try:
-            validate_spec(spec)
-        except OpenAPIValidationError as e:
-            raise InvalidSpecification.create_from(e)
-
-
-class OpenAPISpecification(Specification):
-    yaml_name = 'openapi.yaml'
-    operation_cls = OpenAPIOperation
-
-    @classmethod
-    def _set_defaults(cls, spec):
-        spec.setdefault('components', {})
-
-    @property
-    def security_definitions(self):
-        return self._spec['components'].get('securitySchemes', {})
-
-    @property
-    def components(self):
-        return self._spec['components']
-
-    @classmethod
-    def _validate_spec(cls, spec):
-        from openapi_spec_validator import validate_v3_spec as validate_spec
-        try:
-            validate_spec(spec)
-        except OpenAPIValidationError as e:
-            raise InvalidSpecification.create_from(e)
-
-    @property
-    def base_path(self):
-        servers = self._spec.get('servers', [])
-        try:
-            # assume we're the first server in list
-            server = copy.deepcopy(servers[0])
-            server_vars = server.pop("variables", {})
-            server['url'] = server['url'].format(
-                **{k: v['default'] for k, v
-                   in six.iteritems(server_vars)}
-            )
-            base_path = urlsplit(server['url']).path
-        except IndexError:
-            base_path = ''
-        return canonical_base_path(base_path)
-
-    @base_path.setter
-    def base_path(self, base_path):
-        base_path = canonical_base_path(base_path)
-        user_servers = [{'url': base_path}]
-        self._raw_spec['servers'] = user_servers
-        self._spec['servers'] = user_servers
 
 
 @six.add_metaclass(AbstractAPIMeta)
@@ -498,10 +260,3 @@ class AbstractAPI(object):
     def _set_jsonifier(cls):
         import json
         cls.jsonifier = Jsonifier(json)
-
-
-def canonical_base_path(base_path):
-    """
-    Make given "basePath" a canonical base URL which can be prepended to paths starting with "/".
-    """
-    return base_path.rstrip('/')

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -13,10 +13,10 @@ from six.moves.urllib.parse import urlsplit
 
 from ..exceptions import InvalidSpecification, ResolverError
 from ..json_schema import resolve_refs
-from ..operations import OpenAPIOperation, Swagger2Operation
+from ..operations import OpenAPIOperation, Swagger2Operation, make_operation
 from ..options import ConnexionOptions
 from ..resolver import Resolver
-from ..utils import Jsonifier
+from ..utils import Jsonifier, deep_get
 
 try:
     import collections.abc as collections_abc  # python 3.3+
@@ -58,6 +58,12 @@ class Specification(collections_abc.Mapping):
     def _validate_spec(cls, spec):
         """ validate spec against schema
         """
+
+    def get_path_params(self, path):
+        return deep_get(self._spec, ["paths", path]).get("parameters", [])
+
+    def get_operation(self, path, method):
+        return deep_get(self._spec, ["paths", path, method])
 
     @property
     def raw(self):
@@ -371,7 +377,7 @@ class AbstractAPI(object):
         Adds a 404 error handler to authenticate and only expose the 404 status if the security validation pass.
         """
 
-    def add_operation(self, method, path, swagger_operation, path_parameters):
+    def add_operation(self, path, method):
         """
         Adds one operation to the api.
 
@@ -386,39 +392,20 @@ class AbstractAPI(object):
 
         :type method: str
         :type path: str
-        :type swagger_operation: dict
         """
-
-        shared_args = {
-            "method": method,
-            "path": path,
-            "path_parameters": path_parameters,
-            "operation": swagger_operation,
-            "app_security": self.specification.security,
-            "validate_responses": self.validate_responses,
-            "validator_map": self.validator_map,
-            "strict_validation": self.strict_validation,
-            "resolver": self.resolver,
-            "pythonic_params": self.pythonic_params,
-            "uri_parser_class": self.options.uri_parser_class,
-            "pass_context_arg_name": self.pass_context_arg_name
-        }
-
-        # TODO refactor into AbstractOperation.from_spec(Specification, method, path)
-        if self.specification.version < (3, 0, 0):
-            operation = Swagger2Operation(self,
-                                          app_produces=self.specification.produces,
-                                          app_consumes=self.specification.consumes,
-                                          security_definitions=self.specification.security_definitions,
-                                          definitions=self.specification.definitions,
-                                          parameter_definitions=self.specification.parameter_definitions,
-                                          response_definitions=self.specification.response_definitions,
-                                          **shared_args)
-        else:
-            operation = OpenAPIOperation(self,
-                                         components=self.specification.components,
-                                         **shared_args)
-
+        operation = make_operation(
+            self.specification,
+            self,
+            path,
+            method,
+            self.resolver,
+            validate_responses=self.validate_responses,
+            validator_map=self.validator_map,
+            strict_validation=self.strict_validation,
+            pythonic_params=self.pythonic_params,
+            uri_parser_class=self.options.uri_parser_class,
+            pass_context_arg_name=self.pass_context_arg_name
+        )
         self._add_operation_internal(method, path, operation)
 
     @abc.abstractmethod
@@ -449,15 +436,11 @@ class AbstractAPI(object):
         for path, methods in paths.items():
             logger.debug('Adding %s%s...', self.base_path, path)
 
-            # search for parameters definitions in the path level
-            # http://swagger.io/specification/#pathItemObject
-            path_parameters = methods.get('parameters', [])
-
-            for method, endpoint in methods.items():
+            for method in methods:
                 if method == 'parameters':
                     continue
                 try:
-                    self.add_operation(method, path, endpoint, path_parameters)
+                    self.add_operation(path, method)
                 except ResolverError as err:
                     # If we have an error handler for resolver errors, add it as an operation.
                     # Otherwise treat it as any other error.

--- a/connexion/operations/__init__.py
+++ b/connexion/operations/__init__.py
@@ -2,3 +2,7 @@ from .abstract import AbstractOperation  # noqa
 from .openapi import OpenAPIOperation  # noqa
 from .swagger2 import Swagger2Operation  # noqa
 from .secure import SecureOperation  # noqa
+
+
+def make_operation(spec, *args, **kwargs):
+    return spec.operation_cls.from_spec(spec, *args, **kwargs)

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -99,6 +99,8 @@ class AbstractOperation(SecureOperation):
         self._resolution = resolver.resolve(self)
         self._operation_id = self._resolution.operation_id
 
+        self._responses = self._operation.get("responses", {})
+
         self._validator_map = dict(VALIDATOR_MAP)
         self._validator_map.update(validator_map or {})
 
@@ -115,6 +117,13 @@ class AbstractOperation(SecureOperation):
         The path of the operation, relative to the API base path
         """
         return self._path
+
+    @property
+    def responses(self):
+        """
+        Returns the responses for this operation
+        """
+        return self._responses
 
     @property
     def validator_map(self):
@@ -224,12 +233,6 @@ class AbstractOperation(SecureOperation):
     def parameters(self):
         """
         Returns the parameters for this operation
-        """
-
-    @abc.abstractproperty
-    def responses(self):
-        """
-        Returns the responses for this operation
         """
 
     @abc.abstractproperty

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -101,7 +101,7 @@ class OpenAPIOperation(AbstractOperation):
             }
         }
 
-        self._request_body = operation.get('requestBody')
+        self._request_body = operation.get('requestBody', {})
 
         self._parameters = operation.get('parameters', [])
         if path_parameters:
@@ -112,13 +112,12 @@ class OpenAPIOperation(AbstractOperation):
         # TODO figure out how to support multiple mimetypes
         # NOTE we currently just combine all of the possible mimetypes,
         #      but we need to refactor to support mimetypes by response code
-        response_codes = operation.get('responses', {})
         response_content_types = []
-        for _, defn in response_codes.items():
+        for _, defn in self._responses.items():
             response_content_types += defn.get('content', {}).keys()
         self._produces = response_content_types or ['application/json']
 
-        request_content = operation.get('requestBody', {}).get('content', {})
+        request_content = self._request_body.get('content', {})
         self._consumes = list(request_content.keys()) or ['application/json']
 
         logger.debug('consumes: %s' % self.consumes)
@@ -148,20 +147,12 @@ class OpenAPIOperation(AbstractOperation):
         return self._parameters
 
     @property
-    def responses(self):
-        return self._responses
-
-    @property
     def consumes(self):
         return self._consumes
 
     @property
     def produces(self):
         return self._produces
-
-    @property
-    def _spec_definitions(self):
-        return self._definitions_map
 
     def with_definitions(self, schema):
         if self.components:

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -124,6 +124,21 @@ class OpenAPIOperation(AbstractOperation):
         logger.debug('consumes: %s' % self.consumes)
         logger.debug('produces: %s' % self.produces)
 
+    @classmethod
+    def from_spec(cls, spec, api, path, method, resolver, *args, **kwargs):
+        return cls(
+            api,
+            method,
+            path,
+            spec.get_operation(path, method),
+            resolver,
+            spec.get_path_params(path),
+            spec.security,
+            spec.components,
+            *args,
+            **kwargs
+        )
+
     @property
     def request_body(self):
         return self._request_body

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -131,10 +131,10 @@ class OpenAPIOperation(AbstractOperation):
             method,
             path,
             spec.get_operation(path, method),
-            resolver,
-            spec.get_path_params(path),
-            spec.security,
-            spec.components,
+            resolver=resolver,
+            path_parameters=spec.get_path_params(path),
+            app_security=spec.security,
+            components=spec.components,
             *args,
             **kwargs
         )

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -124,7 +124,7 @@ class Swagger2Operation(AbstractOperation):
             method,
             path,
             spec.get_operation(path, method),
-            resolver,
+            resolver=resolver,
             path_parameters=spec.get_path_params(path),
             app_security=spec.security,
             app_produces=spec.produces,

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -117,6 +117,26 @@ class Swagger2Operation(AbstractOperation):
         logger.debug('consumes: %s', self.consumes)
         logger.debug('produces: %s', self.produces)
 
+    @classmethod
+    def from_spec(cls, spec, api, path, method, resolver, *args, **kwargs):
+        return cls(
+            api,
+            method,
+            path,
+            spec.get_operation(path, method),
+            resolver,
+            path_parameters=spec.get_path_params(path),
+            app_security=spec.security,
+            app_produces=spec.produces,
+            app_consumes=spec.consumes,
+            security_definitions=spec.security_definitions,
+            definitions=spec.definitions,
+            parameter_definitions=spec.parameter_definitions,
+            response_definitions=spec.response_definitions,
+            *args,
+            **kwargs
+        )
+
     @property
     def parameters(self):
         return self._parameters

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -142,10 +142,6 @@ class Swagger2Operation(AbstractOperation):
         return self._parameters
 
     @property
-    def responses(self):
-        return self._responses
-
-    @property
     def consumes(self):
         return self._consumes
 

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -1,0 +1,255 @@
+import abc
+import copy
+import pathlib
+
+import jinja2
+import six
+import yaml
+from openapi_spec_validator.exceptions import OpenAPIValidationError
+from six.moves.urllib.parse import urlsplit
+
+from .exceptions import InvalidSpecification
+from .json_schema import resolve_refs
+from .operations import OpenAPIOperation, Swagger2Operation
+from .utils import deep_get
+
+try:
+    import collections.abc as collections_abc  # python 3.3+
+except ImportError:
+    import collections as collections_abc
+
+
+NO_SPEC_VERSION_ERR_MSG = """Unable to get the spec version.
+You are missing either '"swagger": "2.0"' or '"openapi": "3.0.0"'
+from the top level of your spec."""
+
+
+def canonical_base_path(base_path):
+    """
+    Make given "basePath" a canonical base URL which can be prepended to paths starting with "/".
+    """
+    return base_path.rstrip('/')
+
+
+class Specification(collections_abc.Mapping):
+
+    def __init__(self, raw_spec):
+        self._raw_spec = copy.deepcopy(raw_spec)
+        self._set_defaults(raw_spec)
+        self._validate_spec(raw_spec)
+        self._spec = resolve_refs(raw_spec)
+
+    @classmethod
+    @abc.abstractmethod
+    def _set_defaults(cls, spec):
+        """ set some default values in the spec
+        """
+
+    @classmethod
+    @abc.abstractmethod
+    def _validate_spec(cls, spec):
+        """ validate spec against schema
+        """
+
+    def get_path_params(self, path):
+        return deep_get(self._spec, ["paths", path]).get("parameters", [])
+
+    def get_operation(self, path, method):
+        return deep_get(self._spec, ["paths", path, method])
+
+    @property
+    def raw(self):
+        return self._raw_spec
+
+    @property
+    def version(self):
+        return self._get_spec_version(self._spec)
+
+    @property
+    def security(self):
+        return self._spec.get('security')
+
+    def __getitem__(self, k):
+        return self._spec[k]
+
+    def __iter__(self):
+        return self._spec.__iter__()
+
+    def __len__(self):
+        return self._spec.__len__()
+
+    @staticmethod
+    def _load_spec_from_file(arguments, specification):
+        """
+        Loads a YAML specification file, optionally rendering it with Jinja2.
+        Takes:
+          arguments - passed to Jinja2 renderer
+          specification - path to specification
+        """
+        arguments = arguments or {}
+
+        with specification.open(mode='rb') as openapi_yaml:
+            contents = openapi_yaml.read()
+            try:
+                openapi_template = contents.decode()
+            except UnicodeDecodeError:
+                openapi_template = contents.decode('utf-8', 'replace')
+
+            openapi_string = jinja2.Template(openapi_template).render(**arguments)
+            return yaml.safe_load(openapi_string)
+
+    @classmethod
+    def from_file(cls, spec, arguments=None):
+        """
+        Takes in a path to a YAML file, and returns a Specification
+        """
+        specification_path = pathlib.Path(spec)
+        spec = cls._load_spec_from_file(arguments, specification_path)
+        return cls.from_dict(spec)
+
+    @staticmethod
+    def _get_spec_version(spec):
+        try:
+            version_string = spec.get('openapi') or spec.get('swagger')
+        except AttributeError:
+            raise InvalidSpecification(NO_SPEC_VERSION_ERR_MSG)
+        if version_string is None:
+            raise InvalidSpecification(NO_SPEC_VERSION_ERR_MSG)
+        try:
+            version_tuple = tuple(map(int, version_string.split(".")))
+        except TypeError:
+            err = ('Unable to convert version string to semantic version tuple: '
+                   '{version_string}.')
+            err = err.format(version_string=version_string)
+            raise InvalidSpecification(err)
+        return version_tuple
+
+    @classmethod
+    def from_dict(cls, spec):
+        """
+        Takes in a dictionary, and returns a Specification
+        """
+        def enforce_string_keys(obj):
+            # YAML supports integer keys, but JSON does not
+            if isinstance(obj, dict):
+                return {
+                    str(k): enforce_string_keys(v)
+                    for k, v
+                    in six.iteritems(obj)
+                }
+            return obj
+
+        spec = enforce_string_keys(spec)
+        version = cls._get_spec_version(spec)
+        if version < (3, 0, 0):
+            return Swagger2Specification(spec)
+        return OpenAPISpecification(spec)
+
+    @classmethod
+    def load(cls, spec, arguments=None):
+        if not isinstance(spec, dict):
+            return cls.from_file(spec, arguments=arguments)
+        return cls.from_dict(spec)
+
+
+class Swagger2Specification(Specification):
+    yaml_name = 'swagger.yaml'
+    operation_cls = Swagger2Operation
+
+    @classmethod
+    def _set_defaults(cls, spec):
+        spec.setdefault('produces', [])
+        spec.setdefault('consumes', ['application/json'])  # type: List[str]
+        spec.setdefault('definitions', {})
+        spec.setdefault('parameters', {})
+        spec.setdefault('responses', {})
+
+    @property
+    def produces(self):
+        return self._spec['produces']
+
+    @property
+    def consumes(self):
+        return self._spec['consumes']
+
+    @property
+    def definitions(self):
+        return self._spec['definitions']
+
+    @property
+    def parameter_definitions(self):
+        return self._spec['parameters']
+
+    @property
+    def response_definitions(self):
+        return self._spec['responses']
+
+    @property
+    def security_definitions(self):
+        return self._spec.get('securityDefinitions', {})
+
+    @property
+    def base_path(self):
+        return canonical_base_path(self._spec.get('basePath', ''))
+
+    @base_path.setter
+    def base_path(self, base_path):
+        base_path = canonical_base_path(base_path)
+        self._raw_spec['basePath'] = base_path
+        self._spec['basePath'] = base_path
+
+    @classmethod
+    def _validate_spec(cls, spec):
+        from openapi_spec_validator import validate_v2_spec as validate_spec
+        try:
+            validate_spec(spec)
+        except OpenAPIValidationError as e:
+            raise InvalidSpecification.create_from(e)
+
+
+class OpenAPISpecification(Specification):
+    yaml_name = 'openapi.yaml'
+    operation_cls = OpenAPIOperation
+
+    @classmethod
+    def _set_defaults(cls, spec):
+        spec.setdefault('components', {})
+
+    @property
+    def security_definitions(self):
+        return self._spec['components'].get('securitySchemes', {})
+
+    @property
+    def components(self):
+        return self._spec['components']
+
+    @classmethod
+    def _validate_spec(cls, spec):
+        from openapi_spec_validator import validate_v3_spec as validate_spec
+        try:
+            validate_spec(spec)
+        except OpenAPIValidationError as e:
+            raise InvalidSpecification.create_from(e)
+
+    @property
+    def base_path(self):
+        servers = self._spec.get('servers', [])
+        try:
+            # assume we're the first server in list
+            server = copy.deepcopy(servers[0])
+            server_vars = server.pop("variables", {})
+            server['url'] = server['url'].format(
+                **{k: v['default'] for k, v
+                   in six.iteritems(server_vars)}
+            )
+            base_path = urlsplit(server['url']).path
+        except IndexError:
+            base_path = ''
+        return canonical_base_path(base_path)
+
+    @base_path.setter
+    def base_path(self, base_path):
+        base_path = canonical_base_path(base_path)
+        user_servers = [{'url': base_path}]
+        self._raw_spec['servers'] = user_servers
+        self._spec['servers'] = user_servers

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,8 +7,8 @@ from yaml import YAMLError
 
 import pytest
 from connexion import FlaskApi
-from connexion.apis.abstract import canonical_base_path
 from connexion.exceptions import InvalidSpecification, ResolverError
+from connexion.spec import canonical_base_path
 from mock import MagicMock
 
 TEST_FOLDER = pathlib.Path(__file__).parent


### PR DESCRIPTION
Follow up to #713 

Changes proposed in this pull request:
 - Introduce make_operation that creates the correct Operation class from a Specification
 - Move Specification classes to separate file (spec.py)
