### PR TITLE
Fix return type docstring for get_response

### DIFF
--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -124,7 +124,7 @@ class FlaskApi(AbstractAPI):
         pass the information needed to recreate it.
 
         :type operation_handler_result: flask.Response | (flask.Response, int) | (flask.Response, int, dict)
-        :rtype: ConnexionRequest
+        :rtype: ConnexionResponse
         """
         logger.debug('Getting data and status code',
                      extra={


### PR DESCRIPTION
Changes proposed in this pull request:

 - Fix return type docstring in `connexion.apis.flask_api.FlaskApi.get_response` so editors/IDEs don't raise warnings when type hinting 
