### PR TITLE
Fix unit tests on Windows

### DIFF
--- a/tests/aiohttp/test_aiohttp_app.py
+++ b/tests/aiohttp/test_aiohttp_app.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from unittest import mock
 
 import pytest
@@ -74,13 +75,13 @@ def test_app_run_server_error(web_run_app_mock, aiohttp_api_spec_dir):
 def test_app_get_root_path(aiohttp_api_spec_dir):
     app = AioHttpApp(__name__, port=5001,
                      specification_dir=aiohttp_api_spec_dir)
-    assert app.get_root_path().endswith('connexion/tests/aiohttp') == True
+    assert app.get_root_path().endswith(os.path.join('connexion', 'tests', 'aiohttp')) == True
 
 
 def test_app_get_root_path_not_in_sys_modules(sys_modules_mock, aiohttp_api_spec_dir):
     app = AioHttpApp('connexion', port=5001,
                      specification_dir=aiohttp_api_spec_dir)
-    assert app.get_root_path().endswith('/connexion') == True
+    assert app.get_root_path().endswith(os.sep + 'connexion') == True
 
 
 def test_app_get_root_path_invalid(sys_modules_mock, aiohttp_api_spec_dir):


### PR DESCRIPTION
These five unit tests were failing under Windows due to differences in OS behavior.
The three tests in tests/test_api.py were failing since the NamedTemporaryFile object cannot be opened more than one time on Windows.  
The two tests in tests/aiohttp/test_aiohttp_app.py were failing due to hard-coded '/' path separator.