### PR TITLE
Fix typo in security.rst from of to an or

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -11,7 +11,7 @@ With Connexion, the API security definition **must** include a
 ``x-tokenInfoFunc`` must contain a reference to a function
 used to obtain the token info. This reference should be a string using
 the same syntax that is used to connect an ``operationId`` to a Python
-function when routing. For example, an ``x-tokenInfoFunc`` or 
+function when routing. For example, an ``x-tokenInfoFunc`` with a value of 
 ``auth.verifyToken`` would pass the user's token string to the function
 ``verifyToken`` in the module ``auth.py``. The referenced function accepts
 a token string as argument and should return a dict containing a ``scope``

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -11,7 +11,7 @@ With Connexion, the API security definition **must** include a
 ``x-tokenInfoFunc`` must contain a reference to a function
 used to obtain the token info. This reference should be a string using
 the same syntax that is used to connect an ``operationId`` to a Python
-function when routing. For example, an ``x-tokenInfoFunc`` of 
+function when routing. For example, an ``x-tokenInfoFunc`` or 
 ``auth.verifyToken`` would pass the user's token string to the function
 ``verifyToken`` in the module ``auth.py``. The referenced function accepts
 a token string as argument and should return a dict containing a ``scope``


### PR DESCRIPTION
Changed `of` to an `or`, I guessed a Dutch person wrote this and noticed it's one of the biggest gotchas to see if a Dutchie is the author.

Fixes # .
There is a type in the document where an or should replace the of.


Changes proposed in this pull request:

 - Change "For example, an `x-tokenInfoFunc` of `auth.verifyToken` would pass..." to "For example, an `x-tokenInfoFunc` or `auth.verifyToken` would pass..."

