### PR TITLE
Drop Python 2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ How to Use
 Prerequisites
 -------------
 
-Python 2.7 or Python 3.6+
+Python 3.6+
 
 Installing It
 -------------

--- a/connexion/decorators/decorator.py
+++ b/connexion/decorators/decorator.py
@@ -37,7 +37,7 @@ class RequestResponseDecorator(BaseDecorator):
         :type function: types.FunctionType
         :rtype: types.FunctionType
         """
-        if has_coroutine(function, self.api):  # pragma: 2.7 no cover
+        if has_coroutine(function, self.api):
             from .coroutine_wrappers import get_request_life_cycle_wrapper
             wrapper = get_request_life_cycle_wrapper(function, self.api, self.mimetype)
 

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -99,7 +99,7 @@ class ResponseValidator(BaseDecorator):
 
             return response
 
-        if has_coroutine(function):  # pragma: 2.7 no cover
+        if has_coroutine(function):
             from .coroutine_wrappers import get_response_validator_wrapper
             wrapper = get_response_validator_wrapper(function, _wrapper)
 

--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 
 from connexion.resolver import Resolution, Resolver, ResolverError
@@ -24,7 +25,7 @@ class MockResolver(Resolver):
             operation_id = 'mock-{}'.format(self._operation_id_counter)
             self._operation_id_counter += 1
 
-        mock_func = partial(self.mock_operation, operation=operation)
+        mock_func = functools.partial(self.mock_operation, operation=operation)
         if self.mock_all:
             func = mock_func
         else:

--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -5,17 +5,6 @@ from connexion.resolver import Resolution, Resolver, ResolverError
 logger = logging.getLogger(__name__)
 
 
-def partial(func, **frozen):
-    """
-    Replacement for functools.partial as functools.partial does not work with inspect.py on Python 2.7
-    """
-    def wrapper(*args, **kwargs):
-        for k, v in frozen.items():
-            kwargs[k] = v
-        return func(*args, **kwargs)
-    return wrapper
-
-
 class MockResolver(Resolver):
 
     def __init__(self, mock_all):

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -195,28 +195,24 @@ def has_coroutine(function, api=None):
     If ``function`` is a decorator (has a ``__wrapped__`` attribute)
     this function will also look at the wrapped function.
     """
-    if six.PY3:  # pragma: 2.7 no cover
-        import asyncio
+    import asyncio
 
-        def iscorofunc(func):
+    def iscorofunc(func):
+        iscorofunc = asyncio.iscoroutinefunction(func)
+        while not iscorofunc and hasattr(func, '__wrapped__'):
+            func = func.__wrapped__
             iscorofunc = asyncio.iscoroutinefunction(func)
-            while not iscorofunc and hasattr(func, '__wrapped__'):
-                func = func.__wrapped__
-                iscorofunc = asyncio.iscoroutinefunction(func)
-            return iscorofunc
+        return iscorofunc
 
-        if api is None:
-            return iscorofunc(function)
+    if api is None:
+        return iscorofunc(function)
 
-        else:
-            return any(
-                iscorofunc(func) for func in (
-                    function, api.get_request, api.get_response
-                )
+    else:
+        return any(
+            iscorofunc(func) for func in (
+                function, api.get_request, api.get_response
             )
-    else:  # pragma: 3 no cover
-        # there's no asyncio in python 2
-        return False
+        )
 
 
 def yamldumper(openapi):

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -5,7 +5,7 @@ Quickstart
 Prerequisites
 -------------
 
-Python 2.7 or Python 3.5+
+Python 3.6+
 
 Installing It
 -------------

--- a/py2-coveragerc
+++ b/py2-coveragerc
@@ -6,4 +6,3 @@ omit = connexion/apis/aiohttp_api.py
 [report]
 exclude_lines =
     pragma: no cover
-    pragma: 2.7 no cover

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,6 @@ setup(
     test_suite='tests',
     classifiers=[
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -1,13 +1,5 @@
-from connexion.mock import MockResolver, partial
+from connexion.mock import MockResolver
 from connexion.operations import Swagger2Operation
-
-
-def test_partial():
-    def func(a, b):
-        return a + b
-
-    add_three = partial(func, a=3)
-    assert add_three(b=1) == 4
 
 
 def test_mock_resolver():

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ exclude=connexion/__init__.py
 
 [tox]
 envlist =
-    {py27}-{min,pypi,dev}
     {py36}-{min,pypi,dev}
     {py37}-{min,pypi,dev}
     {py38}-{min,pypi,dev}
@@ -14,7 +13,6 @@ envlist =
     flake8
 
 [travis]
-2.7=py27-min,py27-pypi
 3.6=py36-min,py36-pypi
 3.7=py37-min,py37-pypi,isort-check,isort-check-examples,isort-check-tests,flake8
 3.8=py38-min


### PR DESCRIPTION
Partially #998 

Changes proposed in this pull request:
 - removed 2.7 from classifiers
 - removed all references to 2.7
 - code cleanup
