### PR TITLE
[DRAFT] Directly use spec in operation classes

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -1,33 +1,20 @@
 import abc
-import copy
 import logging
 import pathlib
 import sys
-from typing import AnyStr, List  # NOQA
+from typing import AnyStr  # NOQA
 
-import jinja2
 import six
-import yaml
-from openapi_spec_validator.exceptions import OpenAPIValidationError
-from six.moves.urllib.parse import urlsplit
 
-from ..exceptions import InvalidSpecification, ResolverError
-from ..json_schema import resolve_refs
-from ..operations import OpenAPIOperation, Swagger2Operation, make_operation
+from ..exceptions import ResolverError
+from ..operations import make_operation
 from ..options import ConnexionOptions
 from ..resolver import Resolver
-from ..utils import Jsonifier, deep_get
-
-try:
-    import collections.abc as collections_abc  # python 3.3+
-except ImportError:
-    import collections as collections_abc
+from ..spec import Specification
+from ..utils import Jsonifier
 
 MODULE_PATH = pathlib.Path(__file__).absolute().parent.parent
 SWAGGER_UI_URL = 'ui'
-NO_SPEC_VERSION_ERR_MSG = """Unable to get the spec version.
-You are missing either '"swagger": "2.0"' or '"openapi": "3.0.0"'
-from the top level of your spec."""
 
 logger = logging.getLogger('connexion.apis.abstract')
 
@@ -37,202 +24,6 @@ class AbstractAPIMeta(abc.ABCMeta):
     def __init__(cls, name, bases, attrs):
         abc.ABCMeta.__init__(cls, name, bases, attrs)
         cls._set_jsonifier()
