### PR TITLE
Clean up dropping Python 3.{4,5}

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,6 @@ install_requires = [
     'requests>=2.9.1',
     'six>=1.9',
     'inflection>=0.3.1',
-    'pathlib>=1.0.1; python_version < "3.4"',
-    'typing>=3.6.1; python_version < "3.6"',
     'openapi-spec-validator>=0.2.4',
 ]
 


### PR DESCRIPTION
This is a follow up for c8d8973c7e390a5e2071c7b494dd7bd52bd55ff1
(dropping Python 3.5). There were some leftovers in requirements for
Pythonv versions `connexion` no longer supports.