### PR TITLE
Fix: #772. Serving yaml spec.

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -101,6 +101,7 @@ class AbstractAPI(object):
 
         if self.options.openapi_spec_available:
             self.add_openapi_json()
+            self.add_openapi_yaml()
 
         if self.options.openapi_console_ui_available:
             self.add_swagger_ui()

--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -12,7 +12,7 @@ from connexion.apis.abstract import AbstractAPI
 from connexion.exceptions import OAuthProblem
 from connexion.handlers import AuthErrorHandler
 from connexion.lifecycle import ConnexionRequest, ConnexionResponse
-from connexion.utils import Jsonifier, is_json_mimetype
+from connexion.utils import Jsonifier, is_json_mimetype, yamldumper
 
 try:
     import ujson as json
@@ -77,12 +77,37 @@ class AioHttpApi(AbstractAPI):
             self._get_openapi_json
         )
 
+    def add_openapi_yaml(self):
+        """
+        Adds openapi json to {base_path}/openapi.json
+             (or {base_path}/swagger.json for swagger2)
+        """
+        if not self.options.openapi_spec_path.endswith("json"):
+            return
+
+        openapi_spec_path_yaml = self.options.openapi_spec_path[:-len("json")] + "yaml"
+        logger.debug('Adding spec yaml: %s/%s', self.base_path,
+                     openapi_spec_path_yaml)
+        self.subapp.router.add_route(
+            'GET',
+            openapi_spec_path_yaml,
+            self._get_openapi_yaml
+        )
+
     @asyncio.coroutine
     def _get_openapi_json(self, req):
         return web.Response(
             status=200,
             content_type='application/json',
             body=self.jsonifier.dumps(self.specification.raw)
+        )
+
+    @asyncio.coroutine
+    def _get_openapi_yaml(self, req):
+        return web.Response(
+            status=200,
+            content_type='text/yaml',
+            body=yamldumper(self.specification.raw)
         )
 
     def add_swagger_ui(self):

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -10,7 +10,7 @@ from connexion.apis.abstract import AbstractAPI
 from connexion.decorators.produces import NoContent
 from connexion.handlers import AuthErrorHandler
 from connexion.lifecycle import ConnexionRequest, ConnexionResponse
-from connexion.utils import Jsonifier, is_json_mimetype
+from connexion.utils import Jsonifier, is_json_mimetype, yamldumper
 
 logger = logging.getLogger('connexion.apis.flask_api')
 
@@ -38,6 +38,28 @@ class FlaskApi(AbstractAPI):
         self.blueprint.add_url_rule(self.options.openapi_spec_path,
                                     endpoint_name,
                                     lambda: flask.jsonify(self.specification.raw))
+
+    def add_openapi_yaml(self):
+        """
+        Adds spec yaml to {base_path}/swagger.yaml
+        or {base_path}/openapi.yaml (for oas3)
+        """
+        if not self.options.openapi_spec_path.endswith("json"):
+            return
+
+        openapi_spec_path_yaml = self.options.openapi_spec_path[:-len("json")] + "yaml"
+        logger.debug('Adding spec yaml: %s/%s', self.base_path,
+                     openapi_spec_path_yaml)
+        endpoint_name = "{name}_openapi_yaml".format(name=self.blueprint.name)
+        self.blueprint.add_url_rule(
+            openapi_spec_path_yaml,
+            endpoint_name,
+            lambda: FlaskApi._build_flask_response(
+                status_code=200,
+                content_type="text/yaml",
+                data=yamldumper(self.specification.raw)
+            )
+        )
 
     def add_swagger_ui(self):
         """

--- a/tests/aiohttp/test_aiohttp_simple_api.py
+++ b/tests/aiohttp/test_aiohttp_simple_api.py
@@ -1,6 +1,8 @@
 import asyncio
 import sys
 
+import yaml
+
 import aiohttp.web
 import pytest
 from conftest import TEST_FOLDER
@@ -62,6 +64,22 @@ def test_swagger_json(aiohttp_api_spec_dir, aiohttp_client):
 
 
 @asyncio.coroutine
+def test_swagger_yaml(aiohttp_api_spec_dir, aiohttp_client):
+    """ Verify the swagger.yaml file is returned for default setting passed to app. """
+    app = AioHttpApp(__name__, port=5001,
+                     specification_dir=aiohttp_api_spec_dir,
+                     debug=True)
+    api = app.add_api('swagger_simple.yaml')
+
+    app_client = yield from aiohttp_client(app.app)
+    spec_response = yield from app_client.get('/v1.0/swagger.yaml')
+    data_ = yield from spec_response.read()
+
+    assert spec_response.status == 200
+    assert api.specification.raw == yaml.load(data_)
+
+
+@asyncio.coroutine
 def test_no_swagger_json(aiohttp_api_spec_dir, aiohttp_client):
     """ Verify the swagger.json file is not returned when set to False when creating app. """
     options = {"swagger_json": False}
@@ -74,6 +92,21 @@ def test_no_swagger_json(aiohttp_api_spec_dir, aiohttp_client):
     app_client = yield from aiohttp_client(app.app)
     swagger_json = yield from app_client.get('/v1.0/swagger.json')  # type: flask.Response
     assert swagger_json.status == 404
+
+
+@asyncio.coroutine
+def test_no_swagger_yaml(aiohttp_api_spec_dir, aiohttp_client):
+    """ Verify the swagger.json file is not returned when set to False when creating app. """
+    options = {"swagger_json": False}
+    app = AioHttpApp(__name__, port=5001,
+                     specification_dir=aiohttp_api_spec_dir,
+                     options=options,
+                     debug=True)
+    api = app.add_api('swagger_simple.yaml')
+
+    app_client = yield from aiohttp_client(app.app)
+    spec_response = yield from app_client.get('/v1.0/swagger.yaml')  # type: flask.Response
+    assert spec_response.status == 404
 
 
 @asyncio.coroutine

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -102,6 +102,18 @@ def test_swagger_json_app(simple_api_spec_dir, spec):
 
 
 @pytest.mark.parametrize("spec", SPECS)
+def test_swagger_yaml_app(simple_api_spec_dir, spec):
+    """ Verify the spec yaml file is returned for default setting passed to app. """
+    app = App(__name__, port=5001, specification_dir=simple_api_spec_dir, debug=True)
+    app.add_api(spec)
+    app_client = app.app.test_client()
+    url = '/v1.0/{spec}'
+    url = url.format(spec=spec)
+    spec_response = app_client.get(url)  # type: flask.Response
+    assert spec_response.status_code == 200
+
+
+@pytest.mark.parametrize("spec", SPECS)
 def test_no_swagger_json_app(simple_api_spec_dir, spec):
     """ Verify the spec json file is not returned when set to False when creating app. """
     options = {"serve_spec": False}


### PR DESCRIPTION
@dtkav 

## This PR
Serve yaml spec with a yaml prettifier. 

## It's done
Using separate methods, withouth modifying the openapi_json one.

Fixes #772 



Changes proposed in this pull request:

 - add openapi_yaml endpoint and the associate abstract method
-  add a nice yamldump
 - tests