### PR TITLE
enable empty security definition

### DIFF
--- a/connexion/decorators/security.py
+++ b/connexion/decorators/security.py
@@ -287,6 +287,17 @@ def verify_bearer(bearer_info_func):
     return wrapper
 
 
+def verify_none():
+    """
+    :rtype: types.FunctionType
+    """
+
+    def wrapper(request, required_scopes):
+        return {}
+
+    return wrapper
+
+
 def verify_security(auth_funcs, required_scopes, function):
 
     @functools.wraps(function)

--- a/connexion/operations/secure.py
+++ b/connexion/operations/secure.py
@@ -7,7 +7,7 @@ from ..decorators.security import (get_apikeyinfo_func, get_basicinfo_func,
                                    get_scope_validate_func, get_tokeninfo_func,
                                    security_deny, security_passthrough,
                                    verify_apikey, verify_basic, verify_bearer,
-                                   verify_oauth, verify_security)
+                                   verify_none, verify_oauth, verify_security)
 
 logger = logging.getLogger("connexion.operations.secure")
 
@@ -80,6 +80,7 @@ class SecureOperation(object):
         required_scopes = None
         for security_req in self.security:
             if not security_req:
+                auth_funcs.append(verify_none())
                 continue
             elif len(security_req) > 1:
                 logger.warning("... More than one security scheme in security requirement defined. "

--- a/tests/api/test_secure_api.py
+++ b/tests/api/test_secure_api.py
@@ -88,6 +88,19 @@ def test_security(oauth_requests, secure_endpoint_app):
     get_bye_from_connexion = app_client.get('/v1.0/byesecure-jwt/test-user', headers=headers)  # type: flask.Response
     assert get_bye_from_connexion.data == b'Goodbye test-user (Secure: 100)'
 
+    # has optional auth
+    response = app_client.get('/v1.0/optional-auth')  # type: flask.Response
+    assert response.status_code == 200
+    assert response.data == b'"Unauthenticated"\n'
+    headers = {"X-AUTH": "mykey"}
+    response = app_client.get('/v1.0/optional-auth', headers=headers)  # type: flask.Response
+    assert response.status_code == 200
+    assert response.data == b'"Authenticated"\n'
+    headers = {"X-AUTH": "wrong-key"}
+    response = app_client.get('/v1.0/optional-auth', headers=headers)  # type: flask.Response
+    assert response.status_code == 401
+
+
 def test_checking_that_client_token_has_all_necessary_scopes(
         oauth_requests, secure_endpoint_app):
     app_client = secure_endpoint_app.app.test_client()

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -2,7 +2,7 @@
 import flask
 from flask import jsonify, redirect
 
-from connexion import NoContent, ProblemException, context
+from connexion import NoContent, ProblemException, context, request
 
 
 class DummyClass(object):
@@ -435,6 +435,14 @@ def unordered_params_response(first, path_param, second):
 
 def more_than_one_scope_defined(**kwargs):
     return "OK"
+
+
+def optional_auth(**kwargs):
+    key = apikey_info(request.headers.get('X-AUTH'))
+    if key is None:
+        return "Unauthenticated"
+    else:
+        return "Authenticated"
 
 
 def test_args_kwargs(*args, **kwargs):

--- a/tests/fixtures/secure_endpoint/openapi.yaml
+++ b/tests/fixtures/secure_endpoint/openapi.yaml
@@ -124,6 +124,20 @@ paths:
       responses:
         '200':
           description: some response
+  /optional-auth:
+    get:
+      summary: Test empty security definition
+      description: |
+        Test that connexion handles an empty security definition correctly.
+        In case an empty definition is provided, the user is required to
+        apply proper authentication and authorization techniques.
+      operationId: fakeapi.hello.optional_auth
+      security:
+        - api_key: []
+        - {}
+      responses:
+        '200':
+          description: some response
 servers:
   - url: /v1.0
 components:

--- a/tests/fixtures/secure_endpoint/swagger.yaml
+++ b/tests/fixtures/secure_endpoint/swagger.yaml
@@ -156,3 +156,18 @@ paths:
       responses:
         200:
           description: some response
+
+  /optional-auth:
+    get:
+      summary: Test empty security definition
+      description: |
+        Test that connexion handles an empty security definition correctly.
+        In case an empty definition is provided, the user is required to
+        apply proper authentication and authorization techniques.
+      operationId: fakeapi.hello.optional_auth
+      security:
+        - api_key: []
+        - {}
+      responses:
+        '200':
+          description: some response


### PR DESCRIPTION
This allows to use optional authentication and provide different
responses to authenticated users via the same API-Endpoint.

Fixes #1036

Changes proposed in this pull request:

 - Enable optimal authentication
 - Provide different information to logged in customers via the same API endpoint