### PR TITLE
Add sanitized_params option to allow disabling sanitization

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -35,7 +35,8 @@ class AbstractAPI(object):
     def __init__(self, specification, base_path=None, arguments=None,
                  validate_responses=False, strict_validation=False, resolver=None,
                  auth_all_paths=False, debug=False, resolver_error_handler=None,
-                 validator_map=None, pythonic_params=False, pass_context_arg_name=None, options=None):
+                 validator_map=None, pythonic_params=False, sanitized_params=True,
+                 pass_context_arg_name=None, options=None):
         """
         :type specification: pathlib.Path | dict
         :type base_path: str | None
@@ -53,6 +54,8 @@ class AbstractAPI(object):
         :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended
         to any shadowed built-ins
         :type pythonic_params: bool
+        :param sanitized_params: When True convert parameter names into sanitized Python safe variable names
+        :type sanitized_params: bool
         :param options: New style options dictionary.
         :type options: dict | None
         :param pass_context_arg_name: If not None URL request handling functions with an argument matching this name
@@ -95,6 +98,9 @@ class AbstractAPI(object):
 
         logger.debug('Pythonic params: %s', str(pythonic_params))
         self.pythonic_params = pythonic_params
+
+        logger.debug('Sanitized params: %s', str(sanitized_params))
+        self.sanitized_params = sanitized_params
 
         logger.debug('pass_context_arg_name: %s', pass_context_arg_name)
         self.pass_context_arg_name = pass_context_arg_name
@@ -167,6 +173,7 @@ class AbstractAPI(object):
             validator_map=self.validator_map,
             strict_validation=self.strict_validation,
             pythonic_params=self.pythonic_params,
+            sanitized_params=self.sanitized_params,
             uri_parser_class=self.options.uri_parser_class,
             pass_context_arg_name=self.pass_context_arg_name
         )

--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -87,8 +87,8 @@ class AbstractApp(object):
     def add_api(self, specification, base_path=None, arguments=None,
                 auth_all_paths=None, validate_responses=False,
                 strict_validation=False, resolver=None, resolver_error=None,
-                pythonic_params=False, pass_context_arg_name=None, options=None,
-                validator_map=None):
+                pythonic_params=False, sanitized_params=True, pass_context_arg_name=None,
+                options=None, validator_map=None):
         """
         Adds an API to the application based on a swagger file or API dict
 
@@ -111,6 +111,8 @@ class AbstractApp(object):
         :type resolver_error: int | None
         :param pythonic_params: When True CamelCase parameters are converted to snake_case
         :type pythonic_params: bool
+        :param sanitized_params: When True convert parameter names into sanitized Python safe variable names
+        :type sanitized_params: bool
         :param options: New style options dictionary.
         :type options: dict | None
         :param pass_context_arg_name: Name of argument in handler functions to pass request context to.
@@ -151,6 +153,7 @@ class AbstractApp(object):
                            debug=self.debug,
                            validator_map=validator_map,
                            pythonic_params=pythonic_params,
+                           sanitized_params=sanitized_params,
                            pass_context_arg_name=pass_context_arg_name,
                            options=api_options.as_dict())
         return api

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -58,7 +58,7 @@ def snake_and_shadow(name):
     return snake
 
 
