### PR TITLE
Fixed [connextion] typo in documentation page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -485,7 +485,7 @@ In order to do this, you should specify the following option:
    options = {'swagger_path': '/path/to/swagger_ui/'}
    app = connexion.App(__name__, specification_dir='openapi/', options=options)
 
-If you wish to provide your own swagger-ui distro, note that connextion
+If you wish to provide your own swagger-ui distro, note that connexion
 expects a jinja2 file called ``swagger_ui/index.j2`` in order to load the
 correct ``swagger.json`` by default. Your ``index.j2`` file can use the
 ``openapi_spec_url`` jinja variable for this purpose:

--- a/docs/request.rst
+++ b/docs/request.rst
@@ -148,7 +148,7 @@ api options.
    app = connexion.App(__name__, specification_dir='swagger/', options=options)
 
 You can implement your own URI parsing behavior by inheriting from
-``connextion.decorators.uri_parsing.AbstractURIParser``.
+``connexion.decorators.uri_parsing.AbstractURIParser``.
 
 There are a handful of URI parsers included with connection.
 


### PR DESCRIPTION
Changes proposed in this pull request:

 - Fixes a small typo in the documentation (`request.rst`) and in the `README.md` where `connexion` was typed as `connextion`.
