### PR TITLE
Mention pythonic_params in request docs

### DIFF
--- a/docs/request.rst
+++ b/docs/request.rst
@@ -54,6 +54,38 @@ of the endpoint parameter `message` to your view function.
 
 Connexion will also use default values if they are provided.
 
+If you want to use a parameter name that collides with a Python built-in,
+you can enable the `pythonic_params` option:
+
+.. code-block:: python
+    app = connexion.FlaskApp(__name__)
+    app.add_api('api.yaml', ..., pythonic_params=True)
+
+With this option enabled, Connexion firstly converts *CamelCase* names
+to *snake_case*. Secondly it looks to see if the name matches a known built-in
+and if it does it appends an underscore to the name.
+
+As example you have an endpoint specified as:
+
+.. code-block:: yaml
+    paths:
+      /foo:
+        get:
+          operationId: api.foo_get
+          parameters:
+            - name: filter
+              description: Some filter.
+              in: query
+              type: string
+              required: true
+And the view function:
+
+.. code-block:: python
+    # api.py file
+    def foo_get(filter_):
+        # do something
+        return 'You send the filter: {}'.format(filter_), 200
+
 .. note:: In the OpenAPI 3.x.x spec, the requestBody does not have a name.
           By default it will be passed in as 'body'. You can optionally
           provide the x-body-name parameter in your requestBody schema


### PR DESCRIPTION
Fixes #929

There was no documentation about preventing naming collisions between parameter names and python built-ins with the `pythonic_params` option.
