### PR TITLE
Forward options to the AioHTTP app.

### DIFF
--- a/connexion/apps/aiohttp_app.py
+++ b/connexion/apps/aiohttp_app.py
@@ -87,7 +87,7 @@ class AioHttpApp(AbstractApp):
 
             access_log = options.get('access_log')
 
-            if options.get('use_default_access_log'):
+            if options.pop('use_default_access_log'):
                 access_log = logger
 
             web.run_app(self.app, port=self.port, host=self.host, access_log=access_log, **options)

--- a/connexion/apps/aiohttp_app.py
+++ b/connexion/apps/aiohttp_app.py
@@ -87,7 +87,7 @@ class AioHttpApp(AbstractApp):
 
             access_log = options.get('access_log')
 
-            if options.pop('use_default_access_log'):
+            if options.pop('use_default_access_log', None):
                 access_log = logger
 
             web.run_app(self.app, port=self.port, host=self.host, access_log=access_log, **options)

--- a/connexion/apps/aiohttp_app.py
+++ b/connexion/apps/aiohttp_app.py
@@ -90,6 +90,6 @@ class AioHttpApp(AbstractApp):
             if options.get('use_default_access_log'):
                 access_log = logger
 
-            web.run_app(self.app, port=self.port, host=self.host, access_log=access_log)
+            web.run_app(self.app, port=self.port, host=self.host, access_log=access_log, **options)
         else:
             raise Exception('Server {} not recognized'.format(self.server))

--- a/tests/aiohttp/test_aiohttp_app.py
+++ b/tests/aiohttp/test_aiohttp_app.py
@@ -26,7 +26,7 @@ def test_app_run(web_run_app_mock, aiohttp_api_spec_dir):
     app.run(use_default_access_log=True)
     logger = logging.getLogger('connexion.aiohttp_app')
     assert web_run_app_mock.call_args_list == [
-        mock.call(app.app, port=5001, host='0.0.0.0', access_log=logger)
+        mock.call(app.app, port=5001, host='0.0.0.0', access_log=logger, use_default_access_log=True)
     ]
 
 

--- a/tests/aiohttp/test_aiohttp_app.py
+++ b/tests/aiohttp/test_aiohttp_app.py
@@ -26,7 +26,7 @@ def test_app_run(web_run_app_mock, aiohttp_api_spec_dir):
     app.run(use_default_access_log=True)
     logger = logging.getLogger('connexion.aiohttp_app')
     assert web_run_app_mock.call_args_list == [
-        mock.call(app.app, port=5001, host='0.0.0.0', access_log=logger, use_default_access_log=True)
+        mock.call(app.app, port=5001, host='0.0.0.0', access_log=logger)
     ]
 
 


### PR DESCRIPTION
Changes proposed in this pull request:

 - The `**options` arguments the [`AioHttpApp.run`](https://github.com/zalando/connexion/blob/master/connexion/apps/aiohttp_app.py#L71) method are not forwarded to the [`run_app`](https://github.com/zalando/connexion/blob/master/connexion/apps/aiohttp_app.py#L93) method of the `aiohttp` framework. It is analogous to what is done here: https://github.com/zalando/connexion/blob/master/connexion/apps/flask_app.py#L93, but for the `flask` framework.