-
-
-class Specification(collections_abc.Mapping):
-
-    def __init__(self, raw_spec):
-        self._raw_spec = copy.deepcopy(raw_spec)
-        self._spec = resolve_refs(raw_spec)
-        self._set_defaults()
-        self._validate_spec()
-
-    @abc.abstractmethod
-    def _set_defaults(self):
-        """ set some default values in the spec
-        """
-
-    @abc.abstractmethod
-    def _validate_spec(self):
-        """ validate spec against schema
-        """
-
-    def get_path_params(self, path):
-        return deep_get(self._spec, ["paths", path]).get("parameters", [])
-
-    def get_operation(self, path, method):
-        return deep_get(self._spec, ["paths", path, method])
-
-    @property
-    def raw(self):
-        return self._raw_spec
-
-    @property
-    def version(self):
-        return self._get_spec_version(self._spec)
-
-    @property
-    def security(self):
-        return self._spec.get('security')
-
-    def __getitem__(self, k):
-        return self._spec[k]
-
-    def __iter__(self):
-        return self._spec.__iter__()
-
-    def __len__(self):
-        return self._spec.__len__()
-
-    @staticmethod
-    def _load_spec_from_file(arguments, specification):
-        from openapi_spec_validator.loaders import ExtendedSafeLoader
-        arguments = arguments or {}
-
-        with specification.open(mode='rb') as openapi_yaml:
-            contents = openapi_yaml.read()
-            try:
-                openapi_template = contents.decode()
-            except UnicodeDecodeError:
-                openapi_template = contents.decode('utf-8', 'replace')
-
-            openapi_string = jinja2.Template(openapi_template).render(**arguments)
-            return yaml.load(openapi_string, ExtendedSafeLoader)
-
-    @classmethod
-    def from_file(cls, spec, arguments=None):
-        specification_path = pathlib.Path(spec)
-        spec = cls._load_spec_from_file(arguments, specification_path)
-        return cls.from_dict(spec)
-
-    @staticmethod
-    def _get_spec_version(spec):
-        try:
-            version_string = spec.get('openapi') or spec.get('swagger')
-        except AttributeError:
-            raise InvalidSpecification(NO_SPEC_VERSION_ERR_MSG)
-        if version_string is None:
-            raise InvalidSpecification(NO_SPEC_VERSION_ERR_MSG)
-        try:
-            version_tuple = tuple(map(int, version_string.split(".")))
-        except TypeError:
-            err = ('Unable to convert version string to semantic version tuple: '
-                   '{version_string}.')
-            err = err.format(version_string=version_string)
-            raise InvalidSpecification(err)
-        return version_tuple
-
-    @classmethod
-    def from_dict(cls, spec):
-        version = cls._get_spec_version(spec)
-        if version < (3, 0, 0):
-            return Swagger2Specification(spec)
-        return OpenAPISpecification(spec)
-
-    @classmethod
-    def load(cls, spec, arguments=None):
-        if not isinstance(spec, dict):
-            return cls.from_file(spec, arguments=arguments)
-        return cls.from_dict(spec)
-
-
-class Swagger2Specification(Specification):
-    yaml_name = 'swagger.yaml'
-    operation_cls = Swagger2Operation
-
-    def _set_defaults(self):
-        self._spec.setdefault('produces', [])
-        self._spec.setdefault('consumes', ['application/json'])  # type: List[str]
-        self._spec.setdefault('definitions', {})
-        self._spec.setdefault('parameters', {})
-        self._spec.setdefault('responses', {})
-
-    @property
-    def produces(self):
-        return self._spec['produces']
-
-    @property
-    def consumes(self):
-        return self._spec['consumes']
-
-    @property
-    def definitions(self):
-        return self._spec['definitions']
-
-    @property
-    def parameter_definitions(self):
-        return self._spec['parameters']
-
-    @property
-    def response_definitions(self):
-        return self._spec['responses']
-
-    @property
-    def security_definitions(self):
-        return self._spec.get('securityDefinitions', {})
-
-    @property
-    def base_path(self):
-        return canonical_base_path(self._spec.get('basePath', ''))
-
-    @base_path.setter
-    def base_path(self, base_path):
-        base_path = canonical_base_path(base_path)
-        self._raw_spec['basePath'] = base_path
-        self._spec['basePath'] = base_path
-
-    def _validate_spec(self):
-        from openapi_spec_validator import validate_v2_spec as validate_spec
-        try:
-            validate_spec(self._raw_spec)
-        except OpenAPIValidationError as e:
-            raise InvalidSpecification.create_from(e)
-
-
-class OpenAPISpecification(Specification):
-    yaml_name = 'openapi.yaml'
-    operation_cls = OpenAPIOperation
-
-    def _set_defaults(self):
-        self._spec.setdefault('components', {})
-
-    @property
-    def security_definitions(self):
-        return self._spec['components'].get('securitySchemes', {})
-
-    @property
-    def components(self):
-        return self._spec['components']
-
-    def _validate_spec(self):
-        from openapi_spec_validator import validate_v3_spec as validate_spec
-        try:
-            validate_spec(self._raw_spec)
-        except OpenAPIValidationError as e:
-            raise InvalidSpecification.create_from(e)
-
-    @property
-    def base_path(self):
-        servers = self._spec.get('servers', [])
-        try:
-            # assume we're the first server in list
-            server = copy.deepcopy(servers[0])
-            server_vars = server.pop("variables", {})
-            server['url'] = server['url'].format(
-                **{k: v['default'] for k, v
-                   in six.iteritems(server_vars)}
-            )
-            base_path = urlsplit(server['url']).path
-        except IndexError:
-            base_path = ''
-        return canonical_base_path(base_path)
-
-    @base_path.setter
-    def base_path(self, base_path):
-        base_path = canonical_base_path(base_path)
-        user_servers = [{'url': base_path}]
-        self._raw_spec['servers'] = user_servers
-        self._spec['servers'] = user_servers
 
 
 @six.add_metaclass(AbstractAPIMeta)
@@ -470,10 +261,3 @@ class AbstractAPI(object):
     def _set_jsonifier(cls):
         import json
         cls.jsonifier = Jsonifier(json)
-
-
-def canonical_base_path(base_path):
-    """
-    Make given "basePath" a canonical base URL which can be prepended to paths starting with "/".
-    """
-    return base_path.rstrip('/')

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -7,7 +7,6 @@ from typing import AnyStr  # NOQA
 import six
 
 from ..exceptions import ResolverError
-from ..operations import make_operation
 from ..options import ConnexionOptions
 from ..resolver import Resolver
 from ..spec import Specification
