### PR TITLE
set max aiohttp version to 3.5.1 (until build is fixed)

### DIFF
--- a/requirements-aiohttp.txt
+++ b/requirements-aiohttp.txt
@@ -1,4 +1,4 @@
-aiohttp>=2.2.5
+aiohttp>=2.2.5,<3.5.2
 aiohttp-swagger>=1.0.5
 ujson>=1.35
 aiohttp_jinja2==0.15.0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_requires = [
 swagger_ui_require = 'swagger-ui-bundle>=0.0.2'
 flask_require = 'flask>=0.10.1'
 aiohttp_require = [
-    'aiohttp>=2.3.10',
+    'aiohttp>=2.3.10,<3.5.2',
     'aiohttp-jinja2>=0.14.0'
 ]
 ujson_require = 'ujson>=1.35'


### PR DESCRIPTION
Fixes master

Master is broken because of an aiohttp update upstream:
https://travis-ci.org/zalando/connexion/builds/469438675

Changes proposed in this pull request:
 - add an upper bound on the aiohttp version (<3.5.2)

I want to confirm that this fixes the build, and then we can investigate how to support the newest version.
