### PR TITLE
Fix: aiohttp access_log duplicated if passed as argument

### DIFF
--- a/connexion/apps/aiohttp_app.py
+++ b/connexion/apps/aiohttp_app.py
@@ -85,7 +85,7 @@ class AioHttpApp(AbstractApp):
         if self.server == 'aiohttp':
             logger.info('Listening on %s:%s..', self.host, self.port)
 
-            access_log = options.get('access_log')
+            access_log = options.pop('access_log', None)
 
             if options.pop('use_default_access_log', None):
                 access_log = logger

--- a/tests/aiohttp/test_aiohttp_app.py
+++ b/tests/aiohttp/test_aiohttp_app.py
@@ -62,6 +62,17 @@ def test_app_run_debug(web_run_app_mock, aiohttp_api_spec_dir):
     ]
 
 
+def test_app_run_access_log(web_run_app_mock, aiohttp_api_spec_dir):
+    app = AioHttpApp(__name__, port=5001,
+                     specification_dir=aiohttp_api_spec_dir,
+                     debug=True)
+    logger = logging.getLogger('connexion.aiohttp_app')
+    app.run(access_log=logger)
+    assert web_run_app_mock.call_args_list == [
+        mock.call(app.app, port=5001, host='0.0.0.0', access_log=logger)
+    ]
+
+
 def test_app_run_server_error(web_run_app_mock, aiohttp_api_spec_dir):
     app = AioHttpApp(__name__, port=5001,
                      specification_dir=aiohttp_api_spec_dir)


### PR DESCRIPTION
  - Pop access_log option from aiohttp options
  - Add test to access_log options in aiohttp run