### PR TITLE
Update jsonschema version to 3.0.1 & JSON Schema draft to 7

### DIFF
--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -20,7 +20,7 @@ class ResponseValidator(BaseDecorator):
         :type operation: Operation
         :type mimetype: str
         :param validator: Validator class that should be used to validate passed data
-                          against API schema. Default is jsonschema.Draft4Validator.
+                          against API schema. Default is jsonschema.Draft7Validator.
         :type validator: jsonschema.IValidator
         """
         self.operation = operation

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -5,12 +5,12 @@ import logging
 import sys
 
 import six
-from jsonschema import Draft4Validator, ValidationError, draft4_format_checker
+from jsonschema import Draft7Validator, ValidationError, draft7_format_checker
 from werkzeug import FileStorage
 
 from ..exceptions import ExtraParameterProblem
 from ..http_facts import FORM_CONTENT_TYPES
-from ..json_schema import Draft4RequestValidator, Draft4ResponseValidator
+from ..json_schema import Draft7RequestValidator, Draft7ResponseValidator
 from ..problem import problem
 from ..utils import all_json, boolean, is_json_mimetype, is_null, is_nullable
 
@@ -88,7 +88,7 @@ class RequestBodyValidator(object):
         :param consumes: The list of content types the operation consumes
         :param is_null_value_valid: Flag to indicate if null is accepted as valid value.
         :param validator: Validator class that should be used to validate passed data
-                          against API schema. Default is jsonschema.Draft4Validator.
+                          against API schema. Default is jsonschema.Draft7Validator.
         :type validator: jsonschema.IValidator
         :param strict_validation: Flag indicating if parameters not in spec are allowed
         """
@@ -96,8 +96,8 @@ class RequestBodyValidator(object):
         self.schema = schema
         self.has_default = schema.get('default', False)
         self.is_null_value_valid = is_null_value_valid
-        validatorClass = validator or Draft4RequestValidator
-        self.validator = validatorClass(schema, format_checker=draft4_format_checker)
+        validatorClass = validator or Draft7RequestValidator
+        self.validator = validatorClass(schema, format_checker=draft7_format_checker)
         self.api = api
         self.strict_validation = strict_validation
 
@@ -195,11 +195,11 @@ class ResponseBodyValidator(object):
         """
         :param schema: The schema of the response body
         :param validator: Validator class that should be used to validate passed data
-                          against API schema. Default is jsonschema.Draft4Validator.
+                          against API schema. Default is jsonschema.Draft7Validator.
         :type validator: jsonschema.IValidator
         """
-        ValidatorClass = validator or Draft4ResponseValidator
-        self.validator = ValidatorClass(schema, format_checker=draft4_format_checker)
+        ValidatorClass = validator or Draft7ResponseValidator
+        self.validator = ValidatorClass(schema, format_checker=draft7_format_checker)
 
     def validate_schema(self, data, url):
         # type: (dict, AnyStr) -> Union[ConnexionResponse, None]
@@ -245,13 +245,13 @@ class ParameterValidator(object):
                 del param['required']
             try:
                 if parameter_type == 'formdata' and param.get('type') == 'file':
