### PR TITLE
Switched from mock to unittest.mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ aiohttp_require = [
 
 tests_require = [
     'decorator',
-    'mock',
     'pytest',
     'pytest-cov',
     'testfixtures',

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -1,7 +1,7 @@
 import json
 
 import jinja2
-import mock
+from unittest import mock
 import pytest
 import yaml
 from openapi_spec_validator.loaders import ExtendedSafeLoader

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -1,5 +1,5 @@
 # we are using "mock" module here for Py 2.7 support
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from connexion.decorators.parameter import parameter_to_arg
 

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -1,4 +1,3 @@
-# we are using "mock" module here for Py 2.7 support
 from unittest.mock import MagicMock
 
 from connexion.decorators.parameter import parameter_to_arg

--- a/tests/decorators/test_security.py
+++ b/tests/decorators/test_security.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 import requests
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from connexion.decorators.security import (get_tokeninfo_func,
                                            get_tokeninfo_remote,

--- a/tests/decorators/test_validation.py
+++ b/tests/decorators/test_validation.py
@@ -1,6 +1,6 @@
 import pytest
 from jsonschema import ValidationError
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from connexion.decorators.validation import ParameterValidator
 from connexion.json_schema import (Draft4RequestValidator,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 from yaml import YAMLError
 
 from connexion import FlaskApi

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,8 +2,8 @@ import logging
 
 import pytest
 from click.testing import CliRunner
-from mock import MagicMock
-from mock import call as mock_call
+from unittest.mock import MagicMock
+from unittest.mock import call as mock_call
 
 import connexion
 from conftest import FIXTURES_FOLDER

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,7 +2,7 @@ import json
 
 import flask
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import connexion
 from connexion.exceptions import ProblemException

--- a/tests/test_operation2.py
+++ b/tests/test_operation2.py
@@ -3,7 +3,7 @@ import math
 import pathlib
 import types
 
-import mock
+from unittest import mock
 import pytest
 
 from connexion.apis.flask_api import Jsonifier

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from connexion.apis.flask_api import Jsonifier

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import math
 
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import connexion.apps
 from connexion import utils

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,7 +2,6 @@ import json
 
 import flask
 import pytest
-# we are using "mock" module here for Py 2.7 support
 from unittest.mock import MagicMock
 
 from connexion.apis.flask_api import FlaskApi

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -3,7 +3,7 @@ import json
 import flask
 import pytest
 # we are using "mock" module here for Py 2.7 support
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from connexion.apis.flask_api import FlaskApi
 from connexion.exceptions import BadRequestProblem


### PR DESCRIPTION
Since you dropped python 2.7 support, a switch from mock to unittest.mock is possible. The switch is done in this pull request.

By the way:
I made a request for packaging connexion-2.6.0 for debian unstable and already submitted a package. If you are interested in it, have a look at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=958042