### PR TITLE
Bump flask to 0.12.3 for CVE-2018-1000656

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requires = [
 ]
 
 swagger_ui_require = 'swagger-ui-bundle>=0.0.2'
-flask_require = 'flask>=0.10.1'
+flask_require = 'flask>=0.12.3'
 aiohttp_require = [
     'aiohttp>=2.3.10,<3.5.2',
     'aiohttp-jinja2>=0.14.0'


### PR DESCRIPTION
Fixes #913  .



Changes proposed in this pull request:

 - update flask to >= 0.12.3
