### PR TITLE
Add note about x-openapi-router-controller when using OAS

### DIFF
--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -18,9 +18,10 @@ identify which Python function should handle each URL.
 
 If you provided this path in your specification POST requests to
 ``http://MYHOST/hello_world``, it would be handled by the function
-``hello_world`` in ``myapp.api`` module. Optionally, you can include
-``x-swagger-router-controller`` in your operation definition, making
-``operationId`` relative:
+``hello_world`` in ``myapp.api`` module.
+
+Optionally, you can include ``x-swagger-router-controller`` in your operation
+definition, making ``operationId`` relative:
 
 .. code-block:: yaml
 
@@ -30,17 +31,28 @@ If you provided this path in your specification POST requests to
           x-swagger-router-controller: myapp.api
           operationId: hello_world
 
+NOTE: If you are using an OpenAPI spec, you should use ``x-openapi-router-controller`` 
+in your operation definition, making ``operationId`` relative:
+
+.. code-block:: yaml
+
+    paths:
+      /hello_world:
+        post:
+          x-openapi-router-controller: myapp.api
+          operationId: hello_world
+
 Keep in mind that Connexion follows how `HTTP methods work in Flask`_
 and therefore HEAD requests will be handled by the ``operationId`` specified
 under GET in the specification. If both methods are supported,
 ``connexion.request.method`` can be used to determine which request was made.
 
-By default, Connexion strictly enforces the presence of a handler 
+By default, Connexion strictly enforces the presence of a handler
 function for any path defined in your specification. Because of this, adding
-new paths without implementing a corresponding handler function will produce 
-runtime errors and your application will not start. To allow new paths to be 
-added to your specification, e.g. in an API design first workflow, set the 
-``resolver_error`` to configure Connexion to provide an error response for 
+new paths without implementing a corresponding handler function will produce
+runtime errors and your application will not start. To allow new paths to be
+added to your specification, e.g. in an API design first workflow, set the
+``resolver_error`` to configure Connexion to provide an error response for
 paths that are not yet implemented:
 
 .. code-block:: python
@@ -96,9 +108,9 @@ the endpoints in your specification:
 
 ``RestyResolver`` will give precedence to any ``operationId``
 encountered in the specification. It will also respect
-``x-swagger-router-controller``. You may import and extend
-``connexion.resolver.Resolver`` to implement your own ``operationId``
-(and function) resolution algorithm.
+``x-swagger-router-controller`` and ``x-openapi-router-controller``.
+You may import and extend ``connexion.resolver.Resolver`` to implement your own
+``operationId`` (and function) resolution algorithm.
 Note that when using multiple parameters in the path, they will be
 collected and all passed to the endpoint handlers.
 
@@ -207,9 +219,9 @@ and a __init__.py file to make the Class visible in the api directory.
 
 ``MethodViewResolver`` will give precedence to any ``operationId``
 encountered in the specification. It will also respect
-``x-swagger-router-controller``. You may import and extend
-``connexion.resolver.MethodViewResolver`` to implement your own ``operationId``
-(and function) resolution algorithm.
+``x-swagger-router-controller`` and ``x-openapi-router-controller``.
+You may import and extend ``connexion.resolver.MethodViewResolver`` to implement
+your own ``operationId`` (and function) resolution algorithm.
 
 Parameter Name Sanitation
 -------------------------


### PR DESCRIPTION
Changes proposed in this pull request:

 - Add a note about x-openapi-router-controller when using OAS

Fantastic work, this repo is. There are quite a few confusions out on the interwebs about the RestyResolver, one of which I stumbled on when using OpenAPI 3. A simple docs update should help others not spin their wheels on this like I did.