### PR TITLE
Serve correct openapi spec basepath when path is altered by reverse-proxy

### DIFF
--- a/connexion/__init__.py
+++ b/connexion/__init__.py
@@ -37,7 +37,7 @@ except ImportError:  # pragma: no cover
 App = FlaskApp
 Api = FlaskApi
 
-if sys.version_info[0] >= 3:  # pragma: no cover
+if sys.version_info >= (3, 5, 3):  # pragma: no cover
     try:
         from .apis.aiohttp_api import AioHttpApi
         from .apps.aiohttp_app import AioHttpApp

--- a/connexion/__init__.py
+++ b/connexion/__init__.py
@@ -37,14 +37,13 @@ except ImportError:  # pragma: no cover
 App = FlaskApp
 Api = FlaskApi
 
-if sys.version_info >= (3, 5, 3):  # pragma: no cover
-    try:
-        from .apis.aiohttp_api import AioHttpApi
-        from .apps.aiohttp_app import AioHttpApp
-    except ImportError:  # pragma: no cover
-        _aiohttp_not_installed_error = not_installed_error()
-        AioHttpApi = _aiohttp_not_installed_error
-        AioHttpApp = _aiohttp_not_installed_error
+try:
+    from .apis.aiohttp_api import AioHttpApi
+    from .apps.aiohttp_app import AioHttpApp
+except ImportError:  # pragma: no cover
+    _aiohttp_not_installed_error = not_installed_error()
+    AioHttpApi = _aiohttp_not_installed_error
+    AioHttpApp = _aiohttp_not_installed_error
 
 # This version is replaced during release process.
 __version__ = '2018.0.dev1'

--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -114,6 +114,26 @@ class AioHttpApi(AbstractAPI):
     def normalize_string(string):
         return re.sub(r'[^a-zA-Z0-9]', '_', string.strip('/'))
 
