### PR TITLE
Fix _framework_to_connexion_response for StreamResponse

### DIFF
--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -343,12 +343,15 @@ class AioHttpApi(AbstractAPI):
     @classmethod
     def _framework_to_connexion_response(cls, response, mimetype):
         """ Cast framework response class to ConnexionResponse used for schema validation """
+        body = None
+        if hasattr(response, "body"):  # StreamResponse and FileResponse don't have body
+            body = response.body
         return ConnexionResponse(
             status_code=response.status,
             mimetype=mimetype,
             content_type=response.content_type,
             headers=response.headers,
-            body=response.body
+            body=body
         )
 
     @classmethod

--- a/tests/aiohttp/test_get_response.py
+++ b/tests/aiohttp/test_get_response.py
@@ -24,6 +24,15 @@ def test_get_response_from_aiohttp_response(api):
 
 
 @asyncio.coroutine
+def test_get_response_from_aiohttp_stream_response(api):
+    response = yield from api.get_response(web.StreamResponse(status=201, headers={'X-header': 'value'}))
+    assert isinstance(response, web.StreamResponse)
+    assert response.status == 201
+    assert response.content_type == 'application/octet-stream'
+    assert dict(response.headers) == {'X-header': 'value'}
+
+
+@asyncio.coroutine
 def test_get_response_from_connexion_response(api):
     response = yield from api.get_response(ConnexionResponse(status_code=201, mimetype='text/plain', body='foo', headers={'X-header': 'value'}))
     assert isinstance(response, web.Response)
@@ -170,3 +179,12 @@ def test_get_connexion_response_from_tuple(api):
     assert response.body == b'foo'
     assert response.content_type == 'text/plain'
     assert dict(response.headers) == {'Content-Type': 'text/plain; charset=utf-8', 'X-header': 'value'}
+
+@asyncio.coroutine
+def test_get_connexion_response_from_aiohttp_stream_response(api):
+    response = api.get_connexion_response(web.StreamResponse(status=201, headers={'X-header': 'value'}))
+    assert isinstance(response, ConnexionResponse)
+    assert response.status_code == 201
+    assert response.body == None
+    assert response.content_type == 'application/octet-stream'
+    assert dict(response.headers) == {'X-header': 'value'}


### PR DESCRIPTION
Returning a `aiohttp` `StreamResponse` (and probably `FileResponse`) was failing the `AioHttpApi._framework_to_connexion_response` made the assumption that the `response` object had a body, which is not the case for `StreamResponse` and `FileResponse`

Changes proposed in this pull request:
 - We now check if the `response` given to `_framework_to_connexion_response` has a `body` attribute and default to a `None` body otherwise
 - I prefered to use: 
    ```python
    if hasattr(response, "body"):
        body = response.body
    ```
    rather than:
    ```python
    if isinstance(response, web.Reponse):
        body = response.body
    ```
     in prevision of the unlike case where `aiohttp` would add another `web.StreamResponse` sublcass without body
