### PR TITLE
Bugfix/missing infofuncs

### DIFF
--- a/connexion/security/async_security_handler_factory.py
+++ b/connexion/security/async_security_handler_factory.py
@@ -60,7 +60,7 @@ class AbstractAsyncSecurityHandlerFactory(AbstractSecurityHandlerFactory):
     def verify_security(cls, auth_funcs, required_scopes, function):
         @functools.wraps(function)
         async def wrapper(request):
-            token_info = None
+            token_info = cls.no_value
             for func in auth_funcs:
                 token_info = func(request, required_scopes)
                 while asyncio.iscoroutine(token_info):

--- a/connexion/security/security_handler_factory.py
+++ b/connexion/security/security_handler_factory.py
@@ -338,7 +338,7 @@ class AbstractSecurityHandlerFactory(abc.ABC):
     def verify_security(cls, auth_funcs, required_scopes, function):
         @functools.wraps(function)
         def wrapper(request):
-            token_info = None
+            token_info = cls.no_value
             for func in auth_funcs:
                 token_info = func(request, required_scopes)
                 if token_info is not cls.no_value:

--- a/tests/decorators/test_security.py
+++ b/tests/decorators/test_security.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import json
 import pytest
 import requests
-from connexion.exceptions import OAuthResponseProblem, OAuthScopeProblem
+from connexion.exceptions import OAuthProblem, OAuthResponseProblem, OAuthScopeProblem
 
 
 def test_get_tokeninfo_url(monkeypatch, security_handler_factory):
@@ -164,3 +164,15 @@ def test_verify_apikey_header(security_handler_factory):
     request.headers = {"X-Auth": 'foobar'}
 
     assert wrapped_func(request, ['admin']) is not None
+
+
+def test_verify_security_oauthproblem(security_handler_factory):
+    """Tests whether verify_security raises an OAuthProblem if there are no auth_funcs."""
+    func_to_secure = MagicMock(return_value='func')
+    secured_func = security_handler_factory.verify_security([], [], func_to_secure)
+
+    request = MagicMock()
+    with pytest.raises(OAuthProblem) as exc_info:
+        secured_func(request)
+
+    assert str(exc_info.value) == '401 Unauthorized: No authorization token provided'


### PR DESCRIPTION
In PR #869 , the check for `token_info` was changed from `if token_info is None` to `if token_info is cls.no_value`. However, the initial value for `token_info` is `None`, so if there are no auth_funcs (due to missing `x-XXXInfoFunc`s), the `OAuthProblem` branch isn't entered and `token_info.get()` will raise an AttributeError, leading to a 500 Internal Server Error.

Changes proposed in this pull request:

 - Change the default value of `token_info` from `None` to `cls.no_value` so that an `OAuthProblem` is raised
