### PR TITLE
match all but whitespaces inside object keys

### DIFF
--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -188,7 +188,7 @@ class OpenAPIURIParser(AbstractURIParser):
         root_key = k.split("[", 1)[0]
         if k == root_key:
             return (k, v, False)
-        key_path = re.findall(r'\[(\S[^\[\]]+)\]', k)
+        key_path = re.findall(r'\[(\S[^\[\]]*)\]', k)
         root = prev = node = {}
         for k in key_path:
             node[k] = {}

--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -188,7 +188,7 @@ class OpenAPIURIParser(AbstractURIParser):
         root_key = k.split("[", 1)[0]
         if k == root_key:
             return (k, v, False)
-        key_path = re.findall(r'\[(.[^\[\]]*)\]', k)
+        key_path = re.findall(r'\[([^\[\]]*)\]', k)
         root = prev = node = {}
         for k in key_path:
             node[k] = {}

--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -188,7 +188,7 @@ class OpenAPIURIParser(AbstractURIParser):
         root_key = k.split("[", 1)[0]
         if k == root_key:
             return (k, v, False)
-        key_path = re.findall(r'\[(\S+)\]', k)
+        key_path = re.findall(r'\[(\S[^\[\]]+)\]', k)
         root = prev = node = {}
         for k in key_path:
             node[k] = {}

--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -188,7 +188,7 @@ class OpenAPIURIParser(AbstractURIParser):
         root_key = k.split("[", 1)[0]
         if k == root_key:
             return (k, v, False)
-        key_path = re.findall(r'\[(\S[^\[\]]*)\]', k)
+        key_path = re.findall(r'\[(.[^\[\]]*)\]', k)
         root = prev = node = {}
         for k in key_path:
             node[k] = {}

--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -188,7 +188,7 @@ class OpenAPIURIParser(AbstractURIParser):
         root_key = k.split("[", 1)[0]
         if k == root_key:
             return (k, v, False)
-        key_path = re.findall(r'\[(\w+)\]', k)
+        key_path = re.findall(r'\[(\S+)\]', k)
         root = prev = node = {}
         for k in key_path:
             node[k] = {}

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -166,6 +166,15 @@ def test_exploded_deep_object_param_endpoint_openapi_additional_properties(simpl
     assert response_data == {'foo': 'bar', 'fooint': '2'}
 
 
+def test_exploded_deep_object_param_endpoint_openapi_with_dots(simple_openapi_app):
+    app_client = simple_openapi_app.app.test_client()
+
+    response = app_client.get('/v1.0/exploded-deep-object-param-additional-properties?id[foo]=bar&id[foo.foo]=barbar')  # type: flask.Response
+    assert response.status_code == 200
+    response_data = json.loads(response.data.decode('utf-8', 'replace'))
+    assert response_data == {'foo': 'bar', 'foo.foo': 'barbar'}
+
+
 def test_nested_exploded_deep_object_param_endpoint_openapi(simple_openapi_app):
     app_client = simple_openapi_app.app.test_client()
 


### PR DESCRIPTION
Fixes #1129  .

Changes proposed in this pull request:

 - inside of a exploded `deepObject`, the keys can be any character. Especially dots need to be allowed. sanitation does not apply, because it will result in an object key, not a python var name.
