### PR TITLE
Fixed spelling of uri_parser_class in code example

### DIFF
--- a/docs/request.rst
+++ b/docs/request.rst
@@ -144,7 +144,7 @@ api options.
 .. code-block:: python
 
    from connexion.decorators.uri_parsing import Swagger2URIParser
-   options = {'uri_parsing_class': Swagger2URIParser}
+   options = {'uri_parser_class': Swagger2URIParser}
    app = connexion.App(__name__, specification_dir='swagger/', options=options)
 
 You can implement your own URI parsing behavior by inheriting from


### PR DESCRIPTION
The `uri_parsing_class` option presented in the docs does not exist. It took me some time to figure out that the name of this option is actually `uri_parser_class`.

Changes proposed in this pull request:
 - Correct `uri_parsing_class` to `uri_parser_class` in docs example.
