### PR TITLE
Fixed mocking function not working with examples under numeric status…

### DIFF
--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -69,9 +69,10 @@ def deep_get(obj, keys):
     """
     if not keys:
         return obj
-    try:
+
+    if isinstance(obj, list):
         return deep_get(obj[int(keys[0])], keys[1:])
-    except ValueError:
+    else:
         return deep_get(obj[keys[0]], keys[1:])
 
 

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -2,11 +2,44 @@ from connexion.mock import MockResolver
 from connexion.operations import Swagger2Operation
 
 
-def test_mock_resolver():
+def test_mock_resolver_default():
     resolver = MockResolver(mock_all=True)
 
     responses = {
         'default': {
+            'examples': {
+                'application/json': {
+                    'foo': 'bar'
+                }
+            }
+        }
+    }
+
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation={
+                                      'responses': responses
+                                  },
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions={},
+                                  resolver=resolver)
+    assert operation.operation_id == 'mock-1'
+
+    response, status_code = resolver.mock_operation(operation)
+    assert status_code == 200
+    assert response == {'foo': 'bar'}
+
+def test_mock_resolver_numeric():
+    resolver = MockResolver(mock_all=True)
+
+    responses = {
+        '200': {
             'examples': {
                 'application/json': {
                     'foo': 'bar'

--- a/tests/test_mock3.py
+++ b/tests/test_mock3.py
@@ -2,11 +2,46 @@ from connexion.mock import MockResolver
 from connexion.operations import OpenAPIOperation
 
 
-def test_mock_resolver():
+def test_mock_resolver_default():
     resolver = MockResolver(mock_all=True)
 
     responses = {
         'default': {
+            'content': {
+                'application/json': {
+                    'examples': {
+                        "super_cool_example": {
+                            'foo': 'bar'
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='endpoint',
+        path_parameters=[],
+        operation={
+            'responses': responses
+        },
+        app_security=[],
+        resolver=resolver
+    )
+    assert operation.operation_id == 'mock-1'
+
+    response, status_code = resolver.mock_operation(operation)
+    assert status_code == 200
+    assert response == {'foo': 'bar'}
+
+
+def test_mock_resolver_numeric():
+    resolver = MockResolver(mock_all=True)
+
+    responses = {
+        '200': {
             'content': {
                 'application/json': {
                     'examples': {


### PR DESCRIPTION
… codes (e.g., 200) , due to status code string being casted as integer and not raising a ValueError.

Included tests that break without the patch (it was testing for 'default' only, but not for numeric codes like '200')

Fixes #1087 .



Changes proposed in this pull request:

 - Adding check on `examples` structure type: if it's a dictionary, don't try to cast to integer or it will always result in empty returned value.
 - Added tests that, without the patch, break when there is no "default" string.