### PR TITLE
[#935] supporting application/json within multipart/form-data request body

### DIFF
--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -175,7 +175,7 @@ class OpenAPIURIParser(AbstractURIParser):
                 self._resolve_param_duplicates(form_data[k], encoding, 'form')
             if defn and defn["type"] == "array":
                 form_data[k] = self._split(form_data[k], encoding, 'form')
-            elif encoding.get('contentType', None) == 'application/json':
+            elif 'contentType' in encoding && utils.all_json([encoding.get['contentType'])]:
                 form_data[k] = json.loads(form_data[k])
         return form_data
 

--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -2,7 +2,7 @@
 import abc
 import functools
 import logging
-import json
+from .. import utils
 
 import six
 

--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -175,7 +175,7 @@ class OpenAPIURIParser(AbstractURIParser):
                 self._resolve_param_duplicates(form_data[k], encoding, 'form')
             if defn and defn["type"] == "array":
                 form_data[k] = self._split(form_data[k], encoding, 'form')
-            elif 'contentType' in encoding && utils.all_json([encoding.get['contentType'])]:
+            elif 'contentType' in encoding and utils.all_json([encoding.get['contentType'])]:
                 form_data[k] = json.loads(form_data[k])
         return form_data
 

--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -175,7 +175,7 @@ class OpenAPIURIParser(AbstractURIParser):
                 self._resolve_param_duplicates(form_data[k], encoding, 'form')
             if defn and defn["type"] == "array":
                 form_data[k] = self._split(form_data[k], encoding, 'form')
-            elif 'contentType' in encoding and utils.all_json([encoding.get['contentType'])]:
+            elif 'contentType' in encoding and utils.all_json([encoding.get['contentType']]):
                 form_data[k] = json.loads(form_data[k])
         return form_data
 

--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -2,6 +2,7 @@
 import abc
 import functools
 import logging
+import json
 
 import six
 
@@ -174,6 +175,8 @@ class OpenAPIURIParser(AbstractURIParser):
                 self._resolve_param_duplicates(form_data[k], encoding, 'form')
             if defn and defn["type"] == "array":
                 form_data[k] = self._split(form_data[k], encoding, 'form')
+            elif encoding.get('contentType', None) == 'application/json':
+                form_data[k] = json.loads(form_data[k])
         return form_data
 
     def resolve_query(self, query_data):

--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -2,6 +2,7 @@
 import abc
 import functools
 import logging
+import json
 from .. import utils
 
 import six
@@ -175,7 +176,7 @@ class OpenAPIURIParser(AbstractURIParser):
                 self._resolve_param_duplicates(form_data[k], encoding, 'form')
             if defn and defn["type"] == "array":
                 form_data[k] = self._split(form_data[k], encoding, 'form')
-            elif 'contentType' in encoding and utils.all_json([encoding.get['contentType']]):
+            elif 'contentType' in encoding and utils.all_json([encoding.get('contentType')]):
                 form_data[k] = json.loads(form_data[k])
         return form_data
 

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -508,6 +508,12 @@ def post_user(body):
     body.pop('password', None)
     return body
 
+def post_multipart_form(body):
+    x = body['x']
+    x['name'] += "-reply"
+    x['age'] += 10
+    return x
+
 
 def apikey_info(apikey, required_scopes=None):
     if apikey == 'mykey':

--- a/tests/fixtures/json_validation/openapi.yaml
+++ b/tests/fixtures/json_validation/openapi.yaml
@@ -24,6 +24,13 @@ components:
         password:
           type: string
           writeOnly: true
+    X:
+      type: object
+      properties:
+        name:
+          type: string
+        age:
+          type: integer
 
 paths:
   /minlength:
@@ -75,3 +82,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+
+  /multipart_form_json:
+    post:
+      operationId: fakeapi.hello.post_multipart_form
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                x:
+                  $ref: "#/components/schemas/X"
+            encoding:
+              x:
+                contentType: "application/json"
+      responses:
+        200:
+          description: Modified Echo
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/X"

--- a/tests/test_json_validation.py
+++ b/tests/test_json_validation.py
@@ -75,3 +75,14 @@ def test_writeonly(json_validation_spec_dir, spec):
     res = app_client.get('/v1.0/user_with_password') # type: flask.Response
     assert res.status_code == 500
     assert json.loads(res.data.decode())['title'] == 'Response body does not conform to specification'
+
+
+@pytest.mark.parametrize("spec", ["openapi.yaml"])
+def test_multipart_form_json(json_validation_spec_dir, spec):
+    app = build_app_from_fixture(json_validation_spec_dir, spec, validate_responses=True)
+    app_client = app.app.test_client()
+
+    res = app_client.post('/v1.0/multipart_form_json', data={'x': json.dumps({"name": "joe", "age": 20})}, content_type='multipart/form-data')
+    assert res.status_code == 200
+    assert json.loads(res.data.decode())['name'] == "joe-reply"
+    assert json.loads(res.data.decode())['age'] == 30


### PR DESCRIPTION
adding support to automatically decode json when a multipart/form-data request body contains a field with an application/json content-type

Fixes #935.



Changes proposed in this pull request:

Fills in a decode step where there's already a TODO (I think) saying it needs to be done for a variety of types.