### PR TITLE
Replace python setup.py test with pytest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ import os
 import sys
 
 from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
 
 __location__ = os.path.join(os.getcwd(), os.path.dirname(inspect.getfile(inspect.currentframe())))
 
@@ -50,30 +49,6 @@ tests_require.append('pytest-aiohttp')
 tests_require.append('aiohttp-remotes')
 
 
-class PyTest(TestCommand):
-
-    user_options = [('cov-html=', None, 'Generate junit html report')]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.cov = None
-        self.pytest_args = ['--cov', 'connexion', '--cov-report', 'term-missing',
-                            '--cov-config=py3-coveragerc', '-v']
-        self.cov_html = False
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        if self.cov_html:
-            self.pytest_args.extend(['--cov-report', 'html'])
-        self.pytest_args.extend(['tests'])
-
-    def run_tests(self):
-        import pytest
-
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
-
-
 def readme():
     try:
         return open('README.rst', encoding='utf-8').read()
@@ -101,7 +76,6 @@ setup(
         'swagger-ui': swagger_ui_require,
         'aiohttp': aiohttp_require
     },
-    cmdclass={'test': PyTest},
     test_suite='tests',
     classifiers=[
         'Programming Language :: Python',

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,8 @@ commands=
     dev: requirements-builder --level=dev --req=requirements-devel.txt -o {toxworkdir}/requirements-dev.txt setup.py
     dev: pip install -r {toxworkdir}/requirements-dev.txt
     py3{6,7,8}: pip install -r requirements-aiohttp.txt
-    python setup.py test
+    pip install .["tests"]
+    pytest --cov=connexion --cov-report=term-missing --cov-config=py3-coveragerc -v
 
 [testenv:flake8]
 deps=flake8==3.6.0


### PR DESCRIPTION
Since running the unittest suite through setuptools is deprecated
https://setuptools.readthedocs.io/en/stable/setuptools.html#test-build-package-and-run-a-unittest-suite

The test/tox logs contained this warning
`WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.`

This PR replaces the python setup.py test command from tox.ini with just calling pytest and removes the no longer needed
code from setup.py