### PR TITLE
Remove six (Python 2 support)

### DIFF
--- a/connexion/__init__.py
+++ b/connexion/__init__.py
@@ -15,36 +15,34 @@ full_name = '{}.operation'.format(__package__)
 sys.modules[full_name] = sys.modules[compat.__name__]
 
 
-def not_installed_error():  # pragma: no cover
-    import six
+def not_installed_error(exc):  # pragma: no cover
     import functools
 
-    def _required_lib(exec_info, *args, **kwargs):
-        six.reraise(*exec_info)
+    def _required_lib(exc, *args, **kwargs):
+        raise exc
 
-    return functools.partial(_required_lib, sys.exc_info())
+    return functools.partial(_required_lib, exc)
 
 
 try:
     from .apis.flask_api import FlaskApi, context  # NOQA
     from .apps.flask_app import FlaskApp
     from flask import request  # NOQA
-except ImportError:  # pragma: no cover
-    _flask_not_installed_error = not_installed_error()
+except ImportError as e:  # pragma: no cover
+    _flask_not_installed_error = not_installed_error(e)
     FlaskApi = _flask_not_installed_error
     FlaskApp = _flask_not_installed_error
 
 App = FlaskApp
 Api = FlaskApi
 
-if sys.version_info[0] >= 3:  # pragma: no cover
-    try:
-        from .apis.aiohttp_api import AioHttpApi
-        from .apps.aiohttp_app import AioHttpApp
-    except ImportError:  # pragma: no cover
-        _aiohttp_not_installed_error = not_installed_error()
-        AioHttpApi = _aiohttp_not_installed_error
-        AioHttpApp = _aiohttp_not_installed_error
+try:
+    from .apis.aiohttp_api import AioHttpApi
+    from .apps.aiohttp_app import AioHttpApp
+except ImportError as e:  # pragma: no cover
+    _aiohttp_not_installed_error = not_installed_error(e)
+    AioHttpApi = _aiohttp_not_installed_error
+    AioHttpApp = _aiohttp_not_installed_error
 
 # This version is replaced during release process.
 __version__ = '2018.0.dev1'

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -29,7 +29,7 @@ class AbstractAPIMeta(abc.ABCMeta):
         cls._set_jsonifier()
 
 
-class AbstractAPI(object, metaclass=AbstractAPIMeta):
+class AbstractAPI(metaclass=AbstractAPIMeta):
     """
     Defines an abstract interface for a Swagger API
     """

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -227,7 +227,8 @@ class AbstractAPI(metaclass=AbstractAPIMeta):
             logger.exception(error_msg)
         else:
             logger.error(error_msg)
-            six.reraise(*exc_info)
+            _type, value, traceback = exc_info
+            raise value.with_traceback(traceback)
 
     @classmethod
     @abc.abstractmethod

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -5,8 +5,6 @@ import sys
 import warnings
 from enum import Enum
 
-import six
-
 from ..decorators.produces import NoContent
 from ..exceptions import ResolverError
 from ..http_facts import METHODS
@@ -31,8 +29,7 @@ class AbstractAPIMeta(abc.ABCMeta):
         cls._set_jsonifier()
 
 
-@six.add_metaclass(AbstractAPIMeta)
-class AbstractAPI(object):
+class AbstractAPI(object, metaclass=AbstractAPIMeta):
     """
     Defines an abstract interface for a Swagger API
     """

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -2,7 +2,6 @@ import logging
 import warnings
 
 import flask
-import six
 import werkzeug.exceptions
 from connexion.apis import flask_utils
 from connexion.apis.abstract import AbstractAPI
@@ -182,7 +181,7 @@ class FlaskApi(AbstractAPI):
             'response': data,
             'status': status_code
         }
-        kwargs = {k: v for k, v in six.iteritems(kwargs) if v is not None}
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
         return flask.current_app.response_class(**kwargs)  # type: flask.Response
 
     @classmethod

--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -2,16 +2,13 @@ import abc
 import logging
 import pathlib
 
-import six
-
 from ..options import ConnexionOptions
 from ..resolver import Resolver
 
 logger = logging.getLogger('connexion.app')
 
 
-@six.add_metaclass(abc.ABCMeta)
-class AbstractApp(object):
+class AbstractApp(object, metaclass=abc.ABCMeta):
     def __init__(self, import_name, api_cls, port=None, specification_dir='',
                  host=None, server=None, arguments=None, auth_all_paths=False, debug=None,
                  resolver=None, options=None, skip_error_handlers=False):

--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -8,7 +8,7 @@ from ..resolver import Resolver
 logger = logging.getLogger('connexion.app')
 
 
-class AbstractApp(object, metaclass=abc.ABCMeta):
+class AbstractApp(metaclass=abc.ABCMeta):
     def __init__(self, import_name, api_cls, port=None, specification_dir='',
                  host=None, server=None, arguments=None, auth_all_paths=False, debug=None,
                  resolver=None, options=None, skip_error_handlers=False):

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -4,7 +4,6 @@ import logging
 import re
 
 import inflection
-import six
 
 from ..http_facts import FORM_CONTENT_TYPES
 from ..lifecycle import ConnexionRequest  # NOQA
