### PR TITLE
avoid unnecessary object attribute lookup

### DIFF
--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -47,7 +47,7 @@ class Resolver(object):
         """
         operation_id = operation.operation_id
         router_controller = operation.router_controller
-        if operation.router_controller is None:
+        if router_controller is None:
             return operation_id
         return '{}.{}'.format(router_controller, operation_id)
 


### PR DESCRIPTION
Changes proposed in this pull request:

 - router_controller has already been access before the if state, so we can just reuse it
