### PR TITLE
Fix RuntimeError exception from **application/x-www-form-urlencoded**  (see also PR# 1222)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ htmlcov/
 .vscode/
 venv/
 src/
+venv/

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -127,8 +127,8 @@ class RequestBodyValidator(object):
         spec_params = self.schema.get('properties', {}).keys()
         return validate_parameter_list(request_params, spec_params)
 
-    def parse_body_parameters(self, body):
-        parsed_body = parse_qs(body.decode("utf-8"))
+    def parse_body_parameters(self, body, encoding="ascii"):
+        parsed_body = parse_qs(body.decode(encoding))
         # Flatten the parameters and take only the first value
         params = dict()
         for key,value in parsed_body.items():


### PR DESCRIPTION
Adds to PR #1222  to fix a RuntimeError exception from **application/x-www-form-urlencoded**  processes here, as well as the **multipart/form-data** issues already addressed by the PR.

Changes proposed in this pull request:

 - https://github.com/zalando/connexion/blob/master/connexion/decorators/validation.py#L162 response.body is a byte string from an **application/x-www-form-urlencoded** form **POST**, thus, is not a dictionary with an `update` method (next line). Parsing the byte string out creates a dictionary which is better behaved (coded a local method, `parse_body_parameters(self, body)` , to achieve this). 
 - Note that if the value of the parameters in the URL encoded byte string are singular values (not true arrays of values), then the dictionary value is simplified to a scalar.
 -
