### PR TITLE
More liberal flask number converters for float and int in paths

### DIFF
--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -27,6 +27,8 @@ class FlaskApp(AbstractApp):
     def create_app(self):
         app = flask.Flask(self.import_name, **self.server_args)
         app.json_encoder = FlaskJSONEncoder
+        app.url_map.converters['float'] = NumberConverter
+        app.url_map.converters['int'] = IntegerConverter
         return app
 
     def get_root_path(self):
@@ -142,3 +144,18 @@ class FlaskJSONEncoder(json.JSONEncoder):
             return float(o)
 
         return json.JSONEncoder.default(self, o)
+
+
+class NumberConverter(werkzeug.routing.BaseConverter):
+    """ Flask converter for OpenAPI number type """
+    regex = r"[+-]?[0-9]*(\.[0-9]*)?"
+
+    def to_python(self, value):
+        return float(value)
+
+class IntegerConverter(werkzeug.routing.BaseConverter):
+    """ Flask converter for OpenAPI integer type """
+    regex = r"[+-]?[0-9]+"
+
+    def to_python(self, value):
+        return int(value)

--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -153,6 +153,7 @@ class NumberConverter(werkzeug.routing.BaseConverter):
     def to_python(self, value):
         return float(value)
 
+
 class IntegerConverter(werkzeug.routing.BaseConverter):
     """ Flask converter for OpenAPI integer type """
     regex = r"[+-]?[0-9]+"

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -140,7 +140,7 @@ def test_strict_formdata_param(strict_app):
 def test_path_parameter_someint(simple_app, arg, result):
     assert isinstance(arg, str)  # sanity check
     app_client = simple_app.app.test_client()
-    resp = app_client.get('/v1.0/test-int-path/'+arg)  # type: flask.Response
+    resp = app_client.get(f'/v1.0/test-int-path/{arg}')  # type: flask.Response
     assert resp.data.decode('utf-8', 'replace') == f'"{result}"\n'
 
 
@@ -170,7 +170,7 @@ def test_path_parameter_someint__bad(simple_app):
 def test_path_parameter_somefloat(simple_app, arg, result):
     assert isinstance(arg, str)  # sanity check
     app_client = simple_app.app.test_client()
-    resp = app_client.get('/v1.0/test-float-path/' + arg)  # type: flask.Response
+    resp = app_client.get(f'/v1.0/test-float-path/{arg}')  # type: flask.Response
     assert resp.data.decode('utf-8', 'replace') == f'"{result}"\n'
 
 

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -1,6 +1,8 @@
 import json
 from io import BytesIO
 
+import pytest
+
 
 def test_parameter_validation(simple_app):
     app_client = simple_app.app.test_client()
@@ -124,22 +126,57 @@ def test_strict_formdata_param(strict_app):
     assert resp.status_code == 200
 
 
-def test_path_parameter_someint(simple_app):
+@pytest.mark.parametrize('arg, result', [
+    # The cases accepted by the Flask/Werkzeug converter
+    ['123', 'int 123'],
+    ['0', 'int 0'],
+    ['0000', 'int 0'],
+    # Additional cases that we want to support
+    ['+123', 'int 123'],
+    ['+0', 'int 0'],
+    ['-0', 'int 0'],
+    ['-123', 'int -123'],
+])
+def test_path_parameter_someint(simple_app, arg, result):
+    assert isinstance(arg, str)  # sanity check
     app_client = simple_app.app.test_client()
-    resp = app_client.get('/v1.0/test-int-path/123')  # type: flask.Response
-    assert resp.data.decode('utf-8', 'replace') == '"int"\n'
+    resp = app_client.get('/v1.0/test-int-path/'+arg)  # type: flask.Response
+    assert resp.data.decode('utf-8', 'replace') == f'"{result}"\n'
 
+
+def test_path_parameter_someint__bad(simple_app):
     # non-integer values will not match Flask route
+    app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-int-path/foo')  # type: flask.Response
     assert resp.status_code == 404
 
 
-def test_path_parameter_somefloat(simple_app):
+@pytest.mark.parametrize('arg, result', [
+    # The cases accepted by the Flask/Werkzeug converter
+    ['123.45', 'float 123.45'],
+    ['123.0', 'float 123'],
+    ['0.999999999999999999', 'float 1'],
+    # Additional cases that we want to support
+    ['+123.45', 'float 123.45'],
+    ['-123.45', 'float -123.45'],
+    ['123.', 'float 123'],
+    ['.45', 'float 0.45'],
+    ['123', 'float 123'],
+    ['0', 'float 0'],
+    ['0000', 'float 0'],
+    ['-0.000000001', 'float -1e-09'],
+    ['100000000000', 'float 1e+11'],
+])
+def test_path_parameter_somefloat(simple_app, arg, result):
+    assert isinstance(arg, str)  # sanity check
     app_client = simple_app.app.test_client()
-    resp = app_client.get('/v1.0/test-float-path/123.45')  # type: flask.Response
-    assert resp.data.decode('utf-8' , 'replace') == '"float"\n'
+    resp = app_client.get('/v1.0/test-float-path/' + arg)  # type: flask.Response
+    assert resp.data.decode('utf-8', 'replace') == f'"{result}"\n'
 
+
+def test_path_parameter_somefloat__bad(simple_app):
     # non-float values will not match Flask route
+    app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-float-path/123,45')  # type: flask.Response
     assert resp.status_code == 404
 

--- a/tests/fakeapi/hello/__init__.py
+++ b/tests/fakeapi/hello/__init__.py
@@ -266,11 +266,11 @@ def test_schema_int(test_int):
 
 
 def test_get_someint(someint):
-    return type(someint).__name__
+    return '%s %g' % (type(someint).__name__, someint)
 
 
 def test_get_somefloat(somefloat):
-    return type(somefloat).__name__
+    return '%s %g' % (type(somefloat).__name__, somefloat)
 
 
 def test_default_param(name):

--- a/tests/fakeapi/hello/__init__.py
+++ b/tests/fakeapi/hello/__init__.py
@@ -266,11 +266,11 @@ def test_schema_int(test_int):
 
 
 def test_get_someint(someint):
-    return '%s %g' % (type(someint).__name__, someint)
+    return f'{type(someint).__name__} {someint:g}'
 
 
 def test_get_somefloat(somefloat):
-    return '%s %g' % (type(somefloat).__name__, somefloat)
+    return f'{type(somefloat).__name__} {somefloat:g}'
 
 
 def test_default_param(name):


### PR DESCRIPTION
This change installs more liberal flask converters for `float` and `int`. These don't try to enforce a "single representation" of paths but instead try to convert the numbers that callers pass in.

This is the minimal change to get this effect and installs the custom number converters where the custom JSON converter is being installed already. An alternative would be to register the new converters as `integer` and `number` in Flask and update the `PATH_PARAMETER_CONVERTERS` mapping, but that's a larger change and would change the generated flask paths which could affect existing code.

Fixes #1040
Fixes #1041

The tests for numbers in paths are modified to return not just `int` or `float` but also the value seen by the handler so we can ascertain that the conversion works and not just the routing. Then a few number formats are added.