### PR TITLE
Update readme badges to use main branch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ Connexion
    :alt: Build status
    :target: https://github.com/zalando/connexion/actions/workflows/pipeline.yml
 
-.. image:: https://coveralls.io/repos/zalando/connexion/badge.svg?branch=master
-   :target: https://coveralls.io/r/zalando/connexion?branch=master
+.. image:: https://coveralls.io/repos/zalando/connexion/badge.svg?branch=main
+   :target: https://coveralls.io/r/zalando/connexion?branch=main
    :alt: Coveralls status
 
 .. image:: https://img.shields.io/pypi/v/connexion.svg
@@ -26,7 +26,7 @@ Connexion
    :alt: Python Versions
 
 .. image:: https://img.shields.io/pypi/l/connexion.svg
-   :target: https://github.com/zalando/connexion/blob/master/LICENSE
+   :target: https://github.com/zalando/connexion/blob/main/LICENSE
    :alt: License
 
 Connexion is a framework that automagically handles HTTP requests based on `OpenAPI Specification`_

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Connexion
    :alt: Python Versions
 
 .. image:: https://img.shields.io/pypi/l/connexion.svg
-   :target: https://github.com/zalando/connexion/blob/main/LICENSE
+   :target: https://github.com/zalando/connexion/blob/main/LICENSE.txt
    :alt: License
 
 Connexion is a framework that automagically handles HTTP requests based on `OpenAPI Specification`_

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ Connexion
    :alt: Build status
    :target: https://github.com/zalando/connexion/actions/workflows/pipeline.yml
 
-.. image:: https://coveralls.io/repos/zalando/connexion/badge.svg?branch=main
-   :target: https://coveralls.io/r/zalando/connexion?branch=main
+.. image:: https://coveralls.io/repos/github/zalando/connexion/badge.svg?branch=main
+   :target: https://coveralls.io/github/zalando/connexion?branch=main
    :alt: Coveralls status
 
 .. image:: https://img.shields.io/pypi/v/connexion.svg


### PR DESCRIPTION
This PR updates the badges the reflect the change from `master` to `main`. (Also updated the link of the license badge).

See also #1369.