### PR TITLE
Use `body` for DELETEs

### DIFF
--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -267,7 +267,7 @@ class AbstractOperation(SecureOperation, metaclass=abc.ABCMeta):
         ret.update(self._get_query_arguments(query_params, arguments,
                                              has_kwargs, sanitize))
 
-        if self.method.upper() in ["PATCH", "POST", "PUT"]:
+        if self.method.upper() in ["DELETE", "PATCH", "POST", "PUT"]:
             ret.update(self._get_body_argument(body, arguments,
                                                has_kwargs, sanitize))
             ret.update(self._get_file_arguments(files, arguments, has_kwargs))


### PR DESCRIPTION
According to
https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE, the
`DELETE` method may use a request with a body.

Fixes #517

Changes proposed in this pull request:

 - Do not ignore the "DELETE" method while converting the request body into function args/kwargs.
