### PR TITLE
Revert "Fixes #510: Multiple file uploads via POST now work correctly."

### DIFF
--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -176,7 +176,7 @@ class AbstractOperation(SecureOperation):
 
     @staticmethod
     def _get_file_arguments(files, arguments, has_kwargs=False):
-        return {k: files.getlist(k) for k in files.keys() if k in arguments or has_kwargs}
+        return {k: v for k, v in files.items() if k in arguments or has_kwargs}
 
     @abc.abstractmethod
     def _get_val_from_param(self, value, query_defn):

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -211,17 +211,6 @@ def test_formdata_file_upload(simple_app):
     response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response == {'filename.txt': 'file contents'}
 
-def test_formdata_multiple_file_upload(simple_app):
-    app_client = simple_app.app.test_client()
-    resp = app_client.post('/v1.0/test-formData-file-upload',
-                           data={'formData': [(BytesIO(b'file contents'), 'filename.txt'),
-                                              (BytesIO(b'file contents 2'), 'filename2.txt')]
-                                              })
-    assert resp.status_code == 200
-    response = json.loads(resp.data.decode('utf-8', 'replace'))
-    assert response == [{'filename.txt': 'file contents'},
-                        {'filename2.txt': 'file contents 2'}]
-
 
 def test_formdata_file_upload_bad_request(simple_app):
     app_client = simple_app.app.test_client()

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -306,10 +306,9 @@ def test_formdata_missing_param():
 
 
 def test_formdata_file_upload(formData, **kwargs):
-    if len(formData) == 1:
-        return {x.filename: x.read().decode('utf-8', 'replace') for x in formData}
-
-    return [{x.filename: x.read().decode('utf-8', 'replace')} for x in formData]
+    filename = formData.filename
+    contents = formData.read().decode('utf-8', 'replace')
+    return {filename: contents}
 
 
 def test_formdata_file_upload_missing_param():


### PR DESCRIPTION
Reverts zalando/connexion#1000

This break aiohttp because getlist() is specific to a werkzeug datastructure.