+    def _base_path_for_prefix(self, request):
+        """
+        returns a modified basePath which includes the incoming request's
+        path prefix.
+        """
+        base_path = self.base_path
+        if not request.path.startswith(self.base_path):
+            prefix = request.path.split(self.base_path)[0]
+            base_path = prefix + base_path
+        return base_path
+
+    def _spec_for_prefix(self, request):
+        """
+        returns a spec with a modified basePath / servers block
+        which corresponds to the incoming request path.
+        This is needed when behind a path-altering reverse proxy.
+        """
+        base_path = self._base_path_for_prefix(request)
+        return self.specification.with_base_path(base_path).raw
+
     def add_openapi_json(self):
         """
         Adds openapi json to {base_path}/openapi.json
@@ -135,7 +155,8 @@ class AioHttpApi(AbstractAPI):
         if not self.options.openapi_spec_path.endswith("json"):
             return
 
-        openapi_spec_path_yaml = self.options.openapi_spec_path[:-len("json")] + "yaml"
+        openapi_spec_path_yaml = \
+            self.options.openapi_spec_path[:-len("json")] + "yaml"
         logger.debug('Adding spec yaml: %s/%s', self.base_path,
                      openapi_spec_path_yaml)
         self.subapp.router.add_route(
@@ -146,24 +167,18 @@ class AioHttpApi(AbstractAPI):
 
     @asyncio.coroutine
     def _get_openapi_json(self, request):
-        base_path = self.base_path
-        if not request.path.startswith(self.base_path):
-            prefix = request.path.split(self.base_path)[0]
-            base_path = prefix + base_path
-
-        spec = self.specification.with_base_path(base_path).raw
         return web.Response(
             status=200,
             content_type='application/json',
-            body=self.jsonifier.dumps(spec)
+            body=self.jsonifier.dumps(self._spec_for_prefix(request))
         )
 
     @asyncio.coroutine
-    def _get_openapi_yaml(self, req):
+    def _get_openapi_yaml(self, request):
         return web.Response(
             status=200,
             content_type='text/yaml',
-            body=yamldumper(self.specification.raw)
+            body=yamldumper(self._spec_for_prefix(request))
         )
 
     def add_swagger_ui(self):
@@ -219,11 +234,7 @@ class AioHttpApi(AbstractAPI):
     @aiohttp_jinja2.template('index.j2')
     @asyncio.coroutine
     def _get_swagger_ui_home(self, req):
-        base_path = self.base_path
-        if not req.path.startswith(self.base_path):
-            prefix = req.path.split(self.base_path)[0]
-            base_path = prefix + base_path
-
+        base_path = self._base_path_for_prefix(req)
         template_variables = {
             'openapi_spec_url': (base_path + self.options.openapi_spec_path)
         }

--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -145,11 +145,17 @@ class AioHttpApi(AbstractAPI):
         )
 
     @asyncio.coroutine
-    def _get_openapi_json(self, req):
+    def _get_openapi_json(self, request):
+        base_path = self.base_path
+        if not request.path.startswith(self.base_path):
+            prefix = request.path.split(self.base_path)[0]
+            base_path = prefix + base_path
+
+        spec = self.specification.with_base_path(base_path).raw
         return web.Response(
             status=200,
             content_type='application/json',
-            body=self.jsonifier.dumps(self.specification.raw)
+            body=self.jsonifier.dumps(spec)
         )
 
     @asyncio.coroutine
@@ -213,8 +219,13 @@ class AioHttpApi(AbstractAPI):
     @aiohttp_jinja2.template('index.j2')
     @asyncio.coroutine
     def _get_swagger_ui_home(self, req):
+        base_path = self.base_path
+        if not req.path.startswith(self.base_path):
+            prefix = req.path.split(self.base_path)[0]
+            base_path = prefix + base_path
+
         template_variables = {
-            'openapi_spec_url': (self.base_path + self.options.openapi_spec_path)
+            'openapi_spec_url': (base_path + self.options.openapi_spec_path)
         }
         if self.options.openapi_console_ui_config is not None:
             template_variables['configUrl'] = 'swagger-ui-config.json'

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -300,11 +300,7 @@ class InternalHandlers(object):
         return flask.jsonify(self._spec_for_prefix())
 
     def get_yaml_spec(self):
-        lambda: FlaskApi._build_response(
-            status_code=200,
-            mimetype="text/yaml",
-            data=yamldumper(self._spec_for_prefix())
-        )
+        return yamldumper(self._spec_for_prefix()), 200, {"Content-Type": "text/yaml"}
 
     def _spec_for_prefix(self):
         """

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -27,13 +27,6 @@ class FlaskApi(AbstractAPI):
         self.blueprint = flask.Blueprint(endpoint, __name__, url_prefix=self.base_path,
                                          template_folder=str(self.options.openapi_console_ui_from_dir))
 
-    def _spec_for_prefix(self):
-        """ Modify base_path in the spec based on incoming url
-            This fixes problems with reverse proxies changing the path.
-        """
-        base_path = flask.url_for(flask.request.endpoint).rsplit("/", 1)[0]
-        return self.specification.with_base_path(base_path).raw
-
     def add_openapi_json(self):
         """
         Adds spec json to {base_path}/swagger.json
@@ -43,12 +36,9 @@ class FlaskApi(AbstractAPI):
                      self.options.openapi_spec_path)
         endpoint_name = "{name}_openapi_json".format(name=self.blueprint.name)
 
-        def get_json_spec():
-            return flask.jsonify(self._spec_for_prefix())
-
         self.blueprint.add_url_rule(self.options.openapi_spec_path,
                                     endpoint_name,
-                                    get_json_spec)
+                                    self._handlers.get_json_spec)
 
     def add_openapi_yaml(self):
         """
@@ -66,11 +56,7 @@ class FlaskApi(AbstractAPI):
         self.blueprint.add_url_rule(
             openapi_spec_path_yaml,
             endpoint_name,
-            lambda: FlaskApi._build_response(
-                status_code=200,
-                mimetype="text/yaml",
-                data=yamldumper(self._spec_for_prefix())
-            )
+            self._handlers.get_yaml_spec
         )
 
     def add_swagger_ui(self):
