### PR TITLE
Remove leftover mock import from test_aiohttp_api_secure

### DIFF
--- a/tests/aiohttp/test_aiohttp_api_secure.py
+++ b/tests/aiohttp/test_aiohttp_api_secure.py
@@ -2,7 +2,7 @@ import asyncio
 import base64
 
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from connexion import AioHttpApp
 


### PR DESCRIPTION
With #1218 the mock dependency was removed
The leftover was covered by requirements-builder which pulls mock