-def parameter_to_arg(operation, function, pythonic_params=False,
+def parameter_to_arg(operation, function, pythonic_params=False, sanitized_params=True,
                      pass_context_arg_name=None):
     """
     Pass query and body parameters as keyword arguments to handler function.
@@ -69,6 +69,8 @@ def parameter_to_arg(operation, function, pythonic_params=False,
     :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended to
     any shadowed built-ins
     :type pythonic_params: bool
+    :param sanitized_params: When True convert parameter names into sanitized Python safe variable names
+    :type sanitized_params: bool
     :param pass_context_arg_name: If not None URL and function has an argument matching this name, the framework's
     request context will be passed as that argument.
     :type pass_context_arg_name: str|None
@@ -82,7 +84,10 @@ def parameter_to_arg(operation, function, pythonic_params=False,
         name = name and snake_and_shadow(name)
         return sanitized(name)
 
-    sanitize = pythonic if pythonic_params else sanitized
+    def unsanitized(name):
+        return name
+
+    sanitize = pythonic if pythonic_params else sanitized if sanitized_params else unsanitized
     arguments, has_kwargs = inspect_function_arguments(function)
 
     @functools.wraps(function)

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -45,8 +45,8 @@ class AbstractOperation(SecureOperation):
                  app_security=None, security_schemes=None,
                  validate_responses=False, strict_validation=False,
                  randomize_endpoint=None, validator_map=None,
-                 pythonic_params=False, uri_parser_class=None,
-                 pass_context_arg_name=None):
+                 pythonic_params=False, sanitized_params=True,
+                 uri_parser_class=None, pass_context_arg_name=None):
         """
         :param api: api that this operation is attached to
         :type api: apis.AbstractAPI
@@ -74,6 +74,8 @@ class AbstractOperation(SecureOperation):
         :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended
         to any shadowed built-ins
         :type pythonic_params: bool
+        :param sanitized_params: When True convert parameter names into sanitized Python safe variable names
+        :type sanitized_params: bool
         :param uri_parser_class: class to use for uri parseing
         :type uri_parser_class: AbstractURIParser
         :param pass_context_arg_name: If not None will try to inject the request context to the function using this
@@ -90,6 +92,7 @@ class AbstractOperation(SecureOperation):
         self._validate_responses = validate_responses
         self._strict_validation = strict_validation
         self._pythonic_params = pythonic_params
+        self._sanitized_params = sanitized_params
         self._uri_parser_class = uri_parser_class
         self._pass_context_arg_name = pass_context_arg_name
         self._randomize_endpoint = randomize_endpoint
@@ -165,6 +168,13 @@ class AbstractOperation(SecureOperation):
         If True, convert CamelCase into pythonic_variable_names
         """
         return self._pythonic_params
+
+    @property
+    def sanitized_params(self):
+        """
+        If True, convert parameter names into sanitized Python safe variable names
+        """
+        return self._sanitized_params
 
     @property
     def validate_responses(self):
@@ -347,7 +357,7 @@ class AbstractOperation(SecureOperation):
         """
         function = parameter_to_arg(
             self, self._resolution.function, self.pythonic_params,
-            self._pass_context_arg_name
+            self.sanitized_params, self._pass_context_arg_name
         )
 
         if self.validate_responses:

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -18,7 +18,8 @@ class OpenAPIOperation(AbstractOperation):
     def __init__(self, api, method, path, operation, resolver, path_parameters=None,
                  app_security=None, components=None, validate_responses=False,
                  strict_validation=False, randomize_endpoint=None, validator_map=None,
-                 pythonic_params=False, uri_parser_class=None, pass_context_arg_name=None):
+                 pythonic_params=False, sanitized_params=True, uri_parser_class=None,
+                 pass_context_arg_name=None):
         """
         This class uses the OperationID identify the module and function that will handle the operation
 
@@ -54,6 +55,8 @@ class OpenAPIOperation(AbstractOperation):
         :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended
         to any shadowed built-ins
         :type pythonic_params: bool
+        :param sanitized_params: When True convert parameter names into sanitized Python safe variable names
+        :type sanitized_params: bool
         :param uri_parser_class: class to use for uri parseing
         :type uri_parser_class: AbstractURIParser
         :param pass_context_arg_name: If not None will try to inject the request context to the function using this
@@ -85,6 +88,7 @@ class OpenAPIOperation(AbstractOperation):
             randomize_endpoint=randomize_endpoint,
             validator_map=validator_map,
             pythonic_params=pythonic_params,
+            sanitized_params=sanitized_params,
             uri_parser_class=uri_parser_class,
             pass_context_arg_name=pass_context_arg_name
         )

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -27,7 +27,7 @@ class Swagger2Operation(AbstractOperation):
                  definitions=None, parameter_definitions=None,
                  response_definitions=None, validate_responses=False, strict_validation=False,
                  randomize_endpoint=None, validator_map=None, pythonic_params=False,
-                 uri_parser_class=None, pass_context_arg_name=None):
+                 sanitized_params=True, uri_parser_class=None, pass_context_arg_name=None):
         """
         :param api: api that this operation is attached to
         :type api: apis.AbstractAPI
