### PR TITLE
Python 3.8: replace asyncio.coroutine/yield from with async/await in decorators

### DIFF
--- a/connexion/decorators/coroutine_wrappers.py
+++ b/connexion/decorators/coroutine_wrappers.py
@@ -13,23 +13,23 @@ def get_request_life_cycle_wrapper(function, api, mimetype):
     :rtype asyncio.coroutine
     """
     @functools.wraps(function)
-    def wrapper(*args, **kwargs):
+    async def wrapper(*args, **kwargs):
         connexion_request = api.get_request(*args, **kwargs)
         while asyncio.iscoroutine(connexion_request):
-            connexion_request = yield from connexion_request
+            connexion_request = await connexion_request
 
         connexion_response = function(connexion_request)
         while asyncio.iscoroutine(connexion_response):
-            connexion_response = yield from connexion_response
+            connexion_response = await connexion_response
 
         framework_response = api.get_response(connexion_response, mimetype,
                                               connexion_request)
         while asyncio.iscoroutine(framework_response):
-            framework_response = yield from framework_response
+            framework_response = await framework_response
 
         return framework_response
 
-    return asyncio.coroutine(wrapper)
+    return wrapper
 
 
 def get_response_validator_wrapper(function, _wrapper):
@@ -43,11 +43,11 @@ def get_response_validator_wrapper(function, _wrapper):
     :rtype asyncio.coroutine
     """
     @functools.wraps(function)
-    def wrapper(request):
+    async def wrapper(request):
         response = function(request)
         while asyncio.iscoroutine(response):
-            response = yield from response
+            response = await response
 
         return _wrapper(request, response)
 
-    return asyncio.coroutine(wrapper)
+    return wrapper

--- a/connexion/decorators/coroutine_wrappers.py
+++ b/connexion/decorators/coroutine_wrappers.py
@@ -6,7 +6,7 @@ def get_request_life_cycle_wrapper(function, api, mimetype):
     """
     It is a wrapper used on `RequestResponseDecorator` class.
     This function is located in an extra module because python2.7 don't
-    support the 'yield from' syntax. This function is used to await
+    support the 'await' syntax. This function is used to await
     the coroutines to connexion does the proper validation of parameters
     and responses.
 
@@ -36,7 +36,7 @@ def get_response_validator_wrapper(function, _wrapper):
     """
     It is a wrapper used on `ResponseValidator` class.
     This function is located in an extra module because python2.7 don't
-    support the 'yield from' syntax. This function is used to await
+    support the 'await' syntax. This function is used to await
     the coroutines to connexion does the proper validation of parameters
     and responses.
 

--- a/tests/aiohttp/test_aiohttp_datetime.py
+++ b/tests/aiohttp/test_aiohttp_datetime.py
@@ -8,17 +8,16 @@ except ImportError:
     import json
 
 
-@asyncio.coroutine
-def test_swagger_json(aiohttp_api_spec_dir, aiohttp_client):
+async def test_swagger_json(aiohttp_api_spec_dir, aiohttp_client):
     """ Verify the swagger.json file is returned for default setting passed to app. """
     app = AioHttpApp(__name__, port=5001,
                      specification_dir=aiohttp_api_spec_dir,
                      debug=True)
     app.add_api('datetime_support.yaml')
 
-    app_client = yield from aiohttp_client(app.app)
-    swagger_json = yield from app_client.get('/v1.0/openapi.json')
-    spec_data = yield from swagger_json.json()
+    app_client = await aiohttp_client(app.app)
+    swagger_json = await app_client.get('/v1.0/openapi.json')
+    spec_data = await swagger_json.json()
 
     def get_value(data, path):
         for part in path.split('.'):
@@ -36,17 +35,17 @@ def test_swagger_json(aiohttp_api_spec_dir, aiohttp_client):
     example = get_value(spec_data, 'paths./uuid.get.responses.200.content.application/json.schema.example.value')
     assert example == 'a7b8869c-5f24-4ce0-a5d1-3e44c3663aa9'
 
-    resp = yield from app_client.get('/v1.0/datetime')
+    resp = await app_client.get('/v1.0/datetime')
     assert resp.status == 200
-    json_data = yield from resp.json()
+    json_data = await resp.json()
     assert json_data == {'value': '2000-01-02T03:04:05.000006Z'}
 
-    resp = yield from app_client.get('/v1.0/date')
+    resp = await app_client.get('/v1.0/date')
     assert resp.status == 200
-    json_data = yield from resp.json()
+    json_data = await resp.json()
     assert json_data == {'value': '2000-01-02'}
 
-    resp = yield from app_client.get('/v1.0/uuid')
+    resp = await app_client.get('/v1.0/uuid')
     assert resp.status == 200
-    json_data = yield from resp.json()
+    json_data = await resp.json()
     assert json_data == {'value': 'e7ff66d0-3ec2-4c4e-bed0-6e4723c24c51'}

--- a/tests/aiohttp/test_aiohttp_errors.py
+++ b/tests/aiohttp/test_aiohttp_errors.py
@@ -21,16 +21,15 @@ def aiohttp_app(problem_api_spec_dir):
     return app
 
 
