### PR TITLE
Pin flake8 to avoid needing to import any types mentioned in type hints

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands=
     python setup.py test
 
 [testenv:flake8]
-deps=flake8
+deps=flake8==3.6.0
 commands=python setup.py flake8
 
 [testenv:isort-check]


### PR DESCRIPTION
Attempts to fix the build.

Another attempt is #866 

Long story short, it looks like Flake8 now requires you to import anything mentioned in a type hint comment. This is extra annoying to reconcile across python versions. Hopefully they will resolve this upstream.

Changes proposed in this pull request:
 - Pin Flake8 to avoid nonsense in new version