@@ -68,6 +68,8 @@ class Swagger2Operation(AbstractOperation):
         :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended
         to any shadowed built-ins
         :type pythonic_params: bool
+        :param sanitized_params: When True convert parameter names into sanitized Python safe variable names
+        :type sanitized_params: bool
         :param uri_parser_class: class to use for uri parseing
         :type uri_parser_class: AbstractURIParser
         :param pass_context_arg_name: If not None will try to inject the request context to the function using this
@@ -92,6 +94,7 @@ class Swagger2Operation(AbstractOperation):
             randomize_endpoint=randomize_endpoint,
             validator_map=validator_map,
             pythonic_params=pythonic_params,
+            sanitized_params=sanitized_params,
             uri_parser_class=uri_parser_class,
             pass_context_arg_name=pass_context_arg_name
         )

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -412,6 +412,29 @@ def test_parameters_snake_case(snake_case_app):
     resp = app_client.get('/v1.0/test-get-query-shadow?list=123')
     assert resp.status_code == 200
 
+def test_parameters_unsanitized(unsanitized_app):
+    app_client = unsanitized_app.app.test_client()
+    headers = {'Content-type': 'application/json'}
+
+    data = {'my_key': ['test']}
+    resp = app_client.post('/v1.0/test-post-body-unsanitized', headers=headers, data=json.dumps(data))
+    assert resp.status_code == 200
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == data
+
+    data = {'my-key': ['test']}
+    resp = app_client.post('/v1.0/test-post-body-unsanitized', headers=headers, data=json.dumps(data))
+    assert resp.status_code == 200
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == data
+
+    data = {'myKey': ['test']}
+    resp = app_client.post('/v1.0/test-post-body-unsanitized', headers=headers, data=json.dumps(data))
+    assert resp.status_code == 200
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == data
+
+    data = {'$id': ['test']}
+    resp = app_client.post('/v1.0/test-post-body-unsanitized', headers=headers, data=json.dumps(data))
+    assert resp.status_code == 200
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == data
 
 def test_get_unicode_request(simple_app):
     """Regression test for Python 2 UnicodeEncodeError bug during parameter parsing."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,6 +122,12 @@ def snake_case_app(request):
                                   validate_responses=True,
                                   pythonic_params=True)
 
+@pytest.fixture(scope="session", params=SPECS)
+def unsanitized_app(request):
+    return build_app_from_fixture('unsanitized', request.param,
+                                  validate_responses=True,
+                                  sanitized_params=False)
+
 
 @pytest.fixture(scope="session", params=SPECS)
 def invalid_resp_allowed_app(request):

--- a/tests/fakeapi/unsanitized.py
+++ b/tests/fakeapi/unsanitized.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+def post_body_unsanitized(body):
+    return body

--- a/tests/fixtures/unsanitized/openapi.yaml
+++ b/tests/fixtures/unsanitized/openapi.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+paths:
+  '/test-post-body-unsanitized':
+    post:
+      summary: Test unsanitized body
+      description: Test unsanitized body
+      operationId: fakeapi.unsanitized.post_body_unsanitized
+      responses:
+        '200':
+          description: Success response
+          content:
+            application/json:
+              schema:
+                type: object
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  type: 'string'
+servers:
+  - url: /v1.0

--- a/tests/fixtures/unsanitized/swagger.yaml
+++ b/tests/fixtures/unsanitized/swagger.yaml
@@ -1,0 +1,29 @@
+swagger: "2.0"
+info:
+  title: "{{title}}"
+  version: "1.0"
+basePath: /v1.0
+paths:
+  /test-post-body-unsanitized:
+    post:
+      summary: Test unsanitized body
+      description: Test unsanitized body
+      operationId: fakeapi.unsanitized.post_body_unsanitized
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success response
+          schema:
+            type: object
+      parameters:
+        - name: body
+          in: body
+          description: body parameter
+          required: true
+          schema:
+            type: object
+            additionalProperties:
+              type: array
+              items:
+                type: string


### PR DESCRIPTION
Fixes #835 .



Changes proposed in this pull request:

 - Ability to disable sanitization

This is useful when the keys in a JSON post body contains characters like `-` or `$`