### PR TITLE
Test schema corrections

### DIFF
--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -424,7 +424,7 @@ paths:
         - name: items
           in: query
           description: An comma separated array of items
-          style: csv
+          style: form
           explode: true
           schema:
             type: array

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -406,7 +406,8 @@ paths:
         - name: items
           in: query
           description: An comma separated array of items
-          style: simple
+          style: form
+          explode: false
           schema:
             type: array
             default: ["squash", "banana"]

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -371,7 +371,8 @@ paths:
                     type: string
             encoding:
               items:
-                style: simple
+                style: form
+                explode: false
       responses:
         200:
           description: OK

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -1051,7 +1051,7 @@ paths:
     servers:
       - url: http://localhost
     parameters:
-      - $ref: "#/components/parameters/OptionalName"
+      - $ref: "#/components/parameters/Name"
     get:
       operationId: fakeapi.hello.get_add_operation_on_http_methods_only
       responses:
@@ -1151,10 +1151,10 @@ components:
       required:
         - image_version
   parameters:
-    OptionalName:
+    Name:
       name: name
       in: path
       description: Name of the person to greet.
-      required: false
+      required: true
       schema:
         type: string

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -1054,28 +1054,44 @@ paths:
       - $ref: "#/components/parameters/OptionalName"
     get:
       operationId: fakeapi.hello.get_add_operation_on_http_methods_only
-      responses: {}
+      responses:
+        default:
+          description: ''
     put:
       operationId: fakeapi.hello.put_add_operation_on_http_methods_only
-      responses: {}
+      responses:
+        default:
+          description: ''
     post:
       operationId: fakeapi.hello.post_add_operation_on_http_methods_only
-      responses: {}
+      responses:
+        default:
+          description: ''
     delete:
       operationId: fakeapi.hello.delete_add_operation_on_http_methods_only
-      responses: {}
+      responses:
+        default:
+          description: ''
     options:
       operationId: fakeapi.hello.options_add_operation_on_http_methods_only
-      responses: {}
+      responses:
+        default:
+          description: ''
     head:
       operationId: fakeapi.hello.head_add_operation_on_http_methods_only
-      responses: {}
+      responses:
+        default:
+          description: ''
     patch:
       operationId: fakeapi.hello.patch_add_operation_on_http_methods_only
-      responses: {}
+      responses:
+        default:
+          description: ''
     trace:
       operationId: fakeapi.hello.trace_add_operation_on_http_methods_only
-      responses: {}
+      responses:
+        default:
+          description: ''
   /forward:
     post:
       operationId: fakeapi.hello.forward


### PR DESCRIPTION
This includes assorted fixes to bring the "simple" test schema in line with OpenAPI 3.0.

These issues were identified by attempting to validate the schema against [the OpenAPI schema](https://github.com/OAI/OpenAPI-Specification/blob/master/schemas/v3.0/schema.json) using [jsonschema](https://github.com/Julian/jsonschema).