### PR TITLE
fixes basic auth example doc; adds apikey example

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -58,6 +58,8 @@ taken from there, otherwise it's None. This allows authorizing individual
 operations with oauth scope while using basic authentication for
 authentication.
 
+You can find a `minimal Basic Auth example application`_ in Connexion's "examples" folder.
+
 ApiKey Authentication
 ---------------------
 
@@ -66,7 +68,7 @@ With Connexion, the API security definition **must** include a
 semantics as for ``x-basicInfoFunc``, but the function accepts two
 parameters: apikey and required_scopes.
 
-You can find a `minimal Basic Auth example application`_ in Connexion's "examples" folder.
+You can find a `minimal API Key example application`_ in Connexion's "examples" folder.
 
 Bearer Authentication (JWT)
 ---------------------------
@@ -91,4 +93,5 @@ way to start a HTTPS server when using Connexion?
 .. _rfc7662: https://tools.ietf.org/html/rfc7662
 .. _minimal OAuth example application: https://github.com/zalando/connexion/tree/master/examples/swagger2/oauth2
 .. _minimal Basic Auth example application: https://github.com/zalando/connexion/tree/master/examples/swagger2/basicauth
+.. _minimal API Key example application: https://github.com/zalando/connexion/tree/master/examples/oauth2/apikey
 .. _minimal JWT example application: https://github.com/zalando/connexion/tree/master/examples/openapi3/jwt

--- a/examples/openapi3/apikey/README.rst
+++ b/examples/openapi3/apikey/README.rst
@@ -1,0 +1,20 @@
+=======================
+API Key Example
+=======================
+
+Running:
+
+.. code-block:: bash
+
+    $ sudo pip3 install --upgrade connexion[swagger-ui]  # install Connexion from PyPI
+    $ ./app.py
+
+Now open your browser and go to http://localhost:8080/ui/ to see the Swagger UI.
+
+The hardcoded apikey is `asdf1234567890`.
+
+Test it out (in another terminal):
+
+.. code-block:: bash
+
+    $ curl -H 'X-Auth: asdf1234567890' http://localhost:8080/secret

--- a/examples/openapi3/apikey/app.py
+++ b/examples/openapi3/apikey/app.py
@@ -4,28 +4,20 @@ Basic example of a resource server
 '''
 
 import connexion
-from connexion.decorators.security import validate_scope
-from connexion.exceptions import OAuthScopeProblem
+from connexion.exceptions import OAuthProblem
 
 TOKEN_DB = {
     'asdf1234567890': {
-        'uid': 100,
-        'scope': ['secret'],
+        'uid': 100
     }
 }
 
 
 def apikey_auth(token, required_scopes):
-    info = TOKEN_DB.get(token, {})
+    info = TOKEN_DB.get(token, None)
 
-    # TODO: openapi spec doesn't support scopes for `apiKey` securitySchemes
-    # https://swagger.io/docs/specification/authentication/#scopes
-    if required_scopes is not None and not validate_scope(required_scopes, info.get('scope', [])):
-        raise OAuthScopeProblem(
-                description='Provided user doesn\'t have the required access rights',
-                required_scopes=required_scopes,
-                token_scopes=info['scope']
-            )
+    if not info:
+        raise OAuthProblem('Invalid token')
 
     return info
 

--- a/examples/openapi3/apikey/app.py
+++ b/examples/openapi3/apikey/app.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+'''
+Basic example of a resource server
+'''
+
+import connexion
+from connexion.decorators.security import validate_scope
+from connexion.exceptions import OAuthScopeProblem
+
+TOKEN_DB = {
+    'asdf1234567890': {
+        'uid': 100,
+        'scope': ['secret'],
+    }
+}
+
+
+def apikey_auth(token, required_scopes):
+    info = TOKEN_DB.get(token, {})
+
+    # TODO: openapi spec doesn't support scopes for `apiKey` securitySchemes
+    # https://swagger.io/docs/specification/authentication/#scopes
+    if required_scopes is not None and not validate_scope(required_scopes, info.get('scope', [])):
+        raise OAuthScopeProblem(
+                description='Provided user doesn\'t have the required access rights',
+                required_scopes=required_scopes,
+                token_scopes=info['scope']
+            )
+
+    return info
+
+
+def get_secret(user) -> str:
+    return "You are {user} and the secret is 'wbevuec'".format(user=user)
+
+
+if __name__ == '__main__':
+    app = connexion.FlaskApp(__name__)
+    app.add_api('openapi.yaml')
+    app.run(port=8080)

--- a/examples/openapi3/apikey/openapi.yaml
+++ b/examples/openapi3/apikey/openapi.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  title: API Key Example
+  version: '1.0'
+paths:
+  /secret:
+    get:
+      summary: Return secret string
+      operationId: app.get_secret
+      responses:
+        '200':
+          description: secret response
+          content:
+            '*/*':
+              schema:
+                type: string
+      security:
+        - api_key: []
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: X-Auth
+      in: header
+      x-apikeyInfoFunc: app.apikey_auth


### PR DESCRIPTION
Fixes a documentation link issue. The basic auth example link was under the api key example docs. This PR also implements an example for apiKey security scheme.

One question though (there are TODOs in the code I would like to update), the Connexion docs state that the `x-apikeyInfoFunc` method takes two parameters, `apikey` and `required scopes`. In testing, the required scopes are always None, and after looking at the openapi spec (https://swagger.io/docs/specification/authentication/#scopes) it appears that scopes are not used for the api key scheme.

Should the `x-apikeyInfoFunc` method not take in a `required_scopes` arg? 