### PR TITLE
Fixes util.deep_get when obj is a list

### DIFF
--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -60,6 +60,13 @@ def deep_getattr(obj, attr):
 def deep_get(obj, keys):
     """
     Recurses through a nested object get a leaf value.
+
+    There are cases where the use of inheritance or polymorphism-- the use of allOf or
+    oneOf keywords-- will cause the obj to be a list. In this case the keys will
+    contain one or more strings containing integers.
+
+    :type obj: list or dict
+    :type keys: list of strings
     """
     if not keys:
         return obj

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -63,7 +63,10 @@ def deep_get(obj, keys):
     """
     if not keys:
         return obj
-    return deep_get(obj[keys[0]], keys[1:])
+    try:
+        return deep_get(obj[int(keys[0])], keys[1:])
+    except ValueError:
+        return deep_get(obj[keys[0]], keys[1:])
 
 
 def get_function_from_name(function_name):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,3 +51,13 @@ def test_boolean():
 
     with pytest.raises(ValueError):
         utils.boolean(None)
+
+
+def test_deep_get_dict():
+    obj = {'type': 'object', 'properties': {'id': {'type': 'string'}}}
+    assert utils.deep_get(obj, ['properties', 'id']) == {'type': 'string'}
+
+
+def test_deep_get_list():
+    obj = [{'type': 'object', 'properties': {'id': {'type': 'string'}}}]
+    assert utils.deep_get(obj, ['0', 'properties', 'id']) == {'type': 'string'}


### PR DESCRIPTION
The example below will seem strange. It's the result of distilling a complex
API spec down to the root cause of the issue.

```yaml
---
openapi: 3.0.0
info:
  version: v0
  title: Repo an error
  description: Extremely contrived, but it illustrates the problem
paths:
  /:
    get:
      operationId: app.get
      responses:
        '200':
          description: Just for giggles
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/SomeWeirdResource"
components:
  schemas:
    Resource:
      allOf:
        - type: object
          properties:
            id:
              type: string
    SomeWeirdResource:
      allOf:
        - type: object
          properties:
            id:
              $ref: '#/components/schemas/Resource/allOf/0/properties/id'
```

While convoluted, this is a valid OpenAPI 3 spec.

```sh
$ yarn swagger-cli validate openapi/my_api.yaml
yarn run v1.17.3
$ /[redacted]/node_modules/.bin/swagger-cli validate openapi/my_api.yaml
openapi/my_api.yaml is valid
✨  Done in 0.23s.
```

`utils.deep_get` assumes the obj to be a dictionary when it can also be a list.

Fixes #870 

Changes proposed in this pull request:
 - Attempt to cast key as int
 - Catch `ValueError` and try original behavior
