### PR TITLE
Fix for discarded form data

### DIFF
--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -5,6 +5,7 @@ from connexion.operations.abstract import AbstractOperation
 
 from ..decorators.uri_parsing import OpenAPIURIParser
 from ..utils import deep_get, is_null, is_nullable, make_type
+from ..http_facts import FORM_CONTENT_TYPES
 
 logger = logging.getLogger("connexion.operations.openapi3")
 
@@ -273,6 +274,9 @@ class OpenAPIOperation(AbstractOperation):
 
         if x_body_name in arguments or has_kwargs:
             return {x_body_name: res}
+        # If the content type is "multipart/form-data" return the properties as-is
+        if self.consumes[0] in FORM_CONTENT_TYPES:
+            return res
         return {}
 
     def _sanitize_body_argument(self, body_arg, body_props, additional_props, sanitize):


### PR DESCRIPTION
Attempt to fix a situation where form data is thrown away when the requestBody has no name.

This PR fixes a problem I'm having where a POST requestBody without a name is being discarded. I'm not sure if this is the correct way to do it, but this solves my problem. Please let me know if you know of a better way of doing this.

See issue #935 for more information about this.

Changes proposed in this pull request:

 - Return parameters when the content type is "multipart/form-data"