@@ -33,15 +32,11 @@ def inspect_function_arguments(function):  # pragma: no cover
     :type function: Callable
     :rtype: tuple[list[str], bool]
     """
-    if six.PY3:
-        parameters = inspect.signature(function).parameters
-        bound_arguments = [name for name, p in parameters.items()
-                           if p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)]
-        has_kwargs = any(p.kind == p.VAR_KEYWORD for p in parameters.values())
-        return list(bound_arguments), has_kwargs
-    else:
-        argspec = inspect.getargspec(function)
-        return argspec.args, bool(argspec.keywords)
+    parameters = inspect.signature(function).parameters
+    bound_arguments = [name for name, p in parameters.items()
+                        if p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)]
+    has_kwargs = any(p.kind == p.VAR_KEYWORD for p in parameters.values())
+    return list(bound_arguments), has_kwargs
 
 
 def snake_and_shadow(name):

--- a/connexion/decorators/security.py
+++ b/connexion/decorators/security.py
@@ -7,7 +7,7 @@ import textwrap
 
 import requests
 from connexion.utils import get_function_from_name
-from six.moves import http_cookies
+import http.cookies
 
 from ..exceptions import (ConnexionException, OAuthProblem,
                           OAuthResponseProblem, OAuthScopeProblem)
@@ -240,7 +240,7 @@ def get_cookie_value(cookies, name):
     :param cookies: str: cookies raw data
     :param name: str: cookies key
     '''
-    cookie_parser = http_cookies.SimpleCookie()
+    cookie_parser = http.cookies.SimpleCookie()
     cookie_parser.load(str(cookies))
     try:
         return cookie_parser[name].value

--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -6,8 +6,6 @@ import re
 import json
 from .. import utils
 
-import six
-
 from ..utils import create_empty_dict_from_list
 from .decorator import BaseDecorator
 
@@ -21,8 +19,7 @@ QUERY_STRING_DELIMITERS = {
 }
 
 
-@six.add_metaclass(abc.ABCMeta)
-class AbstractURIParser(BaseDecorator):
+class AbstractURIParser(BaseDecorator, metaclass=abc.ABCMeta):
     parsable_parameters = ["query", "path"]
 
     def __init__(self, param_defns, body_defn):

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -5,7 +5,6 @@ import logging
 import sys
 
 import pkg_resources
-import six
 from jsonschema import Draft4Validator, ValidationError, draft4_format_checker
 from jsonschema.validators import extend
 from werkzeug.datastructures import FileStorage
@@ -230,7 +229,7 @@ class ResponseBodyValidator(object):
             logger.error("{url} validation error: {error}".format(url=url,
                                                                   error=exception),
                          extra={'validator': 'response'})
-            six.reraise(*sys.exc_info())
+            raise exception
 
         return None
 

--- a/connexion/jsonifier.py
+++ b/connexion/jsonifier.py
@@ -2,8 +2,6 @@ import datetime
 import json
 import uuid
 
-import six
-
 
 class JSONEncoder(json.JSONEncoder):
     def default(self, o):
@@ -41,7 +39,7 @@ class Jsonifier(object):
         """ Central point where JSON serialization happens inside
         Connexion.
         """
-        for k, v in six.iteritems(self.dumps_args):
+        for k, v in self.dumps_args.items():
             kwargs.setdefault(k, v)
         return self.json.dumps(data, **kwargs) + '\n'
 

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -1,7 +1,6 @@
 import abc
 import logging
 
-import six
 from connexion.operations.secure import SecureOperation
 
 from ..decorators.metrics import UWSGIMetricsCollector
@@ -22,8 +21,7 @@ VALIDATOR_MAP = {
 }
 
 
-@six.add_metaclass(abc.ABCMeta)
-class AbstractOperation(SecureOperation):
+class AbstractOperation(SecureOperation, metaclass=abc.ABCMeta):
 
     """
     An API routes requests to an Operation by a (path, method) pair.

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -3,10 +3,9 @@ import copy
 import pathlib
 
 import jinja2
-import six
 import yaml
 from openapi_spec_validator.exceptions import OpenAPIValidationError
-from six.moves.urllib.parse import urlsplit
+from urllib.parse import urlsplit
 
 from .exceptions import InvalidSpecification
 from .json_schema import resolve_refs
@@ -135,7 +134,7 @@ class Specification(collections_abc.Mapping):
                 return {
                     str(k): enforce_string_keys(v)
                     for k, v
-                    in six.iteritems(obj)
+                    in obj.items()
                 }
             return obj
 
@@ -240,7 +239,7 @@ class OpenAPISpecification(Specification):
             server_vars = server.pop("variables", {})
             server['url'] = server['url'].format(
                 **{k: v['default'] for k, v
-                   in six.iteritems(server_vars)}
+                   in server_vars.items()}
             )
             base_path = urlsplit(server['url']).path
         except IndexError:

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -1,14 +1,7 @@
 import functools
 import importlib
 
-import six
 import yaml
-
-# Python 2/3 compatibility:
-try:
-    py_string = unicode
-except NameError:  # pragma: no cover
-    py_string = str  # pragma: no cover
 
 
 def boolean(s):
@@ -36,7 +29,7 @@ def boolean(s):
 # https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#data-types
 TYPE_MAP = {'integer': int,
             'number': float,
-            'string': py_string,
+            'string': str,
             'boolean': boolean,
             'array': list,
             'object': dict}  # map of swagger types to python types

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -10,5 +10,3 @@ testfixtures>=5.3.0
 # -e hg+https://bitbucket.org/pitrou/pathlib#egg=pathlib
 # PyYAML is not that easy to build manually, it may fail.
 #-e svn+http://svn.pyyaml.org/pyyaml/trunk#egg=PyYAML
-# six is causing errors during the tests
-#-e git+https://github.com/benjaminp/six.git#egg=six

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ install_requires = [
     'jsonschema>=2.5.1',
     'PyYAML>=5.1',
     'requests>=2.9.1',
-    'six>=1.9',
     'inflection>=0.3.1',
     'openapi-spec-validator>=0.2.4',
 ]


### PR DESCRIPTION
Remove `six` usage, i.e. remove Python 2 support.