### PR TITLE
OpenAPI 3.* has the body name 'requestBody' which Connexion resolves …

### DIFF
--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -244,7 +244,7 @@ class OpenAPIOperation(AbstractOperation):
         return {}
 
     def _get_body_argument(self, body, arguments, has_kwargs, sanitize):
-        x_body_name = self.body_schema.get('x-body-name', 'body')
+        x_body_name = self.body_schema.get('x-body-name', 'request_body')
         if is_nullable(self.body_schema) and is_null(body):
             return {x_body_name: None}
 


### PR DESCRIPTION
…to the argument tag "request_body" so this line of code is not standards compliant, thus non-object JSON request bodies are not captured as arguments (on line 263) without the artificial use of an explicit  'x-body-name' with value 'request_body'

Fixes # .



Changes proposed in this pull request:

 -
 -
 -
