### PR TITLE
Add explicit werkzeug dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ install_requires = [
     'requests>=2.9.1',
     'inflection>=0.3.1',
     'openapi-spec-validator>=0.2.4',
+    'werkzeug>=1.0,<2.0',
 ]
 
 swagger_ui_require = 'swagger-ui-bundle>=0.0.2'


### PR DESCRIPTION
Fixes #1149.



Changes proposed in this pull request:

 - add explicit werkzeug dependency
 - set lower version bound to 1.0 - I'm not sure if there are earlier versions that would break things.
 - set upper version bound to 2.0 - Any breaking changes could be bad.
