### PR TITLE
Fix case sensitive headers

### DIFF
--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -171,7 +171,7 @@ class AioHttpApi(AbstractAPI):
                      extra={'has_body': req.has_body, 'url': url})
 
         query = parse_qs(req.rel_url.query_string)
-        headers = {k.decode(): v.decode() for k, v in req.raw_headers}
+        headers = req.headers
         body = None
         if req.body_exists:
             body = yield from req.read()

--- a/tests/aiohttp/test_aiohttp_api_secure.py
+++ b/tests/aiohttp/test_aiohttp_api_secure.py
@@ -49,3 +49,28 @@ def test_secure_app(oauth_requests, aiohttp_api_spec_dir, aiohttp_client):
 
     assert post_hello.status == 200
     assert (yield from post_hello.read()) == b'{"greeting":"Hello jsantos"}'
+
+    headers = {'authorization': 'Bearer 100'}
+    post_hello = yield from app_client.post(
+        '/v1.0/greeting/jsantos',
+        headers=headers
+    )
+
+    assert post_hello.status == 200, "Authorization header in lower case should be accepted"
+    assert (yield from post_hello.read()) == b'{"greeting":"Hello jsantos"}'
+
+    headers = {'AUTHORIZATION': 'Bearer 100'}
+    post_hello = yield from app_client.post(
+        '/v1.0/greeting/jsantos',
+        headers=headers
+    )
+
+    assert post_hello.status == 200, "Authorization header in upper case should be accepted"
+    assert (yield from post_hello.read()) == b'{"greeting":"Hello jsantos"}'
+
+    no_authorization = yield from app_client.post(
+        '/v1.0/greeting/jsantos',
+    )
+
+    assert no_authorization.status == 401
+    assert no_authorization.content_type == 'application/problem+json'


### PR DESCRIPTION
Fixes #824 .

Changes proposed in this pull request:
 - Use aiohttp headers (in case insensitive dict) instead of copying them in a standard dict.
