### PR TITLE
Fix response validator docstrings

### DIFF
--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -19,7 +19,7 @@ class ResponseValidator(BaseDecorator):
         :type operation: Operation
         :type mimetype: str
         :param validator: Validator class that should be used to validate passed data
-                          against API schema. Default is jsonschema.Draft4Validator.
+                          against API schema.
         :type validator: jsonschema.IValidator
         """
         self.operation = operation

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -216,7 +216,7 @@ class ResponseBodyValidator(object):
         """
         :param schema: The schema of the response body
         :param validator: Validator class that should be used to validate passed data
-                          against API schema. Default is jsonschema.Draft4Validator.
+                          against API schema. Default is Draft4ResponseValidator.
         :type validator: jsonschema.IValidator
         """
         ValidatorClass = validator or Draft4ResponseValidator


### PR DESCRIPTION
The default value of _ResponseBodyValidator.validator_ is not _jsonschema.Draft4Validator_ for some time already. It is _Draft4ResponseValidator_ now.

_ResponseValidator.validator_ does not have a default value. If not set, _ResponseBodyValidator_ default is used, which is eventually _Draft4ResponseValidator_, but it is not _ResponseValidator_ that decides it.
