### PR TITLE
fixed mocks not honouring OpeanAPI 3 examples standard (printing "val…

### DIFF
--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -190,7 +190,7 @@ class OpenAPIOperation(AbstractOperation):
         try:
             # TODO also use example header?
             return (
-                list(deep_get(self._responses, examples_path).values())[0],
+                list(deep_get(self._responses, examples_path).values())[0]['value'],
                 status_code
             )
         except (KeyError, IndexError):

--- a/tests/test_mock3.py
+++ b/tests/test_mock3.py
@@ -11,7 +11,9 @@ def test_mock_resolver_default():
                 'application/json': {
                     'examples': {
                         "super_cool_example": {
-                            'foo': 'bar'
+                            "value": {
+                                'foo': 'bar'
+                            }
                         }
                     }
                 }
@@ -46,7 +48,9 @@ def test_mock_resolver_numeric():
                 'application/json': {
                     'examples': {
                         "super_cool_example": {
-                            'foo': 'bar'
+                            "value": {
+                                'foo': 'bar'
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
…ue" key in output examples)

Fixes #1090 .



Changes proposed in this pull request:

 -Changing the test case that passes a sloppy JSON example
 -Changing the code to get rid of the expected "value" key

Reference example: [https://swagger.io/docs/specification/adding-examples/](https://swagger.io/docs/specification/adding-examples/)