@@ -132,7 +118,7 @@ class FlaskApi(AbstractAPI):
     def _handlers(self):
         # type: () -> InternalHandlers
         if not hasattr(self, '_internal_handlers'):
-            self._internal_handlers = InternalHandlers(self.base_path, self.options)
+            self._internal_handlers = InternalHandlers(self.base_path, self.options, self.specification)
         return self._internal_handlers
 
     @classmethod
@@ -275,9 +261,10 @@ class InternalHandlers(object):
     Flask handlers for internally registered endpoints.
     """
 
-    def __init__(self, base_path, options):
+    def __init__(self, base_path, options, specification):
         self.base_path = base_path
         self.options = options
+        self.specification = specification
 
     def console_ui_home(self):
         """
@@ -286,7 +273,7 @@ class InternalHandlers(object):
         :return:
         """
         openapi_json_route_name = "{blueprint}.{prefix}_openapi_json"
-        escaped = self.base_path.replace(".", "_")
+        escaped = flask_utils.flaskify_endpoint(self.base_path)
         openapi_json_route_name = openapi_json_route_name.format(
             blueprint=escaped,
             prefix=escaped
@@ -308,3 +295,21 @@ class InternalHandlers(object):
         # convert PosixPath to str
         static_dir = str(self.options.openapi_console_ui_from_dir)
         return flask.send_from_directory(static_dir, filename)
+
+    def get_json_spec(self):
+        return flask.jsonify(self._spec_for_prefix())
+
+    def get_yaml_spec(self):
+        lambda: FlaskApi._build_response(
+            status_code=200,
+            mimetype="text/yaml",
+            data=yamldumper(self._spec_for_prefix())
+        )
+
+    def _spec_for_prefix(self):
+        """
+        Modify base_path in the spec based on incoming url
+        This fixes problems with reverse proxies changing the path.
+        """
+        base_path = flask.url_for(flask.request.endpoint).rsplit("/", 1)[0]
+        return self.specification.with_base_path(base_path).raw

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -145,11 +145,19 @@ class Specification(collections_abc.Mapping):
             return Swagger2Specification(spec)
         return OpenAPISpecification(spec)
 
+    def clone(self):
+        return type(self)(copy.deepcopy(self._raw_spec))
+
     @classmethod
     def load(cls, spec, arguments=None):
         if not isinstance(spec, dict):
             return cls.from_file(spec, arguments=arguments)
         return cls.from_dict(spec)
+
+    def with_base_path(self, base_path):
+        new_spec = self.clone()
+        new_spec.base_path = base_path
+        return new_spec
 
 
 class Swagger2Specification(Specification):

--- a/examples/openapi3/reverseproxy/README.rst
+++ b/examples/openapi3/reverseproxy/README.rst
@@ -1,0 +1,58 @@
+=====================
+Reverse Proxy Example
+=====================
+
+This example demonstrates how to run a connexion application behind a path-altering reverse proxy.
+
+You can either set the path in your app, or set the ``X-Forwarded-Path`` header.
+
+Running:
+
+.. code-block:: bash
+
+    $ sudo pip3 install --upgrade connexion[swagger-ui]  # install Connexion from PyPI
+    $ ./app.py
+
+Now open your browser and go to http://localhost:8080/reverse_proxied/ui/ to see the Swagger UI.
+
+
+You can also use the ``X-Forwarded-Path`` header to modify the reverse proxy path.
+For example:
+
+.. code-block:: bash
+
+    curl -H "X-Forwarded-Path: /banana/" http://localhost:8080/openapi.json
+
+    {
+       "servers" : [
+          {
+             "url" : "banana/"
+          }
+       ],
+       "paths" : {
+          "/hello" : {
+             "get" : {
+                "responses" : {
+                   "200" : {
+                      "description" : "hello",
+                      "content" : {
+                         "text/plain" : {
+                            "schema" : {
+                               "type" : "string"
+                            }
+                         }
+                      }
+                   }
+                },
+                "operationId" : "app.hello",
+                "summary" : "say hi"
+             }
+          }
+       },
+       "openapi" : "3.0.0",
+       "info" : {
+          "version" : "1.0",
+          "title" : "Path-Altering Reverse Proxy Example"
+       }
+    }
+

--- a/examples/openapi3/reverseproxy/app.py
+++ b/examples/openapi3/reverseproxy/app.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+'''
+example of connexion running behind a path-altering reverse-proxy
+
+NOTE this demo is not secure by default!!
+You'll want to make sure these headers are coming from your proxy, and not
+directly from users on the web!
+
+'''
+
+import connexion
+
+# adapted from http://flask.pocoo.org/snippets/35/
+class ReverseProxied(object):
+    '''Wrap the application in this middleware and configure the
+    reverse proxy to add these headers, to let you quietly bind
+    this to a URL other than / and to an HTTP scheme that is
+    different than what is used locally.
+
+    In nginx:
+
+    location /proxied {
+        proxy_pass http://192.168.0.1:5001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Scheme $scheme;
+        proxy_set_header X-Forwarded-Path /proxied;
+    }
+
+    :param app: the WSGI application
+    :param script_name: override the default script name (path)
+    :param scheme: override the default scheme
+    :param server: override the default server
+    '''
+
+    def __init__(self, app, script_name=None, scheme=None, server=None):
+        self.app = app
+        self.script_name = script_name
+        self.scheme = scheme
+        self.server = server
+
+    def __call__(self, environ, start_response):
+        script_name = environ.get('HTTP_X_FORWARDED_PATH', '') or self.script_name
+        if script_name:
+            environ['SCRIPT_NAME'] = "/" + script_name.lstrip("/")
+            path_info = environ['PATH_INFO']
+            if path_info.startswith(script_name):
+                environ['PATH_INFO_OLD'] = path_info
+                environ['PATH_INFO'] = path_info[len(script_name):]
+        scheme = environ.get('HTTP_X_SCHEME', '') or self.scheme
+        if scheme:
+            environ['wsgi.url_scheme'] = scheme
+        server = environ.get('HTTP_X_FORWARDED_SERVER', '') or self.server
+        if server:
+            environ['HTTP_HOST'] = server
+        return self.app(environ, start_response)
+
+
+def hello():
+    return "hello"
+
+
+if __name__ == '__main__':
+    app = connexion.FlaskApp(__name__)
+    app.add_api('openapi.yaml')
+    flask_app = app.app
+    proxied = ReverseProxied(
+        flask_app.wsgi_app,
+        script_name='/reverse_proxied/'
+    )
+    flask_app.wsgi_app = proxied
+    app.run(port=8080)

--- a/examples/openapi3/reverseproxy/app.py
+++ b/examples/openapi3/reverseproxy/app.py
@@ -10,6 +10,7 @@ directly from users on the web!
 
 import connexion
 
+
 # adapted from http://flask.pocoo.org/snippets/35/
 class ReverseProxied(object):
     '''Wrap the application in this middleware and configure the

--- a/examples/openapi3/reverseproxy/app.py
+++ b/examples/openapi3/reverseproxy/app.py
@@ -7,6 +7,7 @@ You'll want to make sure these headers are coming from your proxy, and not
 directly from users on the web!
 
 '''
+import logging
 
 import connexion
 
@@ -41,6 +42,11 @@ class ReverseProxied(object):
         self.server = server
 
     def __call__(self, environ, start_response):
+        logging.warn(
+            "this demo is not secure by default!! "
+            "You'll want to make sure these headers are coming from your proxy, "
+            "and not directly from users on the web!"
+            )
         script_name = environ.get('HTTP_X_FORWARDED_PATH', '') or self.script_name
         if script_name:
             environ['SCRIPT_NAME'] = "/" + script_name.lstrip("/")

--- a/examples/openapi3/reverseproxy/app.py
+++ b/examples/openapi3/reverseproxy/app.py
@@ -42,7 +42,7 @@ class ReverseProxied(object):
         self.server = server
 
     def __call__(self, environ, start_response):
-        logging.warn(
+        logging.warning(
             "this demo is not secure by default!! "
             "You'll want to make sure these headers are coming from your proxy, "
             "and not directly from users on the web!"

--- a/examples/openapi3/reverseproxy/openapi.yaml
+++ b/examples/openapi3/reverseproxy/openapi.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.0
+info:
+  title: Path-Altering Reverse Proxy Example
+  version: '1.0'
+paths:
+  /hello:
+    get:
+      summary: say hi
+      operationId: app.hello
+      responses:
+        '200':
+          description: hello
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/examples/openapi3/reverseproxy_aiohttp/README.rst
+++ b/examples/openapi3/reverseproxy_aiohttp/README.rst
@@ -1,0 +1,58 @@
+=====================
+Reverse Proxy Example
+=====================
+
+This example demonstrates how to run a connexion application behind a path-altering reverse proxy.
+
+You can either set the path in your app, or set the ``X-Forwarded-Path`` header.
+
+Running:
+
+.. code-block:: bash
+
+    $ sudo pip3 install --upgrade connexion[swagger-ui] aiohttp-remotes  
+    $ ./app.py
+
+Now open your browser and go to http://localhost:8080/reverse_proxied/ui/ to see the Swagger UI.
+
+
+You can also use the ``X-Forwarded-Path`` header to modify the reverse proxy path.
+For example:
+
+.. code-block:: bash
+
+    curl -H "X-Forwarded-Path: /banana/" http://localhost:8080/openapi.json
+
+    {
+       "servers" : [
+          {
+             "url" : "banana"
+          }
+       ],
+       "paths" : {
+          "/hello" : {
+             "get" : {
+                "responses" : {
+                   "200" : {
+                      "description" : "hello",
+                      "content" : {
+                         "text/plain" : {
+                            "schema" : {
+                               "type" : "string"
+                            }
+                         }
+                      }
+                   }
+                },
+                "operationId" : "app.hello",
+                "summary" : "say hi"
+             }
+          }
+       },
+       "openapi" : "3.0.0",
+       "info" : {
+          "version" : "1.0",
+          "title" : "Path-Altering Reverse Proxy Example"
+       }
+    }
+

--- a/examples/openapi3/reverseproxy_aiohttp/app.py
+++ b/examples/openapi3/reverseproxy_aiohttp/app.py
@@ -4,6 +4,7 @@ example of aiohttp connexion running behind a path-altering reverse-proxy
 '''
 
 import json
+import logging
 
 import connexion
 
@@ -28,6 +29,11 @@ class XPathForwarded(XForwardedBase):
 
     @web.middleware
     async def middleware(self, request, handler):
+        logging.warn(
+            "this demo is not secure by default!! "
+            "You'll want to make sure these headers are coming from your proxy, "
+            "and not directly from users on the web!"
+            )
         try:
             overrides = {}
             headers = request.headers

--- a/examples/openapi3/reverseproxy_aiohttp/app.py
+++ b/examples/openapi3/reverseproxy_aiohttp/app.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+'''
+example of aiohttp connexion running behind a path-altering reverse-proxy
+'''
+
+import json
+import connexion
+from yarl import URL
+from aiohttp import web
+from aiohttp_remotes.x_forwarded import XForwardedBase
+from aiohttp_remotes.exceptions import RemoteError, TooManyHeaders
+
+X_FORWARDED_PATH = "X-Forwarded-Path"
+
+
+class XPathForwarded(XForwardedBase):
+
+    def __init__(self, num=1):
+        self._num = num
+
+    def get_forwarded_path(self, headers):
+        forwarded_host = headers.getall(X_FORWARDED_PATH, [])
+        if len(forwarded_host) > 1:
+            raise TooManyHeaders(X_FORWARDED_PATH)
+        return forwarded_host[0] if forwarded_host else None
+
+    @web.middleware
+    async def middleware(self, request, handler):
+        try:
+            overrides = {}
+            headers = request.headers
+
+            forwarded_for = self.get_forwarded_for(headers)
+            if forwarded_for:
+                overrides['remote'] = str(forwarded_for[-self._num])
+
+            proto = self.get_forwarded_proto(headers)
+            if proto:
+                overrides['scheme'] = proto[-self._num]
+
+            host = self.get_forwarded_host(headers)
+            if host is not None:
+                overrides['host'] = host
+
+            prefix = self.get_forwarded_path(headers)
+            if prefix is not None:
+                prefix = '/' + prefix.strip('/') + '/'
+                request_path = URL(request.path.lstrip('/'))
+                overrides['rel_url'] = URL(prefix).join(request_path)
+
+            request = request.clone(**overrides)
+
+            return await handler(request)
+        except RemoteError as exc:
+            exc.log(request)
+        await self.raise_error(request)
+
+
+def hello(request):
+    ret = {
+        "host": request.host,
+        "scheme": request.scheme,
+        "path": request.path,
+        "_href": str(request.url)
+    }
+    return web.Response(text=json.dumps(ret), status=200)
+
+
+if __name__ == '__main__':
+    app = connexion.AioHttpApp(__name__)
+    app.add_api('openapi.yaml', pass_context_arg_name='request')
+    aio = app.app
+    reverse_proxied = XPathForwarded()
+    aio.middlewares.append(reverse_proxied.middleware)
+    app.run(port=8080)

--- a/examples/openapi3/reverseproxy_aiohttp/app.py
+++ b/examples/openapi3/reverseproxy_aiohttp/app.py
@@ -4,11 +4,13 @@ example of aiohttp connexion running behind a path-altering reverse-proxy
 '''
 
 import json
+
 import connexion
-from yarl import URL
+
 from aiohttp import web
-from aiohttp_remotes.x_forwarded import XForwardedBase
 from aiohttp_remotes.exceptions import RemoteError, TooManyHeaders
+from aiohttp_remotes.x_forwarded import XForwardedBase
+from yarl import URL
 
 X_FORWARDED_PATH = "X-Forwarded-Path"
 

--- a/examples/openapi3/reverseproxy_aiohttp/app.py
+++ b/examples/openapi3/reverseproxy_aiohttp/app.py
@@ -29,7 +29,7 @@ class XPathForwarded(XForwardedBase):
 
     @web.middleware
     async def middleware(self, request, handler):
-        logging.warn(
+        logging.warning(
             "this demo is not secure by default!! "
             "You'll want to make sure these headers are coming from your proxy, "
             "and not directly from users on the web!"

--- a/examples/openapi3/reverseproxy_aiohttp/nginx.conf
+++ b/examples/openapi3/reverseproxy_aiohttp/nginx.conf
@@ -1,0 +1,38 @@
+worker_processes 1;
+error_log stderr;
+daemon off;
+pid nginx.pid;
+
+events {
+  worker_connections  1024;
+}
+
+http {
+  include             /etc/nginx/mime.types;
+  default_type        application/octet-stream;
+
+  sendfile on;
+
+  keepalive_timeout   65;
+
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_prefer_server_ciphers on;
+  access_log access.log;
+  server {
+
+        listen localhost:9000;
+
+        location /reverse_proxied/ {
+          # Define the location of the proxy server to send the request to
+          proxy_pass http://localhost:8080/;
+          # Add prefix header
+          proxy_set_header X-Forwarded-Path /reverse_proxied/;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Host   $host:$server_port;
+          proxy_set_header X-Forwarded-Server $host;
+          proxy_set_header X-Forwarded-Port   $server_port;
+          proxy_set_header X-Forwarded-Proto  http;
+        }
+
+  }
+}

--- a/examples/openapi3/reverseproxy_aiohttp/openapi.yaml
+++ b/examples/openapi3/reverseproxy_aiohttp/openapi.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.0
+info:
+  title: Path-Altering Reverse Proxy Example
+  version: '1.0'
+servers:
+  - url: /api
+paths:
+  /hello:
+    get:
+      summary: say hi
+      operationId: app.hello
+      responses:
+        '200':
+          description: hello
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,9 @@ tests_require = [
     swagger_ui_require
 ]
 
-if sys.version_info >= (3, 5, 3):
-    tests_require.extend(aiohttp_require)
-    tests_require.append('pytest-aiohttp')
-    tests_require.append('aiohttp-remotes')
+tests_require.extend(aiohttp_require)
+tests_require.append('pytest-aiohttp')
+tests_require.append('aiohttp-remotes')
 
 
 class PyTest(TestCommand):
@@ -60,14 +59,8 @@ class PyTest(TestCommand):
     def initialize_options(self):
         TestCommand.initialize_options(self)
         self.cov = None
-        self.pytest_args = ['--cov', 'connexion', '--cov-report', 'term-missing', '-v']
-
-        if sys.version_info < (3, 5, 3):
-            self.pytest_args.append('--cov-config=py2-coveragerc')
-            self.pytest_args.append('--ignore=tests/aiohttp')
-        else:
-            self.pytest_args.append('--cov-config=py3-coveragerc')
-
+        self.pytest_args = ['--cov', 'connexion', '--cov-report', 'term-missing',
+                            '--cov-config=py3-coveragerc', '-v']
         self.cov_html = False
 
     def finalize_options(self):

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,10 @@ tests_require = [
     swagger_ui_require
 ]
 
-if sys.version_info[0] >= 3:
+if sys.version_info >= (3, 5, 3):
     tests_require.extend(aiohttp_require)
     tests_require.append('pytest-aiohttp')
+    tests_require.append('aiohttp-remotes')
 
 
 class PyTest(TestCommand):
@@ -61,7 +62,7 @@ class PyTest(TestCommand):
         self.cov = None
         self.pytest_args = ['--cov', 'connexion', '--cov-report', 'term-missing', '-v']
 
-        if sys.version_info[0] < 3:
+        if sys.version_info < (3, 5, 3):
             self.pytest_args.append('--cov-config=py2-coveragerc')
             self.pytest_args.append('--ignore=tests/aiohttp')
         else:

--- a/tests/aiohttp/test_aiohttp_reverse_proxy.py
+++ b/tests/aiohttp/test_aiohttp_reverse_proxy.py
@@ -1,0 +1,132 @@
+import asyncio
+
+from aiohttp import web
+from aiohttp_remotes.exceptions import RemoteError, TooManyHeaders
+from aiohttp_remotes.x_forwarded import XForwardedBase
+from connexion import AioHttpApp
+from yarl import URL
+
+X_FORWARDED_PATH = "X-Forwarded-Path"
+
+
+class XPathForwarded(XForwardedBase):
+
+    def __init__(self, num=1):
+        self._num = num
+
+    def get_forwarded_path(self, headers):
+        forwarded_host = headers.getall(X_FORWARDED_PATH, [])
+        if len(forwarded_host) > 1:
+            raise TooManyHeaders(X_FORWARDED_PATH)
+        return forwarded_host[0] if forwarded_host else None
+
+    @web.middleware
+    async def middleware(self, request, handler):
+        try:
+            overrides = {}
+            headers = request.headers
+
+            forwarded_for = self.get_forwarded_for(headers)
+            if forwarded_for:
+                overrides['remote'] = str(forwarded_for[-self._num])
+
+            proto = self.get_forwarded_proto(headers)
+            if proto:
+                overrides['scheme'] = proto[-self._num]
+
+            host = self.get_forwarded_host(headers)
+            if host is not None:
+                overrides['host'] = host
+
+            prefix = self.get_forwarded_path(headers)
+            if prefix is not None:
+                prefix = '/' + prefix.strip('/') + '/'
+                request_path = URL(request.path.lstrip('/'))
+                overrides['rel_url'] = URL(prefix).join(request_path)
+
+            request = request.clone(**overrides)
+
+            return await handler(request)
+        except RemoteError as exc:
+            exc.log(request)
+        await self.raise_error(request)
+
+
+    @asyncio.coroutine
+    def test_swagger_json_behind_proxy(simple_api_spec_dir, aiohttp_client):
+        """ Verify the swagger.json file is returned with base_path updated
+            according to X-Forwarded-Path header. """
+        app = AioHttpApp(__name__, port=5001,
+                         specification_dir=simple_api_spec_dir,
+                         debug=True)
+        api = app.add_api('swagger.yaml')
+
+        aio = app.app
+        reverse_proxied = XPathForwarded()
+        aio.middlewares.append(reverse_proxied.middleware)
+
+        app_client = yield from aiohttp_client(app.app)
+        headers = {'X-Forwarded-Path': '/behind/proxy'}
+
+        swagger_ui = yield from app_client.get('/v1.0/ui/', headers=headers)
+        assert swagger_ui.status == 200
+        assert b'url = "/behind/proxy/v1.0/swagger.json"' in (
+            yield from swagger_ui.read()
+        )
+
+        swagger_json = yield from app_client.get('/v1.0/swagger.json',
+                                                 headers=headers)
+        assert swagger_json.status == 200
+        assert swagger_json.headers.get('Content-Type') == 'application/json'
+        json_ = yield from swagger_json.json()
+
+        assert api.specification.raw['basePath'] == '/v1.0', \
+            "Original specifications should not have been changed"
+
+        assert json_.get('basePath') == '/behind/proxy/v1.0', \
+            "basePath should contains original URI"
+
+        json_['basePath'] = api.specification.raw['basePath']
+        assert api.specification.raw == json_, \
+            "Only basePath should have been updated"
+
+
+    @asyncio.coroutine
+    def test_openapi_json_behind_proxy(simple_api_spec_dir, aiohttp_client):
+        """ Verify the swagger.json file is returned with base_path updated
+            according to X-Forwarded-Path header. """
+        app = AioHttpApp(__name__, port=5001,
+                         specification_dir=simple_api_spec_dir,
+                         debug=True)
+
+        api = app.add_api('openapi.yaml')
+
+        aio = app.app
+        reverse_proxied = XPathForwarded()
+        aio.middlewares.append(reverse_proxied.middleware)
+
+        app_client = yield from aiohttp_client(app.app)
+        headers = {'X-Forwarded-Path': '/behind/proxy'}
+
+        swagger_ui = yield from app_client.get('/v1.0/ui/', headers=headers)
+        assert swagger_ui.status == 200
+        assert b'url: "/behind/proxy/v1.0/openapi.json"' in (
+            yield from swagger_ui.read()
+        )
+
+        swagger_json = yield from app_client.get('/v1.0/openapi.json',
+                                                 headers=headers)
+        assert swagger_json.status == 200
+        assert swagger_json.headers.get('Content-Type') == 'application/json'
+        json_ = yield from swagger_json.json()
+
+        assert json_.get('servers', [{}])[0].get('url') == '/behind/proxy/v1.0', \
+            "basePath should contains original URI"
+
+        url = api.specification.raw.get('servers', [{}])[0].get('url')
+        assert url != '/behind/proxy/v1.0', \
+            "Original specifications should not have been changed"
+
+        json_['servers'] = api.specification.raw.get('servers')
+        assert api.specification.raw == json_, \
+            "Only there servers block should have been updated"

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -61,7 +61,7 @@ def test_openapi_yaml_behind_proxy(reverse_proxied_app):
     )
     assert openapi_yaml.status_code == 200
     assert openapi_yaml.headers.get('Content-Type') == 'text/yaml'
-    spec = yaml.load(openapi_yaml.data.decode('utf-8'))
+    spec = yaml.load(openapi_yaml.data.decode('utf-8'), Loader=yaml.BaseLoader)
 
     if reverse_proxied_app._spec_file == 'swagger.yaml':
         assert b'url = "/behind/proxy/v1.0/swagger.json"' in swagger_ui.data


### PR DESCRIPTION
Fixes #820 
Fixes #392 
Fixes #527 

Changes proposed in this pull request:
 - change swagger-ui, and openapi spec location to build the path using `url_for`
 - modify the openapi spec `basePath` or `servers` block to include the reversed api path
 - modify the swagger-ui page to load the reversed openapi spec using `url_for`
 - add a openapi3/reverseproxy example
 - add a openapi3/reverseproxy_aiohttp example

Thanks to @Jyhess for the collaboration, tests, and review!