### PR TITLE
Run travis on python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: python
 python:
-  - "pypy"
+  - "pypy2.7-5.10.0"
   - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 install:
   - pip install --upgrade setuptools tox tox-travis coveralls
+dist:
+  - xenial
 script:
   - tox
 after_success:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ version = read_version('connexion')
 install_requires = [
     'clickclick>=1.2',
     'jsonschema>=2.5.1,<3.0.0',
-    'PyYAML>=3.11',
+    'PyYAML>=3.13',
     'requests>=2.9.1',
     'six>=1.9',
     'inflection>=0.3.1',
@@ -121,6 +121,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
     {py34}-{min,pypi,dev}
     {py35}-{min,pypi,dev}
     {py36}-{min,pypi,dev}
+    {py37}-{min,pypi,dev}
     isort-check
     isort-check-examples
     isort-check-tests
@@ -19,7 +20,8 @@ pypy=pypy-min,pypy-pypi
 2.7=py27-min,py27-pypi
 3.4=py34-min,py34-pypi
 3.5=py35-min,py35-pypi
-3.6=py36-min,py36-pypi,isort-check,isort-check-examples,isort-check-tests,flake8
+3.6=py36-min,py36-pypi
+3.7=py37-min,py37-pypi,isort-check,isort-check-examples,isort-check-tests,flake8
 
 [testenv]
 setenv=PYTHONPATH = {toxinidir}:{toxinidir}
@@ -32,7 +34,7 @@ commands=
     pypi: pip install -r {toxworkdir}/requirements-pypi.txt
     dev: requirements-builder --level=dev --req=requirements-devel.txt -o {toxworkdir}/requirements-dev.txt setup.py
     dev: pip install -r {toxworkdir}/requirements-dev.txt
-    py3{4,5,6}: pip install -r requirements-aiohttp.txt
+    py3{4,5,6,7}: pip install -r requirements-aiohttp.txt
     python setup.py test
 
 [testenv:flake8]


### PR DESCRIPTION
Changes proposed in this pull request:

 - Run travis on python 3.7.
 - Use `Xenial` to run tests ([python 3.7 is incompatible with trusty](https://github.com/travis-ci/travis-ci/issues/9831)).
 - Bump  `PyYaml` to earliest version with python 3.7 support.
