### PR TITLE
Support jsonschema >= 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ version = read_version('connexion')
 
 install_requires = [
     'clickclick>=1.2',
-    'jsonschema>=2.5.1,<3.0.0',
+    'jsonschema>=2.5.1',
     'PyYAML>=5.1',
     'requests>=2.9.1',
     'six>=1.9',


### PR DESCRIPTION
Fixes #983.

Other projects have started using jsonschema >= 3.0.0, and modern python packaging tools such as poetry now fail to install projects using both connexion and a different dependency if they depend on different versions of jsonschema.

Allow jsonschema versions >= 3.0.0 to avoid this problem. Add a version branch to avoid a warning that would otherwise be thrown by jsonschema when using the deprecated `types` parameter of the jsonschema.IValidator constructor.

Changes proposed in this pull request:
 - setup.py: Support jsonschema >= 3.0.0
 - Avoid warning when using jsonschema >= 3.0