-                    Draft4Validator(
+                    Draft7Validator(
                         param,
-                        format_checker=draft4_format_checker,
+                        format_checker=draft7_format_checker,
                         types={'file': FileStorage}).validate(converted_value)
                 else:
-                    Draft4Validator(
-                        param, format_checker=draft4_format_checker).validate(converted_value)
+                    Draft7Validator(
+                        param, format_checker=draft7_format_checker).validate(converted_value)
             except ValidationError as exception:
                 debug_msg = 'Error while converting value {converted_value} from param ' \
                             '{type_converted_value} of type real type {param_type} to the declared type {param}'

--- a/connexion/json_schema.py
+++ b/connexion/json_schema.py
@@ -1,7 +1,8 @@
 import collections
 from copy import deepcopy
 
-from jsonschema import Draft4Validator, RefResolver, _utils
+from jsonschema import (Draft4Validator, Draft6Validator, Draft7Validator,
+                        RefResolver, _utils)
 from jsonschema.exceptions import RefResolutionError, ValidationError  # noqa
 from jsonschema.validators import extend
 from openapi_spec_validator.handlers import UrlHandler
@@ -102,6 +103,34 @@ Draft4RequestValidator = extend(Draft4Validator, {
                                 'readOnly': validate_readOnly})
 
 Draft4ResponseValidator = extend(Draft4Validator, {
+                                 'type': validate_type,
+                                 'enum': validate_enum,
+                                 'required': validate_required,
+                                 'writeOnly': validate_writeOnly,
+                                 'x-writeOnly': validate_writeOnly})
+
+
+Draft6RequestValidator = extend(Draft6Validator, {
+                                'type': validate_type,
+                                'enum': validate_enum,
+                                'required': validate_required,
+                                'readOnly': validate_readOnly})
+
+Draft6ResponseValidator = extend(Draft6Validator, {
+                                 'type': validate_type,
+                                 'enum': validate_enum,
+                                 'required': validate_required,
+                                 'writeOnly': validate_writeOnly,
+                                 'x-writeOnly': validate_writeOnly})
+
+
+Draft7RequestValidator = extend(Draft7Validator, {
+                                'type': validate_type,
+                                'enum': validate_enum,
+                                'required': validate_required,
+                                'readOnly': validate_readOnly})
+
+Draft7ResponseValidator = extend(Draft7Validator, {
                                  'type': validate_type,
                                  'enum': validate_enum,
                                  'required': validate_required,

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -56,9 +56,9 @@ draft4 format checker decorator.
 
 .. code-block:: python
 
-    from jsonschema import draft4_format_checker
+    from jsonschema import draft7_format_checker
 
-    @draft4_format_checker.checks('money')
+    @draft7_format_checker.checks('money')
     def is_money(val):
         ...
 

--- a/examples/swagger2/enforcedefaults/enforcedefaults.py
+++ b/examples/swagger2/enforcedefaults/enforcedefaults.py
@@ -4,7 +4,7 @@ import connexion
 import jsonschema
 import six
 from connexion.decorators.validation import RequestBodyValidator
-from connexion.json_schema import Draft4RequestValidator
+from connexion.json_schema import Draft7RequestValidator
 
 
 def echo(data):
@@ -27,13 +27,13 @@ def extend_with_set_default(validator_class):
     return jsonschema.validators.extend(
         validator_class, {'properties': set_defaults})
 
-DefaultsEnforcingDraft4Validator = extend_with_set_default(Draft4RequestValidator)
+DefaultsEnforcingDraft7Validator = extend_with_set_default(Draft7RequestValidator)
 
 
 class DefaultsEnforcingRequestBodyValidator(RequestBodyValidator):
     def __init__(self, *args, **kwargs):
         super(DefaultsEnforcingRequestBodyValidator, self).__init__(
-            *args, validator=DefaultsEnforcingDraft4Validator, **kwargs)
+            *args, validator=DefaultsEnforcingDraft7Validator, **kwargs)
 
 
 validator_map = {

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/Julian/jsonschema.git@v2.6.0#egg=jsonschema
+-e git+https://github.com/Julian/jsonschema.git@v3.0.1#egg=jsonschema
 -e git+https://github.com/pallets/flask.git#egg=flask
 -e git+https://github.com/kennethreitz/requests#egg=requests
 -e git+https://github.com/zalando/python-clickclick.git#egg=clickclick

--- a/setup.py
+++ b/setup.py
@@ -22,14 +22,14 @@ version = read_version('connexion')
 
 install_requires = [
     'clickclick>=1.2',
-    'jsonschema>=2.5.1,<3.0.0',
+    'jsonschema>=3.0.1,<4.0.0',
     'PyYAML>=5.1',
     'requests>=2.9.1',
-    'six>=1.9',
+    'six>=1.11.0',
     'inflection>=0.3.1',
     'pathlib>=1.0.1; python_version < "3.4"',
     'typing>=3.6.1; python_version < "3.6"',
-    'openapi-spec-validator>=0.2.4',
+    'openapi-spec-validator>=0.2.7',
 ]
 
 swagger_ui_require = 'swagger-ui-bundle>=0.0.2'

--- a/tests/decorators/test_validation.py
+++ b/tests/decorators/test_validation.py
@@ -3,8 +3,8 @@ from jsonschema import ValidationError
 from mock import MagicMock
 
 from connexion.decorators.validation import ParameterValidator
-from connexion.json_schema import (Draft4RequestValidator,
-                                   Draft4ResponseValidator)
+from connexion.json_schema import (Draft7RequestValidator,
+                                   Draft7ResponseValidator)
 
 
 def test_get_valid_parameter():
@@ -82,7 +82,7 @@ def test_support_nullable_properties():
         "properties": {"foo": {"type": "string", "x-nullable": True}},
     }
     try:
-        Draft4RequestValidator(schema).validate({"foo": None})
+        Draft7RequestValidator(schema).validate({"foo": None})
     except ValidationError:
         pytest.fail("Shouldn't raise ValidationError")
 
@@ -94,7 +94,7 @@ def test_support_nullable_properties_raises_validation_error():
     }
 
     with pytest.raises(ValidationError):
-        Draft4RequestValidator(schema).validate({"foo": None})
+        Draft7RequestValidator(schema).validate({"foo": None})
 
 
 def test_support_nullable_properties_not_iterable():
@@ -103,7 +103,7 @@ def test_support_nullable_properties_not_iterable():
         "properties": {"foo": {"type": "string", "x-nullable": True}},
     }
     with pytest.raises(ValidationError):
