### PR TITLE
Fixes Build: Allow new datetime behavior in PyYAML 5.3

### DIFF
--- a/tests/aiohttp/test_aiohttp_datetime.py
+++ b/tests/aiohttp/test_aiohttp_datetime.py
@@ -27,7 +27,10 @@ def test_swagger_json(aiohttp_api_spec_dir, aiohttp_client):
         return data
 
     example = get_value(spec_data, 'paths./datetime.get.responses.200.content.application/json.schema.example.value')
-    assert example == '2000-01-23T04:56:07.000008Z'
+    assert example in [
+        '2000-01-23T04:56:07.000008+00:00',  # PyYAML 5.3
+        '2000-01-23T04:56:07.000008Z'
+    ]
     example = get_value(spec_data, 'paths./date.get.responses.200.content.application/json.schema.example.value')
     assert example == '2000-01-23'
     example = get_value(spec_data, 'paths./uuid.get.responses.200.content.application/json.schema.example.value')

--- a/tests/test_flask_encoder.py
+++ b/tests/test_flask_encoder.py
@@ -63,7 +63,10 @@ def test_readonly(json_datetime_dir, spec):
         return data
 
     example = get_value(spec_data, 'paths./datetime.get.{}.example.value'.format(response_path))
-    assert example == '2000-01-23T04:56:07.000008Z'
+    assert example in [
+        '2000-01-23T04:56:07.000008+00:00',  # PyYAML 5.3+
+        '2000-01-23T04:56:07.000008Z'
+    ]
     example = get_value(spec_data, 'paths./date.get.{}.example.value'.format(response_path))
     assert example == '2000-01-23'
     example = get_value(spec_data, 'paths./uuid.get.{}.example.value'.format(response_path))


### PR DESCRIPTION
Fixes Master, which is broken due to PyYAML change in 5.3
https://github.com/yaml/pyyaml/pull/163

Changes proposed in this pull request:
 - update test to not expect `Zulu` datetime ending, as PyYAML 5.3 parses the date as TZ aware