@@ -156,12 +155,12 @@ class AbstractAPI(object):
         :type method: str
         :type path: str
         """
-        operation = make_operation(
-            self.specification,
+        operation = self.specification.operation_cls(
             self,
-            path,
             method,
-            self.resolver,
+            path,
+            resolver=self.resolver,
+            spec=self.specification,
             validate_responses=self.validate_responses,
             validator_map=self.validator_map,
             strict_validation=self.strict_validation,

--- a/connexion/operations/__init__.py
+++ b/connexion/operations/__init__.py
@@ -2,7 +2,3 @@ from .abstract import AbstractOperation  # noqa
 from .openapi import OpenAPIOperation  # noqa
 from .swagger2 import Swagger2Operation  # noqa
 from .secure import SecureOperation  # noqa
-
-
-def make_operation(spec, *args, **kwargs):
-    return spec.operation_cls.from_spec(spec, *args, **kwargs)

--- a/connexion/operations/__init__.py
+++ b/connexion/operations/__init__.py
@@ -2,3 +2,7 @@ from .abstract import AbstractOperation  # noqa
 from .openapi import OpenAPIOperation  # noqa
 from .swagger2 import Swagger2Operation  # noqa
 from .secure import SecureOperation  # noqa
+
+
+def make_operation(spec, *args, **kwargs):
+    return spec.operation_cls.from_spec(spec, *args, **kwargs)

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -62,11 +62,8 @@ class OpenAPIOperation(AbstractOperation):
         """
         self.components = components or {}
 
-        def component_get(oas3_name):
-            return self.components.get(oas3_name, {})
-
         # operation overrides globals
-        security_schemes = component_get('securitySchemes')
+        security_schemes = self.components.get('securitySchemes', {})
         app_security = operation.get('security', app_security)
         uri_parser_class = uri_parser_class or OpenAPIURIParser
 
@@ -89,19 +86,7 @@ class OpenAPIOperation(AbstractOperation):
             pass_context_arg_name=pass_context_arg_name
         )
 
-        self._definitions_map = {
-            'components': {
-                'schemas': component_get('schemas'),
-                'examples': component_get('examples'),
-                'requestBodies': component_get('requestBodies'),
-                'parameters': component_get('parameters'),
-                'securitySchemes': component_get('securitySchemes'),
-                'responses': component_get('responses'),
-                'headers': component_get('headers'),
-            }
-        }
-
-        self._request_body = operation.get('requestBody')
+        self._request_body = operation.get('requestBody', {})
 
         self._parameters = operation.get('parameters', [])
         if path_parameters:
@@ -112,13 +97,12 @@ class OpenAPIOperation(AbstractOperation):
         # TODO figure out how to support multiple mimetypes
         # NOTE we currently just combine all of the possible mimetypes,
         #      but we need to refactor to support mimetypes by response code
-        response_codes = operation.get('responses', {})
         response_content_types = []
-        for _, defn in response_codes.items():
+        for _, defn in self._responses.items():
             response_content_types += defn.get('content', {}).keys()
         self._produces = response_content_types or ['application/json']
 
-        request_content = operation.get('requestBody', {}).get('content', {})
+        request_content = self._request_body.get('content', {})
         self._consumes = list(request_content.keys()) or ['application/json']
 
         logger.debug('consumes: %s' % self.consumes)
@@ -158,10 +142,6 @@ class OpenAPIOperation(AbstractOperation):
     @property
     def produces(self):
         return self._produces
-
-    @property
-    def _spec_definitions(self):
-        return self._definitions_map
 
     def with_definitions(self, schema):
         if self.components:

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -124,6 +124,21 @@ class OpenAPIOperation(AbstractOperation):
         logger.debug('consumes: %s' % self.consumes)
         logger.debug('produces: %s' % self.produces)
 
+    @classmethod
+    def from_spec(cls, spec, api, path, method, resolver, *args, **kwargs):
+        return cls(
+            api,
+            method,
+            path,
+            spec.get_operation(path, method),
+            resolver,
+            spec.get_path_params(path),
+            spec.security,
+            spec.components,
+            *args,
+            **kwargs
+        )
+
     @property
     def request_body(self):
         return self._request_body

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -131,10 +131,10 @@ class OpenAPIOperation(AbstractOperation):
             method,
             path,
             spec.get_operation(path, method),
-            resolver,
-            spec.get_path_params(path),
-            spec.security,
-            spec.components,
+            resolver=resolver,
+            path_parameters=spec.get_path_params(path),
+            app_security=spec.security,
+            components=spec.components,
             *args,
             **kwargs
         )

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -101,12 +101,6 @@ class Swagger2Operation(AbstractOperation):
 
         self.definitions = definitions or {}
 
-        self.definitions_map = {
-            'definitions': self.definitions,
-            'parameters': parameter_definitions,
-            'responses': response_definitions
-        }
-
         self._parameters = operation.get('parameters', [])
         if path_parameters:
             self._parameters += path_parameters

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -124,7 +124,7 @@ class Swagger2Operation(AbstractOperation):
             method,
             path,
             spec.get_operation(path, method),
