### PR TITLE
#594 & #816 - Add error path to schema validation error in RequestBodyValidator

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -196,10 +196,17 @@ class RequestBodyValidator(object):
         try:
             self.validator.validate(data)
         except ValidationError as exception:
-            logger.error("{url} validation error: {error}".format(url=url,
-                                                                  error=exception.message),
-                         extra={'validator': 'body'})
-            raise BadRequestProblem(detail=str(exception.message))
+            error_path = '.'.join(str(item) for item in exception.path)
+            error_path_msg = " - '{path}'".format(path=error_path) \
+                if error_path else ""
+            logger.error(
+                "{url} validation error: {error}{error_path_msg}".format(
+                    url=url, error=exception.message,
+                    error_path_msg=error_path_msg),
+                extra={'validator': 'body'})
+            raise BadRequestProblem(detail="{message}{error_path_msg}".format(
+                               message=exception.message,
+                               error_path_msg=error_path_msg))
 
         return None
 

--- a/tests/api/test_schema.py
+++ b/tests/api/test_schema.py
@@ -20,6 +20,14 @@ def test_schema(schema_app):
     assert bad_type_response['title'] == 'Bad Request'
     assert bad_type_response['detail'].startswith("22 is not of type 'string'")
 
+    bad_type_path = app_client.post('/v1.0/test_schema', headers=headers,
+                                         data=json.dumps({'image_version': 22}))  # type: flask.Response
+    assert bad_type_path.status_code == 400
+    assert bad_type_path.content_type == 'application/problem+json'
+    bad_type_path_response = json.loads(bad_type.data.decode('utf-8', 'replace'))  # type: dict
+    assert bad_type_path_response['title'] == 'Bad Request'
+    assert bad_type_path_response['detail'].endswith(" - 'image_version'")
+
     good_request = app_client.post('/v1.0/test_schema', headers=headers,
                                    data=json.dumps({'image_version': 'version'}))  # type: flask.Response
     assert good_request.status_code == 200


### PR DESCRIPTION
Fixes #594 .
Fixes https://github.com/zalando/connexion/pull/816 
--> it gives `TypeError` when your json includes a list (the exception.path includes an integer )(TypeError: sequence item 1: expected str instance, int found)
--> Put 'path' at the end of the error message as it can sometimes be empty

Changes proposed in this pull request:

 - include json key with full path into validation error message

