### PR TITLE
swagger-ui README section passes options instead of kwargs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -429,7 +429,7 @@ You can disable the Swagger UI at the application level:
 .. code-block:: python
 
     app = connexion.App(__name__, specification_dir='swagger/',
-                        swagger_ui=False)
+                        options={"swagger_ui": False})
     app.add_api('my_api.yaml')
 
 
@@ -438,7 +438,7 @@ You can also disable it at the API level:
 .. code-block:: python
 
     app = connexion.App(__name__, specification_dir='swagger/')
-    app.add_api('my_api.yaml', swagger_ui=False)
+    app.add_api('my_api.yaml', options={"swagger_ui": False})
 
 If necessary, you can explicitly specify the path to the directory with
 swagger-ui to not use the connexion[swagger-ui] distro.


### PR DESCRIPTION
Fixes #742 

Changes proposed in this pull request:
 - update docs to pass swagger_ui in options instead of kwargs
