### PR TITLE
Fix aiohttp upgrade

### DIFF
--- a/requirements-aiohttp.txt
+++ b/requirements-aiohttp.txt
@@ -1,4 +1,4 @@
-aiohttp>=2.2.5,<3.5.2
+aiohttp>=2.2.5
 aiohttp-swagger>=1.0.5
 ujson>=1.35
 aiohttp_jinja2==0.15.0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_requires = [
 swagger_ui_require = 'swagger-ui-bundle>=0.0.2'
 flask_require = 'flask>=0.10.1'
 aiohttp_require = [
-    'aiohttp>=2.3.10,<3.5.2',
+    'aiohttp>=2.3.10',
     'aiohttp-jinja2>=0.14.0'
 ]
 ujson_require = 'ujson>=1.35'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -262,6 +262,7 @@ def test_run_with_wsgi_containers(mock_app_run, spec_file):
 def test_run_with_aiohttp_not_installed(mock_app_run, spec_file):
     import sys
     aiohttp_bkp = sys.modules.pop('aiohttp', None)
+    sys.modules['aiohttp'] = None
 
     runner = CliRunner()
 


### PR DESCRIPTION
Fix test_run_with_aiohttp_not_installed with aiohttp 3.5.2+.

The error was prevented by requiring `aiohttp<3.5.2` in #844.
Somewhere between 3.5.1 and 3.5.2, this aiohttp reimport started succeeding.
I used pycharm's debugger to determine that it is this import that was successfully re-importing aiohttp.
https://github.com/zalando/connexion/blob/ff3adb393c67dea51a735ef3211794084db3623e/connexion/cli.py#L151-L155

It's not clear which change caused the issue, but I would guess one of these:

- aio-libs/aiohttp#3469 (Remove wildcard imports)
- aio-libs/aiohttp#3464 (Don't suppress gunicorn cleanup errors)
- aio-libs/aiohttp#3471 (Refactor workers)
- aio-libs/aiohttp#3500 (Ignore done tasks)

Changes proposed in this pull request:

 - Revert #844 
 - Also set `sys.modules['aiohttp'] = None` in the test
 - Upgrade aiohttp
