### PR TITLE
Objects and Arrays recursively construct examples

### DIFF
--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -249,6 +249,75 @@ def test_mock_resolver_example_nested_in_list_openapi():
     assert status_code == 200
     assert response == ['bar']
 
+def test_mock_resolver_no_example_nested_in_object():
+    resolver = MockResolver(mock_all=True)
+
+    responses = {
+        '200': {
+            'schema': {
+                'type': 'object',
+                'properties': {
+                    'foo': {
+                        'type': 'string',
+                    }
+                },
+            }
+        }
+    }
+
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation={
+                                      'responses': responses
+                                  },
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions={},
+                                  resolver=resolver)
+    assert operation.operation_id == 'mock-1'
+
+    response, status_code = resolver.mock_operation(operation)
+    assert status_code == 200
+    assert response == 'No example response was defined.'
+
+def test_mock_resolver_no_example_nested_in_list_openapi():
+    resolver = MockResolver(mock_all=True)
+
+    responses = {
+        '202': {
+            'content': {
+                'application/json': {
+                    'schema': {
+                        'type': 'array',
+                        'items': {
+                            'type': 'string',
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    operation = OpenAPIOperation(api=None,
+                                 method='GET',
+                                 path='endpoint',
+                                 path_parameters=[],
+                                 operation={
+                                     'responses': responses
+                                 },
+                                 app_security=[],
+                                 resolver=resolver)
+    assert operation.operation_id == 'mock-1'
+
+    response, status_code = resolver.mock_operation(operation)
+    assert status_code == 202
+    assert response == 'No example response was defined.'
+
 def test_mock_resolver_no_examples():
     resolver = MockResolver(mock_all=True)
 

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -1,5 +1,5 @@
 from connexion.mock import MockResolver
-from connexion.operations import Swagger2Operation
+from connexion.operations import Swagger2Operation, OpenAPIOperation
 
 
 def test_mock_resolver_default():
@@ -106,6 +106,148 @@ def test_mock_resolver_example():
     response, status_code = resolver.mock_operation(operation)
     assert status_code == 200
     assert response == {'foo': 'bar'}
+
+def test_mock_resolver_example_nested_in_object():
+    resolver = MockResolver(mock_all=True)
+
+    responses = {
+        'default': {
+            'schema': {
+                'type': 'object',
+                'properties': {
+                    'foo': {
+                        'type': 'string',
+                        'example': 'bar'
+                    }
+                },
+            }
+        }
+    }
+
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation={
+                                      'responses': responses
+                                  },
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions={},
+                                  resolver=resolver)
+    assert operation.operation_id == 'mock-1'
+
+    response, status_code = resolver.mock_operation(operation)
+    assert status_code == 200
+    assert response == {'foo': 'bar'}
+
+def test_mock_resolver_example_nested_in_list():
+    resolver = MockResolver(mock_all=True)
+
+    responses = {
+        'default': {
+            'schema': {
+                'type': 'array',
+                'items': {
+                    'type': 'string',
+                    'example': 'bar'
+                },
+            }
+        }
+    }
+
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation={
+                                      'responses': responses
+                                  },
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions={},
+                                  resolver=resolver)
+    assert operation.operation_id == 'mock-1'
+
+    response, status_code = resolver.mock_operation(operation)
+    assert status_code == 200
+    assert response == ['bar']
+
+def test_mock_resolver_example_nested_in_object_openapi():
+    resolver = MockResolver(mock_all=True)
+
+    responses = {
+        'default': {
+            'content': {
+                'application/json': {
+                    'schema': {
+                        'type': 'object',
+                        'properties': {
+                            'foo': {
+                                'type': 'string',
+                                'example': 'bar'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    operation = OpenAPIOperation(api=None,
+                                 method='GET',
+                                 path='endpoint',
+                                 path_parameters=[],
+                                 operation={
+                                     'responses': responses
+                                 },
+                                 app_security=[],
+                                 resolver=resolver)
+    assert operation.operation_id == 'mock-1'
+
+    response, status_code = resolver.mock_operation(operation)
+    assert status_code == 200
+    assert response == {'foo': 'bar'}
+
+def test_mock_resolver_example_nested_in_list_openapi():
+    resolver = MockResolver(mock_all=True)
+
+    responses = {
+        'default': {
+            'content': {
+                'application/json': {
+                    'schema': {
+                        'type': 'array',
+                        'items': {
+                            'type': 'string',
+                            'example': 'bar'
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    operation = OpenAPIOperation(api=None,
+                                 method='GET',
+                                 path='endpoint',
+                                 path_parameters=[],
+                                 operation={
+                                     'responses': responses
+                                 },
+                                 app_security=[],
+                                 resolver=resolver)
+    assert operation.operation_id == 'mock-1'
+
+    response, status_code = resolver.mock_operation(operation)
+    assert status_code == 200
+    assert response == ['bar']
 
 def test_mock_resolver_no_examples():
     resolver = MockResolver(mock_all=True)


### PR DESCRIPTION
Objects and Arrays recursively construct examples from examples of their children

Fixes #409 .

Changes proposed in this pull request:

 - In MockResolver, Objects and Arrays recursively construct examples from examples of their children
 - Extra tests in test_mock.py