### PR TITLE
Add redirect to swagger ui in aiohttp

### DIFF
--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -105,6 +105,14 @@ class AioHttpApi(AbstractAPI):
                 self._get_swagger_ui_home
             )
 
+        async def redirect(request):
+            raise web.HTTPMovedPermanently(location=self.base_path + console_ui_path + '/')
+        self.subapp.router.add_route(
+            'GET',
+            console_ui_path,
+            redirect
+        )
+
         self.subapp.router.add_static(
             console_ui_path + '/',
             path=str(self.options.openapi_console_ui_from_dir),


### PR DESCRIPTION
Fixes # .
It fixes swagger UI endpoint to redirect if not backslash is sended. Flask app does it by default.

Example:
```bash
$ curl localhost:8080/v1/ui -vvv
*   Trying ::1...
* TCP_NODELAY set
* connect to ::1 port 8080 failed: Connection refused
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /v1/ui HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.62.0
> Accept: */*
> 
< HTTP/1.1 301 Moved Permanently
< Content-Type: text/plain; charset=utf-8
< Location: /v1/ui/
< Content-Length: 22
< Date: Mon, 17 Dec 2018 23:18:41 GMT
< Server: Python/3.7 aiohttp/3.4.4
< 
* Connection #0 to host localhost left intact
301: Moved Permanently
```



Changes proposed in this pull request:
- replace `/ui` endpoint by a redirection to `/ui/`.

