### PR TITLE
OAuthResponseProblem -> 401 in AioHttpApp

### DIFF
--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -9,7 +9,7 @@ import aiohttp_jinja2
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPNotFound
 from connexion.apis.abstract import AbstractAPI
-from connexion.exceptions import OAuthProblem, OAuthScopeProblem
+from connexion.exceptions import OAuthProblem, OAuthScopeProblem, OAuthResponseProblem
 from connexion.handlers import AuthErrorHandler
 from connexion.lifecycle import ConnexionRequest, ConnexionResponse
 from connexion.utils import Jsonifier, is_json_mimetype, yamldumper
@@ -30,7 +30,7 @@ logger = logging.getLogger('connexion.apis.aiohttp_api')
 def oauth_problem_middleware(request, handler):
     try:
         response = yield from handler(request)
-    except (OAuthProblem, OAuthScopeProblem) as oauth_error:
+    except (OAuthProblem, OAuthScopeProblem, OAuthResponseProblem) as oauth_error:
         return web.Response(
             status=oauth_error.code,
             body=json.dumps(oauth_error.description).encode(),


### PR DESCRIPTION
Fixes #875  .



Changes proposed in this pull request:

 - invalid api key is now described as 401 with appropriate description instead of generic error 500
