### PR TITLE
docs: Fix simple typo, parseing -> parsing

### DIFF
--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -72,7 +72,7 @@ class AbstractOperation(SecureOperation, metaclass=abc.ABCMeta):
         :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended
         to any shadowed built-ins
         :type pythonic_params: bool
-        :param uri_parser_class: class to use for uri parseing
+        :param uri_parser_class: class to use for uri parsing
         :type uri_parser_class: AbstractURIParser
         :param pass_context_arg_name: If not None will try to inject the request context to the function using this
         name.

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -54,7 +54,7 @@ class OpenAPIOperation(AbstractOperation):
         :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended
         to any shadowed built-ins
         :type pythonic_params: bool
-        :param uri_parser_class: class to use for uri parseing
+        :param uri_parser_class: class to use for uri parsing
         :type uri_parser_class: AbstractURIParser
         :param pass_context_arg_name: If not None will try to inject the request context to the function using this
         name.

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -68,7 +68,7 @@ class Swagger2Operation(AbstractOperation):
         :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended
         to any shadowed built-ins
         :type pythonic_params: bool
-        :param uri_parser_class: class to use for uri parseing
+        :param uri_parser_class: class to use for uri parsing
         :type uri_parser_class: AbstractURIParser
         :param pass_context_arg_name: If not None will try to inject the request context to the function using this
         name.


### PR DESCRIPTION
There is a small typo in connexion/operations/abstract.py, connexion/operations/openapi.py, connexion/operations/swagger2.py.

Should read `parsing` rather than `parseing`.

