### PR TITLE
Using string parameters when uploading a multipart/form-data file fails

### DIFF
--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -212,6 +212,21 @@ def test_formdata_file_upload(simple_app):
     assert response == {'filename.txt': 'file contents'}
 
 
+def test_formdata_file_upload_and_string(simple_app):
+    app_client = simple_app.app.test_client()
+    resp = app_client.post('/v1.0/test-formData-file-upload-and-string',
+                           data={
+                               'stringData': 'test-string',
+                               'formData': (BytesIO(b'file contents'), 'filename.txt')
+                           })
+    assert resp.status_code == 200
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
+    assert response == {
+        'stringData': 'test-string',
+        'filename.txt': 'file contents'
+    }
+
+
 def test_formdata_file_upload_bad_request(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.post('/v1.0/test-formData-file-upload')

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -300,6 +300,15 @@ def test_formdata_file_upload(formData, **kwargs):
     return {filename: contents}
 
 
+def test_formdata_file_upload_and_string(stringData, formData):
+    filename = formData.filename
+    contents = formData.read().decode('utf-8', 'replace')
+    return {
+        'stringData': stringData,
+        filename: contents
+    }
+
+
 def test_formdata_file_upload_missing_param():
     return ''
 

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -473,6 +473,28 @@ paths:
                   format: binary
               required:
                 - formData
+  /test-formData-file-upload-and-string:
+    post:
+      summary: 'Test formData with file type, with additional string parameters'
+      operationId: fakeapi.hello.test_formdata_file_upload_and_string
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              x-body-name: formData
+              type: object
+              properties:
+                stringData:
+                  type: string
+                formData:
+                  type: string
+                  format: binary
+              required:
+                - stringData
+                - formData
   /test-formData-file-upload-missing-param:
     post:
       summary: 'Test formData with file type, missing parameter in handler'


### PR DESCRIPTION
So far I only have a failing unit test for this problem.

It appears that `connexion.operations.OpenAPIOperation._get_body_argument()` is dropping my string parameters, but I'm not sure if that's the correct place to fix this?

I'm not sure that I'll be able to any additional work into this myself, but wanted to at least shine a light on this issue before I move on.