### PR TITLE
Add swagger_ui_config option to pass config to the Swagger UI

### DIFF
--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -139,6 +139,13 @@ class AioHttpApi(AbstractAPI):
                 self._get_swagger_ui_home
             )
 
+        if self.options.openapi_console_ui_config is not None:
+            self.subapp.router.add_route(
+                'GET',
+                console_ui_path + '/swagger-ui-config.json',
+                self._get_swagger_ui_config
+            )
+
         # we have to add an explicit redirect instead of relying on the
         # normalize_path_middleware because we also serve static files
         # from this dir (below)
@@ -166,8 +173,20 @@ class AioHttpApi(AbstractAPI):
     @aiohttp_jinja2.template('index.j2')
     @asyncio.coroutine
     def _get_swagger_ui_home(self, req):
-        return {'openapi_spec_url': (self.base_path +
-                                     self.options.openapi_spec_path)}
+        template_variables = {
+            'openapi_spec_url': (self.base_path + self.options.openapi_spec_path)
+        }
+        if self.options.openapi_console_ui_config is not None:
+            template_variables['configUrl'] = 'swagger-ui-config.json'
+        return template_variables
+
+    @asyncio.coroutine
+    def _get_swagger_ui_config(self, req):
+        return web.Response(
+            status=200,
+            content_type='text/json',
+            body=self.jsonifier.dumps(self.options.openapi_console_ui_config)
+        )
 
     def add_auth_on_not_found(self, security, security_definitions):
         """

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -69,6 +69,15 @@ class FlaskApi(AbstractAPI):
                      self.base_path,
                      console_ui_path)
 
+        if self.options.openapi_console_ui_config is not None:
+            config_endpoint_name = "{name}_swagger_ui_config".format(name=self.blueprint.name)
+            config_file_url = '/{console_ui_path}/swagger-ui-config.json'.format(
+                console_ui_path=console_ui_path)
+
+            self.blueprint.add_url_rule(config_file_url,
+                                        config_endpoint_name,
+                                        lambda: flask.jsonify(self.options.openapi_console_ui_config))
+
         static_endpoint_name = "{name}_swagger_ui_static".format(name=self.blueprint.name)
         static_files_url = '/{console_ui_path}/<path:filename>'.format(
             console_ui_path=console_ui_path)
@@ -78,8 +87,8 @@ class FlaskApi(AbstractAPI):
                                     self._handlers.console_ui_static_files)
 
         index_endpoint_name = "{name}_swagger_ui_index".format(name=self.blueprint.name)
-        console_ui_url = '/{swagger_url}/'.format(
-            swagger_url=self.options.openapi_console_ui_path.strip('/'))
+        console_ui_url = '/{console_ui_path}/'.format(
+            console_ui_path=console_ui_path)
 
         self.blueprint.add_url_rule(console_ui_url,
                                     index_endpoint_name,
@@ -299,10 +308,12 @@ class InternalHandlers(object):
 
         :return:
         """
-        return flask.render_template(
-            'index.j2',
-            openapi_spec_url=(self.base_path + self.options.openapi_spec_path)
-        )
+        template_variables = {
+            'openapi_spec_url': (self.base_path + self.options.openapi_spec_path)
+        }
+        if self.options.openapi_console_ui_config is not None:
+            template_variables['configUrl'] = 'swagger-ui-config.json'
+        return flask.render_template('index.j2', **template_variables)
 
     def console_ui_static_files(self, filename):
         """

--- a/connexion/options.py
+++ b/connexion/options.py
@@ -112,6 +112,16 @@ class ConnexionOptions(object):
         return self._options.get('swagger_path', self.swagger_ui_local_path)
 
     @property
+    def openapi_console_ui_config(self):
+        # type: () -> dict
+        """
+        Custom OpenAPI Console UI config.
+
+        Default: None
+        """
+        return self._options.get('swagger_ui_config', None)
+
+    @property
     def uri_parser_class(self):
         # type: () -> AbstractURIParser
         """

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -72,6 +72,18 @@ You can also disable it at the API level:
     app = connexion.FlaskApp(__name__, specification_dir='openapi/')
     app.add_api('my_api.yaml', options=options)
 
+You can pass custom Swagger UI `Configuration Parameters`_ like e.g.
+`displayOperationId` through the `swagger_ui_config` option:
+
+.. code-block:: python
+
+    options = {"swagger_ui_config": {"displayOperationId": True}}
+    app = connexion.FlaskApp(__name__, specification_dir='openapi/',
+                        options=options)
+
+
+.. _Configuration Parameters: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/#parameters
+
 Server Backend
 --------------
 By default connexion uses the default flask server but you can also use Tornado_ or gevent_ as the HTTP server, to do so set server


### PR DESCRIPTION
Fixes #841 by add an option `swagger_ui_config` to pass config parameters to the Swagger UI . 

This is done by providing a `swagger-ui-config.json` endpoint with the contents of the `swagger_ui_config` option. This file is then referenced via the `configUrl` parameter in the Swagger UI `index.j2` template.

Changes proposed in this pull request:

 - Add `swagger_ui_config` option  to pass config parameters to the Swagger UI
