### PR TITLE
Split header by comma

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -60,6 +60,8 @@ def coerce_type(param, value, parameter_type, parameter_name=None):
     parameter_name = parameter_name if parameter_name else param.get('name')
     if param_type == "array":
         converted_params = []
+        if parameter_type == "header":
+            value = value.split(',')
         for v in value:
             try:
                 converted = make_type(v, param_schema["items"]["type"])

--- a/tests/decorators/test_validation.py
+++ b/tests/decorators/test_validation.py
@@ -48,6 +48,14 @@ def test_get_explodable_object_parameter():
              'required': True, 'name': 'foo', 'style': 'deepObject', 'explode': True}
     result = ParameterValidator.validate_parameter('query', {'bar': 1}, param)
     assert result is None
+    
+    
+def test_get_valid_parameter_with_enum_array_header():
+    value = 'VALUE1,VALUE2'
+    param = {'schema': {'type': 'array', 'items': {'type': 'string', 'enum': ['VALUE1', 'VALUE2']}},
+             'name': 'test_header_param'}
+    result = ParameterValidator.validate_parameter('header', value, param)
+    assert result is None
 
 
 def test_invalid_type(monkeypatch):


### PR DESCRIPTION
When specifying array of enum strings in header,
it needs to be split according to commas.

Fixes #1278.



Changes proposed in this pull request:

- When header is of type array, split the string by comma before validating
