### PR TITLE
supporting application/json within multipart/form-data request body

### DIFF
--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -2,6 +2,7 @@
 import abc
 import functools
 import logging
+import json
 
 import six
 
@@ -174,6 +175,8 @@ class OpenAPIURIParser(AbstractURIParser):
                 self._resolve_param_duplicates(form_data[k], encoding, 'form')
             if defn and defn["type"] == "array":
                 form_data[k] = self._split(form_data[k], encoding, 'form')
+            elif encoding.get('contentType', None) == 'application/json':
+                form_data[k] = json.loads(form_data[k])
         return form_data
 
     def resolve_query(self, query_data):


### PR DESCRIPTION
adding support to automatically decode json when a multipart/form-data request body contains a field with an application/json content-type

Fixes #935 

Fills in a decode step where there's already a TODO (I think) saying it needs to be done for a variety of types.