### PR TITLE
Bump flask to be at least 1.0.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requires = [
 ]
 
 swagger_ui_require = 'swagger-ui-bundle>=0.0.2'
-flask_require = 'flask>=0.10.1'
+flask_require = 'flask>=1.0.4'
 aiohttp_require = [
     'aiohttp>=2.3.10,<3.5.2',
     'aiohttp-jinja2>=0.14.0'

--- a/tests/decorators/test_security.py
+++ b/tests/decorators/test_security.py
@@ -64,14 +64,14 @@ def test_verify_oauth_scopes_remote(monkeypatch):
     session.get = get_tokeninfo_response
     monkeypatch.setattr('connexion.decorators.security.session', session)
 
-    with pytest.raises(OAuthScopeProblem, message="Provided token doesn't have the required scope"):
+    with pytest.raises(OAuthScopeProblem, match="Provided token doesn't have the required scope"):
         wrapped_func(request, ['admin'])
 
     tokeninfo["scope"] += " admin"
     assert wrapped_func(request, ['admin']) is not None
 
     tokeninfo["scope"] = ["foo", "bar"]
-    with pytest.raises(OAuthScopeProblem, message="Provided token doesn't have the required scope"):
+    with pytest.raises(OAuthScopeProblem, match="Provided token doesn't have the required scope"):
         wrapped_func(request, ['admin'])
 
     tokeninfo["scope"].append("admin")
@@ -102,14 +102,14 @@ def test_verify_oauth_scopes_local():
     request = MagicMock()
     request.headers = {"Authorization": "Bearer 123"}
 
-    with pytest.raises(OAuthScopeProblem, message="Provided token doesn't have the required scope"):
+    with pytest.raises(OAuthScopeProblem, match="Provided token doesn't have the required scope"):
         wrapped_func(request, ['admin'])
 
     tokeninfo["scope"] += " admin"
     assert wrapped_func(request, ['admin']) is not None
 
     tokeninfo["scope"] = ["foo", "bar"]
-    with pytest.raises(OAuthScopeProblem, message="Provided token doesn't have the required scope"):
+    with pytest.raises(OAuthScopeProblem, match="Provided token doesn't have the required scope"):
         wrapped_func(request, ['admin'])
 
     tokeninfo["scope"].append("admin")


### PR DESCRIPTION
Fixes #991 .

Changes proposed in this pull request:
- bump `flask` to be at least `1.0.4`

Reasons:
- `flask==0.10.1` was released in 2013, which makes it quite old thus unsupported.
- On Flask webpage you can find an information pointing to `1.x` branch as latest stable
- different tools, including these used in `connexion` progressed leaving Python versions, for which `flask<1.0` has been developed.
