### PR TITLE
expose swagger-ui index template variables to app configuration

### DIFF
--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -237,7 +237,8 @@ class AioHttpApi(AbstractAPI):
     async def _get_swagger_ui_home(self, req):
         base_path = self._base_path_for_prefix(req)
         template_variables = {
-            'openapi_spec_url': (base_path + self.options.openapi_spec_path)
+            'openapi_spec_url': (base_path + self.options.openapi_spec_path),
+            **self.options.openapi_console_ui_index_template_variables,
         }
         if self.options.openapi_console_ui_config is not None:
             template_variables['configUrl'] = 'swagger-ui-config.json'

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -286,7 +286,8 @@ class InternalHandlers:
             prefix=escaped
         )
         template_variables = {
-            'openapi_spec_url': flask.url_for(openapi_json_route_name)
+            'openapi_spec_url': flask.url_for(openapi_json_route_name),
+            **self.options.openapi_console_ui_index_template_variables,
         }
         if self.options.openapi_console_ui_config is not None:
             template_variables['configUrl'] = 'swagger-ui-config.json'

--- a/connexion/options.py
+++ b/connexion/options.py
@@ -123,6 +123,16 @@ class ConnexionOptions:
         return self._options.get('swagger_ui_config', None)
 
     @property
+    def openapi_console_ui_index_template_variables(self):
+        # type: () -> dict
+        """
+        Custom variables passed to the OpenAPI Console UI template.
+
+        Default: {}
+        """
+        return self._options.get('swagger_ui_template_arguments', {})
+
+    @property
     def uri_parser_class(self):
         # type: () -> AbstractURIParser
         """


### PR DESCRIPTION
Fixes #1178  .



Changes proposed in this pull request:

- add an app option for variables which will be passed to swagger-ui index.j2 template