-@asyncio.coroutine
-def test_aiohttp_problems_404(aiohttp_app, aiohttp_client):
+async def test_aiohttp_problems_404(aiohttp_app, aiohttp_client):
     # TODO: This is a based on test_errors.test_errors(). That should be refactored
     #       so that it is parameterized for all web frameworks.
-    app_client = yield from aiohttp_client(aiohttp_app.app)  # type: aiohttp.test_utils.TestClient
+    app_client = await aiohttp_client(aiohttp_app.app)  # type: aiohttp.test_utils.TestClient
 
-    greeting404 = yield from app_client.get('/v1.0/greeting')  # type: aiohttp.ClientResponse
+    greeting404 = await app_client.get('/v1.0/greeting')  # type: aiohttp.ClientResponse
     assert greeting404.content_type == 'application/problem+json'
     assert greeting404.status == 404
-    error404 = yield from greeting404.json()
+    error404 = await greeting404.json()
     assert is_valid_problem_json(error404)
     assert error404['type'] == 'about:blank'
     assert error404['title'] == 'Not Found'
@@ -38,16 +37,15 @@ def test_aiohttp_problems_404(aiohttp_app, aiohttp_client):
     assert error404['status'] == 404
     assert 'instance' not in error404
 
-@asyncio.coroutine
-def test_aiohttp_problems_405(aiohttp_app, aiohttp_client):
+async def test_aiohttp_problems_405(aiohttp_app, aiohttp_client):
     # TODO: This is a based on test_errors.test_errors(). That should be refactored
     #       so that it is parameterized for all web frameworks.
-    app_client = yield from aiohttp_client(aiohttp_app.app)  # type: aiohttp.test_utils.TestClient
+    app_client = await aiohttp_client(aiohttp_app.app)  # type: aiohttp.test_utils.TestClient
 
-    get_greeting = yield from app_client.get('/v1.0/greeting/jsantos')  # type: aiohttp.ClientResponse
+    get_greeting = await app_client.get('/v1.0/greeting/jsantos')  # type: aiohttp.ClientResponse
     assert get_greeting.content_type == 'application/problem+json'
     assert get_greeting.status == 405
-    error405 = yield from get_greeting.json()
+    error405 = await get_greeting.json()
     assert is_valid_problem_json(error405)
     assert error405['type'] == 'about:blank'
     assert error405['title'] == 'Method Not Allowed'
@@ -55,16 +53,15 @@ def test_aiohttp_problems_405(aiohttp_app, aiohttp_client):
     assert error405['status'] == 405
     assert 'instance' not in error405
 
-@asyncio.coroutine
-def test_aiohttp_problems_500(aiohttp_app, aiohttp_client):
+async def test_aiohttp_problems_500(aiohttp_app, aiohttp_client):
     # TODO: This is a based on test_errors.test_errors(). That should be refactored
     #       so that it is parameterized for all web frameworks.
-    app_client = yield from aiohttp_client(aiohttp_app.app)  # type: aiohttp.test_utils.TestClient
+    app_client = await aiohttp_client(aiohttp_app.app)  # type: aiohttp.test_utils.TestClient
 
-    get500 = yield from app_client.get('/v1.0/except')  # type: aiohttp.ClientResponse
+    get500 = await app_client.get('/v1.0/except')  # type: aiohttp.ClientResponse
     assert get500.content_type == 'application/problem+json'
     assert get500.status == 500
-    error500 = yield from get500.json()
+    error500 = await get500.json()
     assert is_valid_problem_json(error500)
     assert error500['type'] == 'about:blank'
     assert error500['title'] == 'Internal Server Error'
@@ -72,17 +69,16 @@ def test_aiohttp_problems_500(aiohttp_app, aiohttp_client):
     assert error500['status'] == 500
     assert 'instance' not in error500
 
-@asyncio.coroutine
-def test_aiohttp_problems_418(aiohttp_app, aiohttp_client):
+async def test_aiohttp_problems_418(aiohttp_app, aiohttp_client):
     # TODO: This is a based on test_errors.test_errors(). That should be refactored
     #       so that it is parameterized for all web frameworks.
-    app_client = yield from aiohttp_client(aiohttp_app.app)  # type: aiohttp.test_utils.TestClient
+    app_client = await aiohttp_client(aiohttp_app.app)  # type: aiohttp.test_utils.TestClient
 
-    get_problem = yield from app_client.get('/v1.0/problem')  # type: aiohttp.ClientResponse
+    get_problem = await app_client.get('/v1.0/problem')  # type: aiohttp.ClientResponse
     assert get_problem.content_type == 'application/problem+json'
     assert get_problem.status == 418
     assert get_problem.headers['x-Test-Header'] == 'In Test'
-    error_problem = yield from get_problem.json()
+    error_problem = await get_problem.json()
     assert is_valid_problem_json(error_problem)
     assert error_problem['type'] == 'http://www.example.com/error'
     assert error_problem['title'] == 'Some Error'
@@ -90,30 +86,29 @@ def test_aiohttp_problems_418(aiohttp_app, aiohttp_client):
     assert error_problem['status'] == 418
     assert error_problem['instance'] == 'instance1'
 
