### PR TITLE
Fix handling additionalProperties in body

### DIFF
--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -235,11 +235,12 @@ def test_body_not_allowed_additional_properties(simple_app):
     body = { 'body1': 'bodyString', 'additional_property': 'test1'}
     resp = app_client.post(
         '/v1.0/body-not-allowed-additional-properties',
-        json=body)
+        data=json.dumps(body),
+        headers={'Content-Type': 'application/json'})
     assert resp.status_code == 400
 
-    res = resp.get_json()
-    assert 'Additional properties are not allowed' in res['detail']
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
+    assert 'Additional properties are not allowed' in response['detail']
 
 def test_bool_as_default_param(simple_app):
     app_client = simple_app.app.test_client()
@@ -378,16 +379,18 @@ def test_param_sanitization(simple_app):
     body = { 'body1': 'bodyString', 'body2': 12, 'body3': {'a':'otherString' }}
     resp = app_client.post(
         '/v1.0/body-sanitization-additional-properties',
-        json=body)
+        data=json.dumps(body),
+        headers={'Content-Type': 'application/json'})
     assert resp.status_code == 200
-    assert resp.get_json() == body
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == body
 
-    body = { 'body1': 'bodyString', 'additional_property': 'test1', 'additional_property2': 'test2'}
+    body = {'body1': 'bodyString', 'additional_property': 'test1', 'additional_property2': 'test2'}
     resp = app_client.post(
         '/v1.0/body-sanitization-additional-properties-defined',
-        json=body)
+        data=json.dumps(body),
+        headers={'Content-Type': 'application/json'})
     assert resp.status_code == 200
-    assert resp.get_json() == body
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == body
 
 def test_parameters_snake_case(snake_case_app):
     app_client = snake_case_app.app.test_client()

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -230,6 +230,17 @@ def test_formdata_file_upload_missing_param(simple_app):
     assert resp.status_code == 200
 
 
+def test_body_not_allowed_additional_properties(simple_app):
+    app_client = simple_app.app.test_client()
+    body = { 'body1': 'bodyString', 'additional_property': 'test1'}
+    resp = app_client.post(
+        '/v1.0/body-not-allowed-additional-properties',
+        json=body)
+    assert resp.status_code == 400
+
+    res = resp.get_json()
+    assert 'Additional properties are not allowed' in res['detail']
+
 def test_bool_as_default_param(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-bool-param')
@@ -364,6 +375,19 @@ def test_param_sanitization(simple_app):
     assert resp.status_code == 200
     assert json.loads(resp.data.decode('utf-8', 'replace')) == body
 
+    body = { 'body1': 'bodyString', 'body2': 12, 'body3': {'a':'otherString' }}
+    resp = app_client.post(
+        '/v1.0/body-sanitization-additional-properties',
+        json=body)
+    assert resp.status_code == 200
+    assert resp.get_json() == body
+
+    body = { 'body1': 'bodyString', 'additional_property': 'test1', 'additional_property2': 'test2'}
+    resp = app_client.post(
+        '/v1.0/body-sanitization-additional-properties-defined',
+        json=body)
+    assert resp.status_code == 200
+    assert resp.get_json() == body
 
 def test_parameters_snake_case(snake_case_app):
     app_client = snake_case_app.app.test_client()

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -445,6 +445,14 @@ def test_param_sanitization3(query=None, body=None):
 def test_body_sanitization(body=None):
     return body
 
+def test_body_sanitization_additional_properties(body):
+    return body
+
+def test_body_sanitization_additional_properties_defined(body):
+    return body
+
+def test_body_not_allowed_additional_properties(body):
+    return body
 
 def post_wrong_content_type():
     return "NOT OK"

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -795,6 +795,52 @@ paths:
           description: OK
       requestBody:
         $ref: '#/components/requestBodies/fakeapi.hello.test_body_sanitization_body'
+  /body-sanitization-additional-properties:
+    post:
+      operationId: fakeapi.hello.test_body_sanitization_additional_properties
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                body1:
+                  type: string
+              additionalProperties: true
+  /body-sanitization-additional-properties-defined:
+    post:
+      operationId: fakeapi.hello.test_body_sanitization_additional_properties_defined
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                body1:
+                  type: string
+              additionalProperties:
+                type: string
+  /body-not-allowed-additional-properties:
+    post:
+      operationId: fakeapi.hello.test_body_not_allowed_additional_properties
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                body1:
+                  type: string
+              additionalProperties: false
   /get_non_conforming_response:
     get:
       operationId: fakeapi.hello.get_empty_dict

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -781,6 +781,73 @@ paths:
         200:
           description: OK
 
+  /body-sanitization-additional-properties:
+    post:
+      operationId: fakeapi.hello.test_body_sanitization_additional_properties
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: $body
+          description: Just a testing parameter in the body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              body1:
+                type: string
+            additionalProperties: true
+      responses:
+        200:
+          description: OK
+
+  /body-sanitization-additional-properties-defined:
+    post:
+      operationId: fakeapi.hello.test_body_sanitization_additional_properties_defined
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: $body
+          description: Just a testing parameter in the body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              body1:
+                type: string
+            additionalProperties:
+              type: string
+      responses:
+        200:
+          description: OK
+
+  /body-not-allowed-additional-properties:
+    post:
+      operationId: fakeapi.hello.test_body_not_allowed_additional_properties
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: $body
+          description: Just a testing parameter in the body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              body1:
+                type: string
+            additionalProperties: false
+      responses:
+        200:
+          description: OK
+
   /get_non_conforming_response:
     get:
       operationId: fakeapi.hello.get_empty_dict


### PR DESCRIPTION
Currently when object is send as body parameter only properties defined in `properties` in body schema are passed to handler function. Additional keys are filtered out, which is opposite to [spec](https://github.com/OAI/OpenAPI-Specification/blame/3.0.2/versions/3.0.2.md#L2305). For me specification is counter intuitive :(

Changes proposed in this pull request:
 - If `additionalProperties` is not set or is `True`, all properties not defined in `properties` are passed without type casting.
 - If `additionalProperties` declares value type,  unknown properties are cast according to https://github.com/zalando/connexion#type-casting.

The best explanation for `additionalProperties` I found in https://github.com/OAI/OpenAPI-Specification/issues/668#issuecomment-218829120

