### PR TITLE
Fix test that relies on the repo folder being named Connexion

### DIFF
--- a/tests/aiohttp/test_aiohttp_app.py
+++ b/tests/aiohttp/test_aiohttp_app.py
@@ -75,7 +75,7 @@ def test_app_run_server_error(web_run_app_mock, aiohttp_api_spec_dir):
 def test_app_get_root_path(aiohttp_api_spec_dir):
     app = AioHttpApp(__name__, port=5001,
                      specification_dir=aiohttp_api_spec_dir)
-    assert app.get_root_path().endswith(os.path.join('connexion', 'tests', 'aiohttp')) == True
+    assert app.get_root_path().endswith(os.path.join('tests', 'aiohttp')) == True
 
 
 def test_app_get_root_path_not_in_sys_modules(sys_modules_mock, aiohttp_api_spec_dir):


### PR DESCRIPTION
Fixes #1097 

Changes proposed in this pull request:
 - don't check that the repo is cloned into "connexion" directory
