### PR TITLE
Fix travis deprecation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ envlist =
     isort-check-tests
     flake8
 
-[tox:travis]
+[travis]
 pypy=pypy-min,pypy-pypi
 2.7=py27-min,py27-pypi
 3.4=py34-min,py34-pypi


### PR DESCRIPTION
Fixes (none).

Changes proposed in this pull request:
- remove minor warning in travis output, apparently `[tox:travis]` is deprecated in favor of `[travis]`

From travis logs:
```The [tox:travis] section is deprecated in favor of the "python" key of the [travis] section.```