### PR TITLE
Updated readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -317,11 +317,11 @@ api options.
 .. code-block:: python
 
    from connexion.decorators.uri_parsing import AlwaysMultiURIParser
-   options = {'uri_parsing_class': AlwaysMultiURIParser}
+   options = {'uri_parser_class': AlwaysMultiURIParser}
    app = connexion.App(__name__, specification_dir='swagger/', options=options)
 
 You can implement your own URI parsing behavior by inheriting from
-``connextion.decorators.uri_parsing.AbstractURIParser``.
+``connexion.decorators.uri_parsing.AbstractURIParser``.
 
 There are a handful of URI parsers included with connection.
 


### PR DESCRIPTION
A few typos in the readme uri_parsing_class instead of uri_parser_class in options example.

Fixes # .

The uri_parser_class example showed the options attribute as 'uri_parsing_class'. Connexion was spelled connextion just below there.

Changes proposed in this pull request:

 -
 -
 -