-@asyncio.coroutine
-def test_aiohttp_problems_misc(aiohttp_app, aiohttp_client):
+async def test_aiohttp_problems_misc(aiohttp_app, aiohttp_client):
     # TODO: This is a based on test_errors.test_errors(). That should be refactored
     #       so that it is parameterized for all web frameworks.
-    app_client = yield from aiohttp_client(aiohttp_app.app)  # type: aiohttp.test_utils.TestClient
+    app_client = await aiohttp_client(aiohttp_app.app)  # type: aiohttp.test_utils.TestClient
 
-    problematic_json = yield from app_client.get(
+    problematic_json = await app_client.get(
         '/v1.0/json_response_with_undefined_value_to_serialize')  # type: aiohttp.ClientResponse
     assert problematic_json.content_type == 'application/problem+json'
     assert problematic_json.status == 500
-    problematic_json_body = yield from problematic_json.json()
+    problematic_json_body = await problematic_json.json()
     assert is_valid_problem_json(problematic_json_body)
 
-    custom_problem = yield from app_client.get('/v1.0/customized_problem_response')  # type: aiohttp.ClientResponse
+    custom_problem = await app_client.get('/v1.0/customized_problem_response')  # type: aiohttp.ClientResponse
     assert custom_problem.content_type == 'application/problem+json'
     assert custom_problem.status == 403
-    problem_body = yield from custom_problem.json()
+    problem_body = await custom_problem.json()
     assert is_valid_problem_json(problem_body)
     assert 'amount' in problem_body
 
-    problem_as_exception = yield from app_client.get('/v1.0/problem_exception_with_extra_args')  # type: aiohttp.ClientResponse
+    problem_as_exception = await app_client.get('/v1.0/problem_exception_with_extra_args')  # type: aiohttp.ClientResponse
     assert problem_as_exception.content_type == "application/problem+json"
     assert problem_as_exception.status == 400
-    problem_as_exception_body = yield from problem_as_exception.json()
+    problem_as_exception_body = await problem_as_exception.json()
     assert is_valid_problem_json(problem_as_exception_body)
     assert 'age' in problem_as_exception_body
     assert problem_as_exception_body['age'] == 30
@@ -122,14 +117,13 @@ def test_aiohttp_problems_misc(aiohttp_app, aiohttp_client):
 @pytest.mark.skip(reason="aiohttp_api.get_connexion_response uses _cast_body "
                          "to stringify the dict directly instead of using json.dumps. "
                          "This differs from flask usage, where there is no _cast_body.")
-@asyncio.coroutine
-def test_aiohttp_problem_with_text_content_type(aiohttp_app, aiohttp_client):
-    app_client = yield from aiohttp_client(aiohttp_app.app)  # type: aiohttp.test_utils.TestClient
+async def test_aiohttp_problem_with_text_content_type(aiohttp_app, aiohttp_client):
+    app_client = await aiohttp_client(aiohttp_app.app)  # type: aiohttp.test_utils.TestClient
 
-    get_problem2 = yield from app_client.get('/v1.0/other_problem')  # type: aiohttp.ClientResponse
+    get_problem2 = await app_client.get('/v1.0/other_problem')  # type: aiohttp.ClientResponse
     assert get_problem2.content_type == 'application/problem+json'
     assert get_problem2.status == 418
-    error_problem2 = yield from get_problem2.json()
+    error_problem2 = await get_problem2.json()
     assert is_valid_problem_json(error_problem2)
     assert error_problem2['type'] == 'about:blank'
     assert error_problem2['title'] == 'Some Error'

--- a/tests/aiohttp/test_aiohttp_reverse_proxy.py
+++ b/tests/aiohttp/test_aiohttp_reverse_proxy.py
@@ -52,8 +52,7 @@ class XPathForwarded(XForwardedBase):
         await self.raise_error(request)
 
 
-    @asyncio.coroutine
-    def test_swagger_json_behind_proxy(simple_api_spec_dir, aiohttp_client):
+    async def test_swagger_json_behind_proxy(simple_api_spec_dir, aiohttp_client):
         """ Verify the swagger.json file is returned with base_path updated
             according to X-Forwarded-Path header. """
         app = AioHttpApp(__name__, port=5001,
@@ -65,20 +64,20 @@ class XPathForwarded(XForwardedBase):
         reverse_proxied = XPathForwarded()
         aio.middlewares.append(reverse_proxied.middleware)
 
-        app_client = yield from aiohttp_client(app.app)
+        app_client = await aiohttp_client(app.app)
         headers = {'X-Forwarded-Path': '/behind/proxy'}
 
-        swagger_ui = yield from app_client.get('/v1.0/ui/', headers=headers)
+        swagger_ui = await app_client.get('/v1.0/ui/', headers=headers)
         assert swagger_ui.status == 200
         assert b'url = "/behind/proxy/v1.0/swagger.json"' in (
-            yield from swagger_ui.read()
+            await swagger_ui.read()
         )
 
-        swagger_json = yield from app_client.get('/v1.0/swagger.json',
+        swagger_json = await app_client.get('/v1.0/swagger.json',
                                                  headers=headers)
         assert swagger_json.status == 200
         assert swagger_json.headers.get('Content-Type') == 'application/json'
-        json_ = yield from swagger_json.json()
+        json_ = await swagger_json.json()
 
         assert api.specification.raw['basePath'] == '/v1.0', \
             "Original specifications should not have been changed"
@@ -91,8 +90,7 @@ class XPathForwarded(XForwardedBase):
             "Only basePath should have been updated"
 
 
-    @asyncio.coroutine
-    def test_openapi_json_behind_proxy(simple_api_spec_dir, aiohttp_client):
+    async def test_openapi_json_behind_proxy(simple_api_spec_dir, aiohttp_client):
         """ Verify the swagger.json file is returned with base_path updated
             according to X-Forwarded-Path header. """
         app = AioHttpApp(__name__, port=5001,
@@ -105,20 +103,20 @@ class XPathForwarded(XForwardedBase):
         reverse_proxied = XPathForwarded()
         aio.middlewares.append(reverse_proxied.middleware)
 
-        app_client = yield from aiohttp_client(app.app)
+        app_client = await aiohttp_client(app.app)
         headers = {'X-Forwarded-Path': '/behind/proxy'}
 
-        swagger_ui = yield from app_client.get('/v1.0/ui/', headers=headers)
+        swagger_ui = await app_client.get('/v1.0/ui/', headers=headers)
         assert swagger_ui.status == 200
         assert b'url: "/behind/proxy/v1.0/openapi.json"' in (
-            yield from swagger_ui.read()
+            await swagger_ui.read()
         )
 
-        swagger_json = yield from app_client.get('/v1.0/openapi.json',
+        swagger_json = await app_client.get('/v1.0/openapi.json',
                                                  headers=headers)
         assert swagger_json.status == 200
         assert swagger_json.headers.get('Content-Type') == 'application/json'
-        json_ = yield from swagger_json.json()
+        json_ = await swagger_json.json()
 
         assert json_.get('servers', [{}])[0].get('url') == '/behind/proxy/v1.0', \
             "basePath should contains original URI"

--- a/tests/aiohttp/test_aiohttp_simple_api.py
+++ b/tests/aiohttp/test_aiohttp_simple_api.py
@@ -23,63 +23,58 @@ def aiohttp_app(aiohttp_api_spec_dir):
     return app
 
 
-@asyncio.coroutine
-def test_app(aiohttp_app, aiohttp_client):
+async def test_app(aiohttp_app, aiohttp_client):
     # Create the app and run the test_app testcase below.
-    app_client = yield from aiohttp_client(aiohttp_app.app)
-    get_bye = yield from app_client.get('/v1.0/bye/jsantos')
+    app_client = await aiohttp_client(aiohttp_app.app)
+    get_bye = await app_client.get('/v1.0/bye/jsantos')
     assert get_bye.status == 200
-    assert (yield from get_bye.read()) == b'Goodbye jsantos'
+    assert (await get_bye.read()) == b'Goodbye jsantos'
 
 
-@asyncio.coroutine
-def test_app_with_relative_path(aiohttp_api_spec_dir, aiohttp_client):
+async def test_app_with_relative_path(aiohttp_api_spec_dir, aiohttp_client):
     # Create the app with a relative path and run the test_app testcase below.
     app = AioHttpApp(__name__, port=5001,
                      specification_dir='..' /
                                        aiohttp_api_spec_dir.relative_to(TEST_FOLDER),
                      debug=True)
     app.add_api('swagger_simple.yaml')
-    app_client = yield from aiohttp_client(app.app)
-    get_bye = yield from app_client.get('/v1.0/bye/jsantos')
+    app_client = await aiohttp_client(app.app)
+    get_bye = await app_client.get('/v1.0/bye/jsantos')
     assert get_bye.status == 200
-    assert (yield from get_bye.read()) == b'Goodbye jsantos'
+    assert (await get_bye.read()) == b'Goodbye jsantos'
 
 
-@asyncio.coroutine
-def test_swagger_json(aiohttp_api_spec_dir, aiohttp_client):
+async def test_swagger_json(aiohttp_api_spec_dir, aiohttp_client):
     """ Verify the swagger.json file is returned for default setting passed to app. """
     app = AioHttpApp(__name__, port=5001,
                      specification_dir=aiohttp_api_spec_dir,
                      debug=True)
     api = app.add_api('swagger_simple.yaml')
 
-    app_client = yield from aiohttp_client(app.app)
-    swagger_json = yield from app_client.get('/v1.0/swagger.json')
+    app_client = await aiohttp_client(app.app)
+    swagger_json = await app_client.get('/v1.0/swagger.json')
 
     assert swagger_json.status == 200
-    json_ = yield from swagger_json.json()
+    json_ = await swagger_json.json()
     assert api.specification.raw == json_
 
 
-@asyncio.coroutine
-def test_swagger_yaml(aiohttp_api_spec_dir, aiohttp_client):
+async def test_swagger_yaml(aiohttp_api_spec_dir, aiohttp_client):
     """ Verify the swagger.yaml file is returned for default setting passed to app. """
     app = AioHttpApp(__name__, port=5001,
                      specification_dir=aiohttp_api_spec_dir,
                      debug=True)
     api = app.add_api('swagger_simple.yaml')
 
-    app_client = yield from aiohttp_client(app.app)
-    spec_response = yield from app_client.get('/v1.0/swagger.yaml')
-    data_ = yield from spec_response.read()
+    app_client = await aiohttp_client(app.app)
+    spec_response = await app_client.get('/v1.0/swagger.yaml')
+    data_ = await spec_response.read()
 
     assert spec_response.status == 200
     assert api.specification.raw == yaml.load(data_)
 
 
-@asyncio.coroutine
-def test_no_swagger_json(aiohttp_api_spec_dir, aiohttp_client):
+async def test_no_swagger_json(aiohttp_api_spec_dir, aiohttp_client):
     """ Verify the swagger.json file is not returned when set to False when creating app. """
     options = {"swagger_json": False}
     app = AioHttpApp(__name__, port=5001,
@@ -88,13 +83,12 @@ def test_no_swagger_json(aiohttp_api_spec_dir, aiohttp_client):
                      debug=True)
     app.add_api('swagger_simple.yaml')
 
-    app_client = yield from aiohttp_client(app.app)
-    swagger_json = yield from app_client.get('/v1.0/swagger.json')  # type: flask.Response
+    app_client = await aiohttp_client(app.app)
+    swagger_json = await app_client.get('/v1.0/swagger.json')  # type: flask.Response
     assert swagger_json.status == 404
 
 
-@asyncio.coroutine
-def test_no_swagger_yaml(aiohttp_api_spec_dir, aiohttp_client):
+async def test_no_swagger_yaml(aiohttp_api_spec_dir, aiohttp_client):
     """ Verify the swagger.json file is not returned when set to False when creating app. """
     options = {"swagger_json": False}
     app = AioHttpApp(__name__, port=5001,
@@ -103,31 +97,29 @@ def test_no_swagger_yaml(aiohttp_api_spec_dir, aiohttp_client):
                      debug=True)
     app.add_api('swagger_simple.yaml')
 
-    app_client = yield from aiohttp_client(app.app)
-    spec_response = yield from app_client.get('/v1.0/swagger.yaml')  # type: flask.Response
+    app_client = await aiohttp_client(app.app)
+    spec_response = await app_client.get('/v1.0/swagger.yaml')  # type: flask.Response
     assert spec_response.status == 404
 
 
-@asyncio.coroutine
-def test_swagger_ui(aiohttp_api_spec_dir, aiohttp_client):
+async def test_swagger_ui(aiohttp_api_spec_dir, aiohttp_client):
     app = AioHttpApp(__name__, port=5001,
                      specification_dir=aiohttp_api_spec_dir,
                      debug=True)
     app.add_api('swagger_simple.yaml')
 
-    app_client = yield from aiohttp_client(app.app)
-    swagger_ui = yield from app_client.get('/v1.0/ui')
+    app_client = await aiohttp_client(app.app)
+    swagger_ui = await app_client.get('/v1.0/ui')
     assert swagger_ui.status == 200
     assert swagger_ui.url.path == '/v1.0/ui/'
-    assert b'url = "/v1.0/swagger.json"' in (yield from swagger_ui.read())
+    assert b'url = "/v1.0/swagger.json"' in (await swagger_ui.read())
 
-    swagger_ui = yield from app_client.get('/v1.0/ui/')
+    swagger_ui = await app_client.get('/v1.0/ui/')
     assert swagger_ui.status == 200
-    assert b'url = "/v1.0/swagger.json"' in (yield from swagger_ui.read())
+    assert b'url = "/v1.0/swagger.json"' in (await swagger_ui.read())
 
 
-@asyncio.coroutine
-def test_swagger_ui_config_json(aiohttp_api_spec_dir, aiohttp_client):
+async def test_swagger_ui_config_json(aiohttp_api_spec_dir, aiohttp_client):
     """ Verify the swagger-ui-config.json file is returned for swagger_ui_config option passed to app. """
     swagger_ui_config = {"displayOperationId": True}
     options = {"swagger_ui_config": swagger_ui_config}
@@ -137,43 +129,40 @@ def test_swagger_ui_config_json(aiohttp_api_spec_dir, aiohttp_client):
                      debug=True)
     api = app.add_api('swagger_simple.yaml')
 
-    app_client = yield from aiohttp_client(app.app)
-    swagger_ui_config_json = yield from app_client.get('/v1.0/ui/swagger-ui-config.json')
-    json_ = yield from swagger_ui_config_json.read()
+    app_client = await aiohttp_client(app.app)
+    swagger_ui_config_json = await app_client.get('/v1.0/ui/swagger-ui-config.json')
+    json_ = await swagger_ui_config_json.read()
 
     assert swagger_ui_config_json.status == 200
     assert swagger_ui_config == json.loads(json_)
 
 
-@asyncio.coroutine
-def test_no_swagger_ui_config_json(aiohttp_api_spec_dir, aiohttp_client):
+async def test_no_swagger_ui_config_json(aiohttp_api_spec_dir, aiohttp_client):
     """ Verify the swagger-ui-config.json file is not returned when the swagger_ui_config option not passed to app. """
     app = AioHttpApp(__name__, port=5001,
                      specification_dir=aiohttp_api_spec_dir,
                      debug=True)
     app.add_api('swagger_simple.yaml')
 
-    app_client = yield from aiohttp_client(app.app)
-    swagger_ui_config_json = yield from app_client.get('/v1.0/ui/swagger-ui-config.json')
+    app_client = await aiohttp_client(app.app)
+    swagger_ui_config_json = await app_client.get('/v1.0/ui/swagger-ui-config.json')
     assert swagger_ui_config_json.status == 404
 
 
-@asyncio.coroutine
-def test_swagger_ui_index(aiohttp_api_spec_dir, aiohttp_client):
+async def test_swagger_ui_index(aiohttp_api_spec_dir, aiohttp_client):
     app = AioHttpApp(__name__, port=5001,
                      specification_dir=aiohttp_api_spec_dir,
                      debug=True)
     app.add_api('openapi_secure.yaml')
 
-    app_client = yield from aiohttp_client(app.app)
-    swagger_ui = yield from app_client.get('/v1.0/ui/index.html')
+    app_client = await aiohttp_client(app.app)
+    swagger_ui = await app_client.get('/v1.0/ui/index.html')
     assert swagger_ui.status == 200
-    assert b'url: "/v1.0/openapi.json"' in (yield from swagger_ui.read())
-    assert b'swagger-ui-config.json' not in (yield from swagger_ui.read())
+    assert b'url: "/v1.0/openapi.json"' in (await swagger_ui.read())
+    assert b'swagger-ui-config.json' not in (await swagger_ui.read())
 
 
-@asyncio.coroutine
-def test_swagger_ui_index_with_config(aiohttp_api_spec_dir, aiohttp_client):
+async def test_swagger_ui_index_with_config(aiohttp_api_spec_dir, aiohttp_client):
     swagger_ui_config = {"displayOperationId": True}
     options = {"swagger_ui_config": swagger_ui_config}
     app = AioHttpApp(__name__, port=5001,
@@ -182,52 +171,49 @@ def test_swagger_ui_index_with_config(aiohttp_api_spec_dir, aiohttp_client):
                      debug=True)
     app.add_api('openapi_secure.yaml')
 
-    app_client = yield from aiohttp_client(app.app)
-    swagger_ui = yield from app_client.get('/v1.0/ui/index.html')
+    app_client = await aiohttp_client(app.app)
+    swagger_ui = await app_client.get('/v1.0/ui/index.html')
     assert swagger_ui.status == 200
-    assert b'configUrl: "swagger-ui-config.json"' in (yield from swagger_ui.read())
+    assert b'configUrl: "swagger-ui-config.json"' in (await swagger_ui.read())
 
 
-@asyncio.coroutine
-def test_pythonic_path_param(aiohttp_api_spec_dir, aiohttp_client):
+async def test_pythonic_path_param(aiohttp_api_spec_dir, aiohttp_client):
     app = AioHttpApp(__name__, port=5001,
                      specification_dir=aiohttp_api_spec_dir,
                      debug=True)
     app.add_api('openapi_simple.yaml', pythonic_params=True)
 
-    app_client = yield from aiohttp_client(app.app)
-    pythonic = yield from app_client.get('/v1.0/pythonic/100')
+    app_client = await aiohttp_client(app.app)
+    pythonic = await app_client.get('/v1.0/pythonic/100')
     assert pythonic.status == 200
-    j = yield from pythonic.json()
+    j = await pythonic.json()
     assert j['id_'] == 100
 
 
-@asyncio.coroutine
-def test_swagger_ui_static(aiohttp_api_spec_dir, aiohttp_client):
+async def test_swagger_ui_static(aiohttp_api_spec_dir, aiohttp_client):
     app = AioHttpApp(__name__, port=5001,
                      specification_dir=aiohttp_api_spec_dir,
                      debug=True)
     app.add_api('swagger_simple.yaml')
 
-    app_client = yield from aiohttp_client(app.app)
-    swagger_ui = yield from app_client.get('/v1.0/ui/lib/swagger-oauth.js')
+    app_client = await aiohttp_client(app.app)
+    swagger_ui = await app_client.get('/v1.0/ui/lib/swagger-oauth.js')
     assert swagger_ui.status == 200
 
-    app_client = yield from aiohttp_client(app.app)
-    swagger_ui = yield from app_client.get('/v1.0/ui/swagger-ui.min.js')
+    app_client = await aiohttp_client(app.app)
+    swagger_ui = await app_client.get('/v1.0/ui/swagger-ui.min.js')
     assert swagger_ui.status == 200
 
 
-@asyncio.coroutine
-def test_no_swagger_ui(aiohttp_api_spec_dir, aiohttp_client):
+async def test_no_swagger_ui(aiohttp_api_spec_dir, aiohttp_client):
     options = {"swagger_ui": False}
     app = AioHttpApp(__name__, port=5001,
                      specification_dir=aiohttp_api_spec_dir,
                      options=options, debug=True)
     app.add_api('swagger_simple.yaml')
 
-    app_client = yield from aiohttp_client(app.app)
-    swagger_ui = yield from app_client.get('/v1.0/ui/')
+    app_client = await aiohttp_client(app.app)
+    swagger_ui = await app_client.get('/v1.0/ui/')
     assert swagger_ui.status == 404
 
     app2 = AioHttpApp(__name__, port=5001,
@@ -235,18 +221,15 @@ def test_no_swagger_ui(aiohttp_api_spec_dir, aiohttp_client):
                       debug=True)
     options = {"swagger_ui": False}
     app2.add_api('swagger_simple.yaml', options=options)
-    app2_client = yield from aiohttp_client(app.app)
-    swagger_ui2 = yield from app2_client.get('/v1.0/ui/')
+    app2_client = await aiohttp_client(app.app)
+    swagger_ui2 = await app2_client.get('/v1.0/ui/')
     assert swagger_ui2.status == 404
 
 
-@asyncio.coroutine
-def test_middlewares(aiohttp_api_spec_dir, aiohttp_client):
-    @asyncio.coroutine
-    def middleware(app, handler):
-        @asyncio.coroutine
-        def middleware_handler(request):
-            response = (yield from handler(request))
+async def test_middlewares(aiohttp_api_spec_dir, aiohttp_client):
+    async def middleware(app, handler):
+        async def middleware_handler(request):
+            response = (await handler(request))
             response.body += b' middleware'
             return response
 
@@ -257,81 +240,73 @@ def test_middlewares(aiohttp_api_spec_dir, aiohttp_client):
                      specification_dir=aiohttp_api_spec_dir,
                      debug=True, options=options)
     app.add_api('swagger_simple.yaml')
-    app_client = yield from aiohttp_client(app.app)
-    get_bye = yield from app_client.get('/v1.0/bye/jsantos')
+    app_client = await aiohttp_client(app.app)
+    get_bye = await app_client.get('/v1.0/bye/jsantos')
     assert get_bye.status == 200
-    assert (yield from get_bye.read()) == b'Goodbye jsantos middleware'
+    assert (await get_bye.read()) == b'Goodbye jsantos middleware'
 
 
-@asyncio.coroutine
-def test_response_with_str_body(aiohttp_app, aiohttp_client):
+async def test_response_with_str_body(aiohttp_app, aiohttp_client):
     # Create the app and run the test_app testcase below.
-    app_client = yield from aiohttp_client(aiohttp_app.app)
-    get_bye = yield from app_client.get('/v1.0/aiohttp_str_response')
+    app_client = await aiohttp_client(aiohttp_app.app)
+    get_bye = await app_client.get('/v1.0/aiohttp_str_response')
     assert get_bye.status == 200
-    assert (yield from get_bye.read()) == b'str response'
+    assert (await get_bye.read()) == b'str response'
 
 
-@asyncio.coroutine
-def test_response_with_non_str_and_non_json_body(aiohttp_app, aiohttp_client):
-    app_client = yield from aiohttp_client(aiohttp_app.app)
-    get_bye = yield from app_client.get(
+async def test_response_with_non_str_and_non_json_body(aiohttp_app, aiohttp_client):
+    app_client = await aiohttp_client(aiohttp_app.app)
+    get_bye = await app_client.get(
         '/v1.0/aiohttp_non_str_non_json_response'
     )
     assert get_bye.status == 200
-    assert (yield from get_bye.read()) == b'1234'
+    assert (await get_bye.read()) == b'1234'
 
 
-@asyncio.coroutine
-def test_response_with_bytes_body(aiohttp_app, aiohttp_client):
+async def test_response_with_bytes_body(aiohttp_app, aiohttp_client):
     # Create the app and run the test_app testcase below.
-    app_client = yield from aiohttp_client(aiohttp_app.app)
-    get_bye = yield from app_client.get('/v1.0/aiohttp_bytes_response')
+    app_client = await aiohttp_client(aiohttp_app.app)
+    get_bye = await app_client.get('/v1.0/aiohttp_bytes_response')
     assert get_bye.status == 200
-    assert (yield from get_bye.read()) == b'bytes response'
+    assert (await get_bye.read()) == b'bytes response'
 
 
-@asyncio.coroutine
-def test_validate_responses(aiohttp_app, aiohttp_client):
-    app_client = yield from aiohttp_client(aiohttp_app.app)
-    get_bye = yield from app_client.get('/v1.0/aiohttp_validate_responses')
+async def test_validate_responses(aiohttp_app, aiohttp_client):
+    app_client = await aiohttp_client(aiohttp_app.app)
+    get_bye = await app_client.get('/v1.0/aiohttp_validate_responses')
     assert get_bye.status == 200
-    assert (yield from get_bye.json()) == {"validate": True}
+    assert (await get_bye.json()) == {"validate": True}
 
 
-@asyncio.coroutine
-def test_get_users(aiohttp_client, aiohttp_app):
-    app_client = yield from aiohttp_client(aiohttp_app.app)
-    resp = yield from app_client.get('/v1.0/users')
+async def test_get_users(aiohttp_client, aiohttp_app):
+    app_client = await aiohttp_client(aiohttp_app.app)
+    resp = await app_client.get('/v1.0/users')
     assert resp.url.path == '/v1.0/users/'  # followed redirect
     assert resp.status == 200
 
-    json_data = yield from resp.json()
+    json_data = await resp.json()
     assert json_data == \
            [{'name': 'John Doe', 'id': 1}, {'name': 'Nick Carlson', 'id': 2}]
 
 
-@asyncio.coroutine
-def test_create_user(aiohttp_client, aiohttp_app):
-    app_client = yield from aiohttp_client(aiohttp_app.app)
+async def test_create_user(aiohttp_client, aiohttp_app):
+    app_client = await aiohttp_client(aiohttp_app.app)
     user = {'name': 'Maksim'}
-    resp = yield from app_client.post('/v1.0/users', json=user, headers={'Content-type': 'application/json'})
+    resp = await app_client.post('/v1.0/users', json=user, headers={'Content-type': 'application/json'})
     assert resp.status == 201
 
 
-@asyncio.coroutine
-def test_access_request_context(aiohttp_client, aiohttp_app):
-    app_client = yield from aiohttp_client(aiohttp_app.app)
-    resp = yield from app_client.post('/v1.0/aiohttp_access_request_context/')
+async def test_access_request_context(aiohttp_client, aiohttp_app):
+    app_client = await aiohttp_client(aiohttp_app.app)
+    resp = await app_client.post('/v1.0/aiohttp_access_request_context/')
     assert resp.status == 204
 
 
-@asyncio.coroutine
-def test_query_parsing_simple(aiohttp_client, aiohttp_app):
+async def test_query_parsing_simple(aiohttp_client, aiohttp_app):
     expected_query = 'query'
 
-    app_client = yield from aiohttp_client(aiohttp_app.app)
-    resp = yield from app_client.get(
+    app_client = await aiohttp_client(aiohttp_app.app)
+    resp = await app_client.get(
         '/v1.0/aiohttp_query_parsing_str',
         params={
             'query': expected_query,
@@ -339,16 +314,15 @@ def test_query_parsing_simple(aiohttp_client, aiohttp_app):
     )
     assert resp.status == 200
 
-    json_data = yield from resp.json()
+    json_data = await resp.json()
     assert json_data == {'query': expected_query}
 
 
-@asyncio.coroutine
-def test_query_parsing_array(aiohttp_client, aiohttp_app):
+async def test_query_parsing_array(aiohttp_client, aiohttp_app):
     expected_query = ['queryA', 'queryB']
 
-    app_client = yield from aiohttp_client(aiohttp_app.app)
-    resp = yield from app_client.get(
+    app_client = await aiohttp_client(aiohttp_app.app)
+    resp = await app_client.get(
         '/v1.0/aiohttp_query_parsing_array',
         params={
             'query': ','.join(expected_query),
@@ -356,22 +330,21 @@ def test_query_parsing_array(aiohttp_client, aiohttp_app):
     )
     assert resp.status == 200
 
-    json_data = yield from resp.json()
+    json_data = await resp.json()
     assert json_data == {'query': expected_query}
 
 
-@asyncio.coroutine
-def test_query_parsing_array_multi(aiohttp_client, aiohttp_app):
+async def test_query_parsing_array_multi(aiohttp_client, aiohttp_app):
     expected_query = ['queryA', 'queryB', 'queryC']
     query_str = '&'.join(['query=%s' % q for q in expected_query])
 
-    app_client = yield from aiohttp_client(aiohttp_app.app)
-    resp = yield from app_client.get(
+    app_client = await aiohttp_client(aiohttp_app.app)
+    resp = await app_client.get(
         '/v1.0/aiohttp_query_parsing_array_multi?%s' % query_str,
     )
     assert resp.status == 200
 
-    json_data = yield from resp.json()
+    json_data = await resp.json()
     assert json_data == {'query': expected_query}
 
 
@@ -385,9 +358,8 @@ if sys.version_info[0:2] >= (3, 5):
         return app
 
 
-    @asyncio.coroutine
-    def test_validate_responses_async_def(aiohttp_app_async_def, aiohttp_client):
-        app_client = yield from aiohttp_client(aiohttp_app_async_def.app)
-        get_bye = yield from app_client.get('/v1.0/aiohttp_validate_responses')
+    async def test_validate_responses_async_def(aiohttp_app_async_def, aiohttp_client):
+        app_client = await aiohttp_client(aiohttp_app_async_def.app)
+        get_bye = await app_client.get('/v1.0/aiohttp_validate_responses')
         assert get_bye.status == 200
-        assert (yield from get_bye.read()) == b'{"validate": true}'
+        assert (await get_bye.read()) == b'{"validate": true}'


### PR DESCRIPTION
This is the place missed in https://github.com/zalando/connexion/pull/1186 that gives annoying `DeprecationWarning`-s in `pytest`.