### PR TITLE
Fix reverseproxy example for OpenAPI 3

### DIFF
--- a/examples/openapi3/reverseproxy/app.py
+++ b/examples/openapi3/reverseproxy/app.py
@@ -76,4 +76,4 @@ if __name__ == '__main__':
         script_name='/reverse_proxied/'
     )
     flask_app.wsgi_app = proxied
-    app.run(port=8080)
+    flask_app.run(port=8080)


### PR DESCRIPTION
In the current example, the run() method is called on the app variable, which does not have its path altered.
This small PR updates app to flask_app to fix that problem.