### PR TITLE
Don't allow connexion installation in py27

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,6 @@ setup(
     cmdclass={'test': PyTest},
     test_suite='tests',
     classifiers=[
-        'Programming Language :: Python',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(
     cmdclass={'test': PyTest},
     test_suite='tests',
     classifiers=[
+        'Programming Language :: Python',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
     keywords='openapi oai swagger rest api oauth flask microservice framework',
     license='Apache License Version 2.0',
     setup_requires=['flake8'],
+    python_requires=">=3.6",
     install_requires=install_requires + [flask_require],
     tests_require=tests_require,
     extras_require={


### PR DESCRIPTION
Pip installing connection in a py2.7 env pulls in unsupported 2.5.0
This PR updates connextion to only allow installation on python >= 3.6

If merged, this PR should fix:
https://github.com/zalando/connexion/issues/1108