### PR TITLE
Allow users to enable debug mode via environment variables

### DIFF
--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -13,7 +13,7 @@ logger = logging.getLogger('connexion.app')
 @six.add_metaclass(abc.ABCMeta)
 class AbstractApp(object):
     def __init__(self, import_name, api_cls, port=None, specification_dir='',
-                 host=None, server=None, arguments=None, auth_all_paths=False, debug=False,
+                 host=None, server=None, arguments=None, auth_all_paths=False, debug=None,
                  resolver=None, options=None, skip_error_handlers=False):
         """
         :param import_name: the name of the application package

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,21 @@
+# coding: utf-8
+from flask import Flask
+
+from connexion.apps.flask_app import FlaskApp
+from connexion.apis.flask_api import FlaskApi
+
+
+def test_flask_app_default_params():
+    app = FlaskApp('MyApp')
+    assert app.import_name == 'MyApp'
+    assert app.server == 'flask'
+    assert app.api_cls == FlaskApi
+    assert app.arguments == {}
+    # debug should be None so that user can use Flask environment variables to set it
+    assert app.debug is None
+    assert app.host is None
+    assert app.port is None
+    assert app.resolver is None
+    assert app.resolver_error is None
+    assert not app.auth_all_paths
+    assert type(app.app) == Flask


### PR DESCRIPTION
Fixes #1083 


Changes proposed in this pull request:

 - use `None` as default value for `debug` parameter in `AbstractApp` to allow users to use flask environment variables to activate debug mode
