### PR TITLE
scope deepObject defaults code to query params only 

### DIFF
--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -40,6 +40,24 @@ def make_type(value, _type):
     return type_func(value)
 
 
+def deep_merge(a, b):
+    """ merges b into a
+        in case of conflict the value from b is used
+    """
+    for key in b:
+        if key in a:
+            if isinstance(a[key], dict) and isinstance(b[key], dict):
+                deep_merge(a[key], b[key])
+            elif a[key] == b[key]:
+                pass
+            else:
+                # b overwrites a
+                a[key] = b[key]
+        else:
+            a[key] = b[key]
+    return a
+
+
 def deep_getattr(obj, attr):
     """
     Recurses through an attribute chain to get the ultimate value.
@@ -229,12 +247,3 @@ def yamldumper(openapi):
     yaml.representer.SafeRepresenter.represent_scalar = my_represent_scalar
 
     return yaml.dump(openapi, allow_unicode=True, Dumper=NoAnchorDumper)
-
-
-def create_empty_dict_from_list(_list, _dict, _end_value):
-    """create from ['foo', 'bar'] a dict like {'foo': {'bar': {}}} recursively. needed for converting query params"""
-    current_key = _list.pop(0)
-    if _list:
-        return {current_key: create_empty_dict_from_list(_list, _dict, _end_value)}
-    else:
-        return {current_key: _end_value}

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -137,8 +137,8 @@ def test_path_parameter_somefloat(simple_app):
     assert resp.status_code == 404
 
 
-def test_default_param(simple_app):
-    app_client = simple_app.app.test_client()
+def test_default_param(strict_app):
+    app_client = strict_app.app.test_client()
     resp = app_client.get('/v1.0/test-default-query-parameter')
     assert resp.status_code == 200
     response = json.loads(resp.data.decode('utf-8', 'replace'))


### PR DESCRIPTION
Fixes spread of defaults into other parameters

Redo #971 
Fixes #1092 
Fixes #1082 

Changes proposed in this pull request:
 - scope deepObject code to openapi3-only code blocks (defaults do not belong in uri_parsing, nor does deepObject logic make sense in an AbstractURIParser)
 - fix set_default_values(...) which put defaults from any parameter type into all other parameters.

Future:
- modify testing fixtures to catch setting request.form, request.files, request.body etc unintentionally