### PR TITLE
Handle connexion.problem being directly returned in error handlers

### DIFF
--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -57,7 +57,9 @@ class FlaskApp(AbstractApp):
 
     def add_error_handler(self, error_code, function):
         # type: (int, FunctionType) -> None
-        self.app.register_error_handler(error_code, function)
+        def wrapper(error):
+            return FlaskApi.get_response(function(error))
+        self.app.register_error_handler(error_code, wrapper)
 
     def run(self, port=None, server=None, debug=None, host=None, **options):  # pragma: no cover
         """

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -410,6 +410,10 @@ def throw_problem_exception():
     )
 
 
+def throw_value_error():
+    raise ValueError('Something really wrong.')
+
+
 def unordered_params_response(first, path_param, second):
     return dict(first=int(first), path_param=str(path_param), second=int(second))
 

--- a/tests/fixtures/problem/openapi.yaml
+++ b/tests/fixtures/problem/openapi.yaml
@@ -79,6 +79,13 @@ paths:
       responses:
         '200':
           description: Problem exception
+  /value_error:
+    get:
+      description: Simply raise a ValueError
+      operationId: fakeapi.hello.throw_value_error
+      responses:
+        '200':
+          description: ValueError
 servers:
   - url: /v1.0
 components:

--- a/tests/fixtures/problem/swagger.yaml
+++ b/tests/fixtures/problem/swagger.yaml
@@ -101,3 +101,13 @@ paths:
       responses:
         200:
           description: Problem exception
+
+  /value_error:
+    get:
+      description: Simply raise a ValueError
+      operationId: fakeapi.hello.throw_value_error
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ValueError


### PR DESCRIPTION
I was able to reproduce #511 in the `dev-2.0` branch. This PR adds a regression test case for it and also propose a fix, by decorating the handlers before registering them with Flask, taking the opportunity to hand them to `FlaskApi.get_response` so the conversion magic can happen.

As this is my first contribution to this project it is possible that the fix and the test case would be better placed elsewhere in the code, so just let me know if that is the case.