### PR TITLE
Remove AioHttp deprecation warning

### DIFF
--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -42,7 +42,6 @@ def oauth_problem_middleware(request, handler):
 class AioHttpApi(AbstractAPI):
     def __init__(self, *args, **kwargs):
         self.subapp = web.Application(
-            debug=kwargs.get('debug', False),
             middlewares=[oauth_problem_middleware]
         )
         AbstractAPI.__init__(self, *args, **kwargs)

--- a/connexion/apps/aiohttp_app.py
+++ b/connexion/apps/aiohttp_app.py
@@ -20,7 +20,7 @@ class AioHttpApp(AbstractApp):
         self._api_added = False
 
     def create_app(self):
-        return web.Application(debug=self.debug)
+        return web.Application()
 
     def get_root_path(self):
         mod = sys.modules.get(self.import_name)
@@ -79,9 +79,6 @@ class AioHttpApp(AbstractApp):
 
         if debug is not None:
             self.debug = debug
-            self.app._debug = debug
-            for subapp in self.app._subapps:
-                subapp._debug = debug
 
         logger.debug('Starting %s HTTP server..', self.server, extra=vars(self))
 


### PR DESCRIPTION
[debug argument is deprecated](https://github.com/aio-libs/aiohttp/issues/2859) for AioHttp.
Remove it to remove deprecation warnings in logs.
