### PR TITLE
Limit `openapi-spec-validator`

### DIFF
--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -1,4 +1,4 @@
 -r requirements-aiohttp.txt
 -r requirements-devel.txt
-openapi_spec_validator
+openapi_spec_validator<=0.2.10
 pytest-aiohttp

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ install_requires = [
     'PyYAML>=5.1',
     'requests>=2.9.1',
     'inflection>=0.3.1',
-    'openapi-spec-validator>=0.2.4',
+    'openapi-spec-validator>=0.2.4,<=0.2.10',
 ]
 
 swagger_ui_require = 'swagger-ui-bundle>=0.0.2'


### PR DESCRIPTION
Recent 0.3.0 release is not compatible with connexion in its current state. This limits to the latest compatible release.

Fixes #1343  .



Changes proposed in this pull request:

 - Limit `openapi-spec-validator` dependency to <=0.2.10
