### PR TITLE
Flask API: allow setting content type in response headers

### DIFF
--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -165,6 +165,9 @@ class FlaskApi(AbstractAPI):
     @classmethod
     def _build_flask_response(cls, mimetype=None, content_type=None,
                               headers=None, status_code=None, data=None):
+        # use content type specified in headers, if set
+        content_type = headers.get("Content-Type", content_type) if headers else None
+        mimetype = content_type.rsplit(";", 1)[0] if content_type else mimetype
         kwargs = {
             'mimetype': mimetype,
             'content_type': content_type,


### PR DESCRIPTION
Partially fixes #266 . If this PR is accepted then one way to go forward would be to change `connexion.problem.problem()` to return a `tuple` response instead of a `ConnexionResponse`.


Changes proposed in this pull request:

 - Allow for changing the content type of a response via the header element when using a tuple response from a controller method.
