### PR TITLE
pass files to handler if filename in arguments _or_ has_kwargs

### DIFF
--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -168,7 +168,7 @@ class AbstractOperation(SecureOperation):
 
     @staticmethod
     def _get_file_arguments(files, arguments, has_kwargs=False):
-        return {k: v for k, v in files.items() if not has_kwargs and k in arguments}
+        return {k: v for k, v in files.items() if k in arguments or has_kwargs}
 
     @abc.abstractmethod
     def _get_val_from_param(self, value, query_defn):

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -288,7 +288,7 @@ def test_formdata_missing_param():
     return ''
 
 
-def test_formdata_file_upload(formData):
+def test_formdata_file_upload(formData, **kwargs):
     filename = formData.filename
     contents = formData.read().decode('utf-8', 'replace')
     return {filename: contents}


### PR DESCRIPTION
Fixes #750 

Changes proposed in this pull request:
 - pass file if filename in arguments _or_ has_kwargs