-            resolver,
+            resolver=resolver,
             path_parameters=spec.get_path_params(path),
             app_security=spec.security,
             app_produces=spec.produces,

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -117,6 +117,26 @@ class Swagger2Operation(AbstractOperation):
         logger.debug('consumes: %s', self.consumes)
         logger.debug('produces: %s', self.produces)
 
+    @classmethod
+    def from_spec(cls, spec, api, path, method, resolver, *args, **kwargs):
+        return cls(
+            api,
+            method,
+            path,
+            spec.get_operation(path, method),
+            resolver,
+            path_parameters=spec.get_path_params(path),
+            app_security=spec.security,
+            app_produces=spec.produces,
+            app_consumes=spec.consumes,
+            security_definitions=spec.security_definitions,
+            definitions=spec.definitions,
+            parameter_definitions=spec.parameter_definitions,
+            response_definitions=spec.response_definitions,
+            *args,
+            **kwargs
+        )
+
     @property
     def parameters(self):
         return self._parameters

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -1,0 +1,227 @@
+import abc
+import copy
+import pathlib
+
+import jinja2
+import six
+import yaml
+from openapi_spec_validator.exceptions import OpenAPIValidationError
+from six.moves.urllib.parse import urlsplit
+
+from .exceptions import InvalidSpecification
+from .json_schema import resolve_refs
+from .operations import OpenAPIOperation, Swagger2Operation
+from .utils import deep_get
+
+try:
+    import collections.abc as collections_abc  # python 3.3+
+except ImportError:
+    import collections as collections_abc
+
+
+NO_SPEC_VERSION_ERR_MSG = """Unable to get the spec version.
+You are missing either '"swagger": "2.0"' or '"openapi": "3.0.0"'
+from the top level of your spec."""
+
+
+def canonical_base_path(base_path):
+    """
+    Make given "basePath" a canonical base URL which can be prepended to paths starting with "/".
+    """
+    return base_path.rstrip('/')
+
+
+class Specification(collections_abc.Mapping):
+
+    def __init__(self, raw_spec):
+        self._raw_spec = copy.deepcopy(raw_spec)
+        self._spec = resolve_refs(raw_spec)
+        self._set_defaults()
+        self._validate_spec()
+
+    @abc.abstractmethod
+    def _set_defaults(self):
+        """ set some default values in the spec
+        """
+
+    @abc.abstractmethod
+    def _validate_spec(self):
+        """ validate spec against schema
+        """
+
+    def get_path_params(self, path):
+        return deep_get(self._spec, ["paths", path]).get("parameters", [])
+
+    def get_operation(self, path, method):
+        return deep_get(self._spec, ["paths", path, method])
+
+    @property
+    def raw(self):
+        return self._raw_spec
+
+    @property
+    def version(self):
+        return self._get_spec_version(self._spec)
+
+    @property
+    def security(self):
+        return self._spec.get('security')
+
+    def __getitem__(self, k):
+        return self._spec[k]
+
+    def __iter__(self):
+        return self._spec.__iter__()
+
+    def __len__(self):
+        return self._spec.__len__()
+
+    @staticmethod
+    def _load_spec_from_file(arguments, specification):
+        from openapi_spec_validator.loaders import ExtendedSafeLoader
+        arguments = arguments or {}
+
+        with specification.open(mode='rb') as openapi_yaml:
+            contents = openapi_yaml.read()
+            try:
+                openapi_template = contents.decode()
+            except UnicodeDecodeError:
+                openapi_template = contents.decode('utf-8', 'replace')
+
+            openapi_string = jinja2.Template(openapi_template).render(**arguments)
+            return yaml.load(openapi_string, ExtendedSafeLoader)
+
+    @classmethod
+    def from_file(cls, spec, arguments=None):
+        specification_path = pathlib.Path(spec)
+        spec = cls._load_spec_from_file(arguments, specification_path)
+        return cls.from_dict(spec)
+
+    @staticmethod
+    def _get_spec_version(spec):
+        try:
+            version_string = spec.get('openapi') or spec.get('swagger')
+        except AttributeError:
+            raise InvalidSpecification(NO_SPEC_VERSION_ERR_MSG)
+        if version_string is None:
+            raise InvalidSpecification(NO_SPEC_VERSION_ERR_MSG)
+        try:
+            version_tuple = tuple(map(int, version_string.split(".")))
+        except TypeError:
+            err = ('Unable to convert version string to semantic version tuple: '
+                   '{version_string}.')
+            err = err.format(version_string=version_string)
+            raise InvalidSpecification(err)
+        return version_tuple
+
+    @classmethod
+    def from_dict(cls, spec):
+        version = cls._get_spec_version(spec)
+        if version < (3, 0, 0):
+            return Swagger2Specification(spec)
+        return OpenAPISpecification(spec)
+
+    @classmethod
+    def load(cls, spec, arguments=None):
+        if not isinstance(spec, dict):
+            return cls.from_file(spec, arguments=arguments)
+        return cls.from_dict(spec)
+
+
+class Swagger2Specification(Specification):
+    yaml_name = 'swagger.yaml'
+    operation_cls = Swagger2Operation
+
+    def _set_defaults(self):
+        self._spec.setdefault('produces', [])
+        self._spec.setdefault('consumes', ['application/json'])  # type: List[str]
+        self._spec.setdefault('definitions', {})
+        self._spec.setdefault('parameters', {})
+        self._spec.setdefault('responses', {})
+
+    @property
+    def produces(self):
+        return self._spec['produces']
+
+    @property
+    def consumes(self):
+        return self._spec['consumes']
+
+    @property
+    def definitions(self):
+        return self._spec['definitions']
+
+    @property
+    def parameter_definitions(self):
+        return self._spec['parameters']
+
+    @property
+    def response_definitions(self):
+        return self._spec['responses']
+
+    @property
+    def security_definitions(self):
+        return self._spec.get('securityDefinitions', {})
+
+    @property
+    def base_path(self):
+        return canonical_base_path(self._spec.get('basePath', ''))
+
+    @base_path.setter
+    def base_path(self, base_path):
+        base_path = canonical_base_path(base_path)
+        self._raw_spec['basePath'] = base_path
+        self._spec['basePath'] = base_path
+
+    def _validate_spec(self):
+        from openapi_spec_validator import validate_v2_spec as validate_spec
+        try:
+            validate_spec(self._raw_spec)
+        except OpenAPIValidationError as e:
+            raise InvalidSpecification.create_from(e)
+
+
+class OpenAPISpecification(Specification):
+    yaml_name = 'openapi.yaml'
+    operation_cls = OpenAPIOperation
+
+    def _set_defaults(self):
+        self._spec.setdefault('components', {})
+
+    @property
+    def security_definitions(self):
+        return self._spec['components'].get('securitySchemes', {})
+
+    @property
+    def components(self):
+        return self._spec['components']
+
+    def _validate_spec(self):
+        from openapi_spec_validator import validate_v3_spec as validate_spec
+        try:
+            validate_spec(self._raw_spec)
+        except OpenAPIValidationError as e:
+            raise InvalidSpecification.create_from(e)
+
+    @property
+    def base_path(self):
+        servers = self._spec.get('servers', [])
+        try:
+            # assume we're the first server in list
+            server = copy.deepcopy(servers[0])
+            server_vars = server.pop("variables", {})
+            server['url'] = server['url'].format(
+                **{k: v['default'] for k, v
+                   in six.iteritems(server_vars)}
+            )
+            base_path = urlsplit(server['url']).path
+        except IndexError:
+            base_path = ''
+        return canonical_base_path(base_path)
+
+    @base_path.setter
+    def base_path(self, base_path):
+        base_path = canonical_base_path(base_path)
+        user_servers = [{'url': base_path}]
+        self._raw_spec['servers'] = user_servers
+        self._spec['servers'] = user_servers

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,8 +7,8 @@ from yaml import YAMLError
 
 import pytest
 from connexion import FlaskApi
-from connexion.apis.abstract import canonical_base_path
 from connexion.exceptions import InvalidSpecification, ResolverError
+from connexion.spec import canonical_base_path
 from mock import MagicMock
 
 TEST_FOLDER = pathlib.Path(__file__).parent


### PR DESCRIPTION
Follow up on #726.

Changes proposed in this pull request:
- Code cleanup
- Directly use spec in operation classes
  - It saves a lot of parameter passing
  - Move some common code to base class
  - Future: Allow preprocessing of security definitions per spec and not per operation

Tests are not yet updated.
@dtkav what do you think?

