### PR TITLE
add path to API only for HTTP operations

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -6,6 +6,7 @@ import sys
 import six
 
 from ..exceptions import ResolverError
+from ..http_facts import METHODS
 from ..operations import make_operation
 from ..options import ConnexionOptions
 from ..resolver import Resolver
@@ -199,7 +200,7 @@ class AbstractAPI(object):
             logger.debug('Adding %s%s...', self.base_path, path)
 
             for method in methods:
-                if method == 'parameters':
+                if method not in METHODS:
                     continue
                 try:
                     self.add_operation(path, method)

--- a/connexion/http_facts.py
+++ b/connexion/http_facts.py
@@ -2,3 +2,14 @@ FORM_CONTENT_TYPES = [
     'application/x-www-form-urlencoded',
     'multipart/form-data'
 ]
+
+METHODS = set([
+    "get",
+    "put"
+    "post",
+    "delete",
+    "options",
+    "head",
+    "patch",
+    "trace"
+])

--- a/connexion/http_facts.py
+++ b/connexion/http_facts.py
@@ -5,7 +5,7 @@ FORM_CONTENT_TYPES = [
 
 METHODS = set([
     "get",
-    "put"
+    "put",
     "post",
     "delete",
     "options",

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -242,7 +242,7 @@ def test_handle_add_operation_error(simple_api_spec_dir):
 def test_using_all_fields_in_path_item(simple_api_spec_dir):
     """Test that connexion will try to add an endpoint only on http methods.
 
-    test also that each http methods has its own endpoint. 
+    test also that each http methods has its own endpoint.
     """
     app = App(__name__, specification_dir=simple_api_spec_dir)
     app.add_api('openapi.yaml')

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -236,3 +236,8 @@ def test_handle_add_operation_error(simple_api_spec_dir):
     app.api_cls.add_operation = mock.MagicMock(side_effect=Exception('operation error!'))
     with pytest.raises(Exception):
         app.add_api('swagger.yaml', resolver=lambda oid: (lambda foo: 'bar'))
+
+
+def test_using_all_fields_in_path_item(simple_api_spec_dir):
+    app = App(__name__, specification_dir=simple_api_spec_dir)
+    app.add_api('openapi.yaml')

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -9,6 +9,7 @@ import pytest
 from conftest import TEST_FOLDER, build_app_from_fixture
 from connexion import App
 from connexion.exceptions import InvalidSpecification
+from connexion.http_facts import METHODS
 
 SPECS = ["swagger.yaml", "openapi.yaml"]
 
@@ -239,5 +240,16 @@ def test_handle_add_operation_error(simple_api_spec_dir):
 
 
 def test_using_all_fields_in_path_item(simple_api_spec_dir):
+    """Test that connexion will try to add an endpoint only on http methods.
+
+    test also that each http methods has its own endpoint. 
+    """
     app = App(__name__, specification_dir=simple_api_spec_dir)
     app.add_api('openapi.yaml')
+
+    test_methods = set()
+    for rule in app.app.url_map.iter_rules():
+        if rule.rule != "/v1.0/add_operation_on_http_methods_only":
+            continue
+        test_methods.update({method.lower() for method in rule.methods})
+    assert set(test_methods) == METHODS

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -510,7 +510,40 @@ def apikey_info(apikey, required_scopes=None):
         return {'sub': 'admin'}
     return None
 
+
 def jwt_info(token):
     if token == '100':
         return {'sub': '100'}
     return None
+
+
+def get_add_operation_on_http_methods_only():
+    return ""
+
+
+def put_add_operation_on_http_methods_only():
+    return ""
+
+
+def post_add_operation_on_http_methods_only():
+    return ""
+
+
+def delete_add_operation_on_http_methods_only():
+    return ""
+
+
+def options_add_operation_on_http_methods_only():
+    return ""
+
+
+def head_add_operation_on_http_methods_only():
+    return ""
+
+
+def patch_add_operation_on_http_methods_only():
+    return ""
+
+
+def trace_add_operation_on_http_methods_only():
+    return ""

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -931,6 +931,41 @@ paths:
               schema:
                 type: array
                 items: {}
+  /add_operation_on_http_methods_only:
+    summary: this is a test
+    description: check if add_operation is called only on http methods field
+    x-test: True
+    servers:
+      - url: http://localhost
+    parameters:
+      - $ref: "#/components/parameters/OptionalName"
+    get:
+      operationId: fakeapi.hello.get_add_operation_on_http_methods_only
+      responses: {}
+    put:
+      operationId: fakeapi.hello.put_add_operation_on_http_methods_only
+      responses: {}
+    post:
+      operationId: fakeapi.hello.post_add_operation_on_http_methods_only
+      responses: {}
+    delete:
+      operationId: fakeapi.hello.delete_add_operation_on_http_methods_only
+      responses: {}
+    options:
+      operationId: fakeapi.hello.options_add_operation_on_http_methods_only
+      responses: {}
+    head:
+      operationId: fakeapi.hello.head_add_operation_on_http_methods_only
+      responses: {}
+    patch:
+      operationId: fakeapi.hello.patch_add_operation_on_http_methods_only
+      responses: {}
+    trace:
+      operationId: fakeapi.hello.trace_add_operation_on_http_methods_only
+      responses: {}
+    
+
+
 servers:
   - url: http://localhost:{port}/{basePath}
     variables:
@@ -972,3 +1007,11 @@ components:
           description: Docker image version to deploy
       required:
         - image_version
+  parameters:
+    OptionalName:
+      name: name
+      in: path
+      description: Name of the person to greet.
+      required: false
+      schema:
+        type: string


### PR DESCRIPTION
hi,

First thing, thank you for creating and maintaining connexion !

this pull request allows to use [all path item fields](https://swagger.io/specification/#pathItemObject).

I encountered an error while creating an extension using **x-** vars in path object.  
The code was skipping only the field **Parameters** and tried to create an operation on others fields.

### stacktrace
```
    def test_using_all_fields_in_path_item(simple_api_spec_dir):
        app = App(__name__, specification_dir=simple_api_spec_dir)
>       app.add_api('openapi.yaml')

tests/api/test_bootstrap.py:243: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../.local/share/virtualenvs/connexion-LpTILqQi/lib/python3.6/site-packages/connexion/apps/flask_app.py:54: in add_api
    api = super(FlaskApp, self).add_api(specification, **kwargs)
../../.local/share/virtualenvs/connexion-LpTILqQi/lib/python3.6/site-packages/connexion/apps/abstract.py:155: in add_api
    options=api_options.as_dict())
../../.local/share/virtualenvs/connexion-LpTILqQi/lib/python3.6/site-packages/connexion/apis/abstract.py:108: in __init__
    self.add_paths()
../../.local/share/virtualenvs/connexion-LpTILqQi/lib/python3.6/site-packages/connexion/apis/abstract.py:217: in add_paths
    self._handle_add_operation_error(path, method, sys.exc_info())
../../.local/share/virtualenvs/connexion-LpTILqQi/lib/python3.6/site-packages/connexion/apis/abstract.py:228: in _handle_add_operation_error
    six.reraise(*exc_info)
../../.local/share/virtualenvs/connexion-LpTILqQi/lib/python3.6/site-packages/six.py:693: in reraise
    raise value
../../.local/share/virtualenvs/connexion-LpTILqQi/lib/python3.6/site-packages/connexion/apis/abstract.py:207: in add_paths
    self.add_operation(path, method)
../../.local/share/virtualenvs/connexion-LpTILqQi/lib/python3.6/site-packages/connexion/apis/abstract.py:170: in add_operation
    pass_context_arg_name=self.pass_context_arg_name
../../.local/share/virtualenvs/connexion-LpTILqQi/lib/python3.6/site-packages/connexion/operations/__init__.py:8: in make_operation
    return spec.operation_cls.from_spec(spec, *args, **kwargs)
../../.local/share/virtualenvs/connexion-LpTILqQi/lib/python3.6/site-packages/connexion/operations/openapi.py:138: in from_spec
    **kwargs
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <connexion.operations.openapi.OpenAPIOperation object at 0x7fa49c011860>
api = <connexion.apis.flask_api.FlaskApi object at 0x7fa49c4c2ac8>
method = 'summary', path = '/add_operation_on_http_methods_only'
operation = 'this is a test'
resolver = <connexion.resolver.Resolver object at 0x7fa49c0ad780>
path_parameters = [{'description': 'Name of the person to greet.', 'in': 'path', 'name': 'name', 'required': False, ...}]
app_security = None
components = {'examples': {'justAnExample': {'summary': 'a basic example.', 'value': 'Good evening, doctor.'}}, 'parameters': {'Opt...'description': 'Docker image version to deploy', 'type': 'string'}}, 'required': ['image_version'], 'type': 'object'}}}
validate_responses = False, strict_validation = False, randomize_endpoint = None
validator_map = None, pythonic_params = False, uri_parser_class = None
pass_context_arg_name = None

    def __init__(self, api, method, path, operation, resolver, path_parameters=None,
                 app_security=None, components=None, validate_responses=False,
                 strict_validation=False, randomize_endpoint=None, validator_map=None,
                 pythonic_params=False, uri_parser_class=None, pass_context_arg_name=None):
        """
        This class uses the OperationID identify the module and function that will handle the operation
    
        ...
        """
        self.components = components or {}
    
        def component_get(oas3_name):
            return self.components.get(oas3_name, {})
    
        # operation overrides globals
        security_schemes = component_get('securitySchemes')
>       app_security = operation.get('security', app_security)
E       AttributeError: 'str' object has no attribute 'get'

../../.local/share/virtualenvs/connexion-LpTILqQi/lib/python3.6/site-packages/connexion/operations/openapi.py:70: AttributeError
```

