### PR TITLE
Add for support relative paths in schema refs -- updated.

### DIFF
--- a/connexion/json_schema.py
+++ b/connexion/json_schema.py
@@ -15,16 +15,17 @@ default_handlers = {
 }
 
 
-def resolve_refs(spec, store=None, handlers=None):
+def resolve_refs(spec, store=None, handlers=None, spec_url=''):
     """
     Resolve JSON references like {"$ref": <some URI>} in a spec.
     Optionally takes a store, which is a mapping from reference URLs to a
     dereferenced objects. Prepopulating the store can avoid network calls.
+    Passing a spec_url enables the use of references with relative URLs.
     """
     spec = deepcopy(spec)
     store = store or {}
     handlers = handlers or default_handlers
-    resolver = RefResolver('', spec, store, handlers=handlers)
+    resolver = RefResolver(spec_url, spec, store, handlers=handlers)
 
     def _do_resolve(node):
         if isinstance(node, collections.Mapping) and '$ref' in node:

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -33,11 +33,11 @@ def canonical_base_path(base_path):
 
 class Specification(collections_abc.Mapping):
 
-    def __init__(self, raw_spec, spec_url):
+    def __init__(self, raw_spec, spec_url=''):
         self._raw_spec = copy.deepcopy(raw_spec)
         self._set_defaults(raw_spec)
         self._validate_spec(raw_spec, spec_url)
-        self._spec = resolve_refs(raw_spec)
+        self._spec = resolve_refs(raw_spec, spec_url=spec_url)
 
     @classmethod
     @abc.abstractmethod
@@ -105,7 +105,8 @@ class Specification(collections_abc.Mapping):
         """
         specification_path = pathlib.Path(spec)
         spec = cls._load_spec_from_file(arguments, specification_path)
-        return cls._from_dict(spec, specification_path.resolve().as_uri())
+        spec_url = specification_path.resolve().as_uri()
+        return cls._from_dict(spec, spec_url)
 
     @staticmethod
     def _get_spec_version(spec):
@@ -132,7 +133,7 @@ class Specification(collections_abc.Mapping):
         return cls._from_dict(spec)
 
     @classmethod
-    def _from_dict(cls, spec, spec_url=None):
+    def _from_dict(cls, spec, spec_url=''):
         def enforce_string_keys(obj):
             # YAML supports integer keys, but JSON does not
             if isinstance(obj, dict):

--- a/tests/api/test_schema.py
+++ b/tests/api/test_schema.py
@@ -1,7 +1,5 @@
 import json
 
-import pytest
-
 
 def test_schema(schema_app):
     app_client = schema_app.app.test_client()
@@ -190,14 +188,11 @@ def test_schema_recursive(schema_app):
     assert right_type.status_code == 200
 
 
-@pytest.mark.skip(reason='Skipped until relative ref resolution is fully implemented')
 def test_schema_relative_ref(schema_app):
     app_client = schema_app.app.test_client()
     headers = {'Content-type': 'application/json'}
     good_request = app_client.get('/v1.0/test_schema_relative_ref', headers=headers,
                                   query_string={'image_version': 'version'})
-    # Currently returns a 500 error since Operation.resolve_reference expects
-    # a ref in the same file
     assert good_request.status_code == 200
 
 

--- a/tests/api/test_schema.py
+++ b/tests/api/test_schema.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 
 def test_schema(schema_app):
     app_client = schema_app.app.test_client()
@@ -186,6 +188,17 @@ def test_schema_recursive(schema_app):
     right_type = app_client.post('/v1.0/test_schema_recursive', headers=headers,
                                  data=json.dumps(valid_object))  # type: flask.Response
     assert right_type.status_code == 200
+
+
+@pytest.mark.skip(reason='Skipped until relative ref resolution is fully implemented')
+def test_schema_relative_ref(schema_app):
+    app_client = schema_app.app.test_client()
+    headers = {'Content-type': 'application/json'}
+    good_request = app_client.get('/v1.0/test_schema_relative_ref', headers=headers,
+                                  query_string={'image_version': 'version'})
+    # Currently returns a 500 error since Operation.resolve_reference expects
+    # a ref in the same file
+    assert good_request.status_code == 200
 
 
 def test_schema_format(schema_app):

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -195,6 +195,10 @@ def schema_map():
     return ''
 
 
+def schema_relative_ref(image_version=None):
+    return {'image_version': image_version}
+
+
 def schema_recursive():
     return ''
 

--- a/tests/fixtures/different_schemas/definitions.json
+++ b/tests/fixtures/different_schemas/definitions.json
@@ -1,0 +1,12 @@
+{
+  "new_stack": {
+    "type": "object",
+    "properties": {
+      "image_version": {
+        "type": "string",
+        "description": "Docker image version to deploy"
+      }
+    },
+    "required": ["image_version"]
+  }
+}

--- a/tests/fixtures/different_schemas/openapi.yaml
+++ b/tests/fixtures/different_schemas/openapi.yaml
@@ -215,6 +215,24 @@ paths:
             schema:
               $ref: '#/components/schemas/simple_tree'
         required: true
+  /test_schema_relative_ref:
+    get:
+      summary: Returns the image version
+      description: Returns the image version
+      operationId: fakeapi.hello.schema_relative_ref
+      parameters:
+        - name: image_version
+          required: true
+          in: query
+          schema:
+            type: string
+      responses:
+        200:
+          description: goodbye response
+          content:
+            application/json:
+              schema:
+                $ref: 'definitions.json#/new_stack'
   /test_schema_format:
     post:
       summary: Returns empty response

--- a/tests/fixtures/different_schemas/swagger.yaml
+++ b/tests/fixtures/different_schemas/swagger.yaml
@@ -233,6 +233,24 @@ paths:
           schema:
             type: string
 
+  /test_schema_relative_ref:
+    get:
+      summary: Returns the image version
+      description: Returns the image version
+      operationId: fakeapi.hello.schema_relative_ref
+      parameters:
+        - name: image_version
+          required: true
+          in: query
+          type: string
+      produces:
+        - application/json
+      responses:
+        200:
+          description: goodbye response
+          schema:
+            $ref: 'definitions.json#/new_stack'
+
   /test_schema_format:
     post:
       summary: Returns empty response


### PR DESCRIPTION
Refs #461
Refs #254
Updates #543 

From #543:
"Fix to allow the json schema validation to handle relative refs by passing in the spec file path. This will only work when passing a file path to add_api and not a dict.
**Note:** This will only work with response validation disabled. There are more changes required to support local refs elsewhere in the code."