### PR TITLE
fix openapi3 path and query validation and tests

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -240,6 +240,7 @@ class ParameterValidator(object):
                 return str(e)
 
             param = copy.deepcopy(param)
+            param = param.get('schema', param)
             if 'required' in param:
                 del param['required']
             try:


### PR DESCRIPTION
Fixes #811 

Changes proposed in this pull request:
 - use 'schema' in param_defn if available in validate_parameter(...)
