### PR TITLE
Fix formdata parameter validation for OAS3

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -305,10 +305,9 @@ class ParameterValidator(object):
 
     def validate_formdata_parameter_list(self, request):
         request_params = request.form.keys()
-        try:
+        if 'formData' in self.parameters:  # Swagger 2:
             spec_params = [x['name'] for x in self.parameters['formData']]
-        except KeyError:
-            # OAS 3
+        else:  # OAS 3
             return set()
         return validate_parameter_list(request_params, spec_params)
 

--- a/tests/decorators/test_validation.py
+++ b/tests/decorators/test_validation.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from connexion.apis.flask_api import FlaskApi
 from connexion.decorators.validation import ParameterValidator
 from connexion.json_schema import (Draft4RequestValidator,
                                    Draft4ResponseValidator)
@@ -180,3 +181,21 @@ def test_writeonly_required_error():
     }
     with pytest.raises(ValidationError):
         Draft4RequestValidator(schema).validate({"bar": "baz"})
+
+
+def test_formdata_extra_parameter_strict():
+    """Tests that connexion handles explicitly defined formData parameters well across Swagger 2
+    and OpenApi 3. In Swagger 2, any formData parameter should be defined explicitly, while in
+    OpenAPI 3 this is not allowed. See issues #1020 #1160 #1340 #1343."""
+    request = MagicMock(form={'param': 'value', 'extra_param': 'extra_value'})
+
+    # OAS3
+    validator = ParameterValidator([], FlaskApi, strict_validation=True)
+    errors = validator.validate_formdata_parameter_list(request)
+    assert not errors
+
+    # Swagger 2
+    validator = ParameterValidator([{'in': 'formData', 'name': 'param'}], FlaskApi,
+                                   strict_validation=True)
+    errors = validator.validate_formdata_parameter_list(request)
+    assert errors


### PR DESCRIPTION
Fixes #1020. Fixes #1160. Fixes #1340. Fixes #1343.

The previous fix which tries to catch a `KeyError` does not work since `self.parameters` is a `defaultdict`. Changed to an explicit `if` check instead.