### PR TITLE
remove type hint for options in App.run(...)

### DIFF
--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -233,7 +233,6 @@ class AbstractApp(object):
         :param debug: include debugging information
         :type debug: bool
         :param options: options to be forwarded to the underlying server
-        :type options: dict
         """
 
     def __call__(self, environ, start_response):  # pragma: no cover

--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -71,7 +71,6 @@ class FlaskApp(AbstractApp):
         :param debug: include debugging information
         :type debug: bool
         :param options: options to be forwarded to the underlying server
-        :type options: dict
         """
         # this functions is not covered in unit tests because we would effectively testing the mocks
 


### PR DESCRIPTION
Fixes #645 

@paulkernstock can you verify that this fixes your problem?
