### PR TITLE
WIP: type hints now requre types to be imported

### DIFF
--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any  # NOQA
 
 import flask
 import six

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -2,6 +2,7 @@ import functools
 import inspect
 import logging
 import re
+from typing import Any  # NOQA
 
 import inflection
 import six

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -6,11 +6,13 @@ import sys
 
 import six
 from jsonschema import Draft4Validator, ValidationError, draft4_format_checker
+from typing import (Any, AnyStr, Union)   # NOQA
 from werkzeug import FileStorage
 
 from ..exceptions import ExtraParameterProblem
 from ..http_facts import FORM_CONTENT_TYPES
 from ..json_schema import Draft4RequestValidator, Draft4ResponseValidator
+from ..lifecycle import ConnexionResponse # NOQA (for type hints)
 from ..problem import problem
 from ..utils import all_json, boolean, is_json_mimetype, is_null, is_nullable
 

--- a/connexion/options.py
+++ b/connexion/options.py
@@ -2,6 +2,8 @@ import logging
 import pathlib
 from typing import Optional  # NOQA
 
+from connexion.decorators.uri_parsing import AbstractURIParser  # NOQA
+
 try:
     from swagger_ui_bundle import (swagger_ui_2_path,
                                    swagger_ui_3_path)

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -1,6 +1,7 @@
 import abc
 import copy
 import pathlib
+from typing import List  # NOQA
 
 import jinja2
 import six


### PR DESCRIPTION
Attempt to fix the build.

Apparently the newest version of flake8 require that types mentioned in comments (type hints) must be imported.

Another path is to disable F821, but I think it's actually a pretty useful error, except in this specific case.
