### PR TITLE
Pop apiKey from query parameters in security decorator to fix #470

### DIFF
--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -218,6 +218,10 @@ def test_required_query_param():
     return ''
 
 
+def test_apikey_query_parameter_validation():
+    return ''
+
+
 def test_array_csv_query_param(items):
     return items
 

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -340,6 +340,19 @@ paths:
       responses:
         '200':
           description: OK
+  /test_apikey_query_parameter_validation:
+    get:
+      operationId: fakeapi.hello.test_apikey_query_parameter_validation
+      parameters:
+        - name: name
+          in: query
+          schema:
+            type: string
+      security:
+        - api_key: []
+      responses:
+        '200':
+          description: OK
   /test_required_query_param:
     get:
       operationId: fakeapi.hello.test_required_query_param
@@ -1140,3 +1153,9 @@ components:
       required: false
       schema:
         type: string
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: apikey
+      in: query
+      x-apikeyInfoFunc: fakeapi.hello.apikey_info

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -245,6 +245,19 @@ paths:
         200:
           description: OK
 
+  /test_apikey_query_parameter_validation:
+    get:
+      operationId: fakeapi.hello.test_apikey_query_parameter_validation
+      parameters:
+        - name: name
+          in: query
+          type: string
+      security:
+        - api_key: []
+      responses:
+        200:
+          description: OK
+
   /test_required_query_param:
     get:
       operationId: fakeapi.hello.test_required_query_param
@@ -993,3 +1006,10 @@ definitions:
         description: Docker image version to deploy
     required:
       - image_version
+
+securityDefinitions:
+    api_key:
+      type: apiKey
+      name: apikey
+      in: query
+      x-apikeyInfoFunc: fakeapi.hello.apikey_info


### PR DESCRIPTION
Fixes:

Fixes Bad Request error when ApiKey authentication is used with the apiKey query parameter, and strict validation is enabled.
The corresponding open issue is https://github.com/zalando/connexion/issues/470.

Changes proposed in this pull request:

- Pop apiKey from the query parameters before validation.