### PR TITLE
add rfc3339-validator for date-time format validation

### DIFF
--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -2,3 +2,4 @@
 -r requirements-devel.txt
 openapi_spec_validator
 pytest-aiohttp
+rfc3339-validator>=0.1.2

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ install_requires = [
     'requests>=2.9.1',
     'inflection>=0.3.1',
     'openapi-spec-validator>=0.2.4',
+    'rfc3339-validator>=0.1.2'
 ]
 
 swagger_ui_require = 'swagger-ui-bundle>=0.0.2'


### PR DESCRIPTION
Fixes #476 



Changes proposed in this pull request:

 Currently to validate date-time format, users have to install `strict_rfc3339` which is not compatible with Apache License.
This change adds `rfc3339_validator` as a dependency. `rfc3339_validator` is MIT licensed.
jsonschema uses this `rfc3339_validator` as can be seen here: https://github.com/Julian/jsonschema/blob/9d5edb4749ab1f6194aa5c7c099c6e6fd402c4cf/jsonschema/_format.py#L305-L324