-        Draft4RequestValidator(schema).validate(12345)
+        Draft7RequestValidator(schema).validate(12345)
 
 
 def test_nullable_enum():
@@ -112,7 +112,7 @@ def test_nullable_enum():
         "nullable": True
     }
     try:
-        Draft4RequestValidator(schema).validate(None)
+        Draft7RequestValidator(schema).validate(None)
     except ValidationError:
         pytest.fail("Shouldn't raise ValidationError")
 
@@ -122,7 +122,7 @@ def test_nullable_enum_error():
         "enum": ["foo", 7]
     }
     with pytest.raises(ValidationError):
-        Draft4RequestValidator(schema).validate(None)
+        Draft7RequestValidator(schema).validate(None)
 
 
 def test_writeonly_value():
@@ -131,7 +131,7 @@ def test_writeonly_value():
         "properties": {"foo": {"type": "string", "writeOnly": True}},
     }
     try:
-        Draft4RequestValidator(schema).validate({"foo": "bar"})
+        Draft7RequestValidator(schema).validate({"foo": "bar"})
     except ValidationError:
         pytest.fail("Shouldn't raise ValidationError")
 
@@ -142,7 +142,7 @@ def test_writeonly_value_error():
         "properties": {"foo": {"type": "string", "writeOnly": True}},
     }
     with pytest.raises(ValidationError):
-        Draft4ResponseValidator(schema).validate({"foo": "bar"})
+        Draft7ResponseValidator(schema).validate({"foo": "bar"})
 
 
 def test_writeonly_required():
@@ -152,7 +152,7 @@ def test_writeonly_required():
         "properties": {"foo": {"type": "string", "writeOnly": True}},
     }
     try:
-        Draft4RequestValidator(schema).validate({"foo": "bar"})
+        Draft7RequestValidator(schema).validate({"foo": "bar"})
     except ValidationError:
         pytest.fail("Shouldn't raise ValidationError")
 
@@ -164,4 +164,4 @@ def test_writeonly_required_error():
         "properties": {"foo": {"type": "string", "writeOnly": True}},
     }
     with pytest.raises(ValidationError):
-        Draft4RequestValidator(schema).validate({"bar": "baz"})
+        Draft7RequestValidator(schema).validate({"bar": "baz"})

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -151,7 +151,7 @@ def schema_response_integer(valid):
     if valid == "valid":
         return 3
     else:
-        return 3.0
+        return 3.14
 
 
 def schema_response_number(valid):

--- a/tests/test_json_validation.py
+++ b/tests/test_json_validation.py
@@ -6,7 +6,7 @@ from jsonschema.validators import _utils, extend
 from conftest import build_app_from_fixture
 from connexion import App
 from connexion.decorators.validation import RequestBodyValidator
-from connexion.json_schema import Draft4RequestValidator
+from connexion.json_schema import Draft7RequestValidator
 
 SPECS = ["swagger.yaml", "openapi.yaml"]
 
@@ -14,16 +14,16 @@ SPECS = ["swagger.yaml", "openapi.yaml"]
 def test_validator_map(json_validation_spec_dir, spec):
     def validate_type(validator, types, instance, schema):
         types = _utils.ensure_list(types)
-        errors = Draft4RequestValidator.VALIDATORS['type'](validator, types, instance, schema)
+        errors = Draft7RequestValidator.VALIDATORS['type'](validator, types, instance, schema)
         for e in errors:
             yield e
 
         if 'string' in types and 'minLength' not in schema:
-            errors = Draft4RequestValidator.VALIDATORS['minLength'](validator, 1, instance, schema)
+            errors = Draft7RequestValidator.VALIDATORS['minLength'](validator, 1, instance, schema)
             for e in errors:
                 yield e
 
-    MinLengthRequestValidator = extend(Draft4RequestValidator, {'type': validate_type})
+    MinLengthRequestValidator = extend(Draft7RequestValidator, {'type': validate_type})
 
     class MyRequestBodyValidator(RequestBodyValidator):
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Fixes #983.

**Changes proposed in this pull request:**
- Update `jsonschema` requirement version to `>=3.0.1,4.0.0`
- Update default JSON Schema draft from `4` to `7`

**Related Pull Request(s):**
- https://github.com/p1c2u/openapi-spec-validator/pull/78