### PR TITLE
tox.ini: flake8==3.9.2

### DIFF
--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+from typing import Any
 
 import flask
 import werkzeug.exceptions

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -3,6 +3,7 @@ import functools
 import inspect
 import logging
 import re
+from typing import Any
 
 import inflection
 

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -2,6 +2,7 @@ import collections
 import copy
 import functools
 import logging
+from typing import AnyStr, Union
 
 import pkg_resources
 from jsonschema import Draft4Validator, ValidationError, draft4_format_checker
@@ -12,6 +13,7 @@ from ..exceptions import (BadRequestProblem, ExtraParameterProblem,
                           UnsupportedMediaTypeProblem)
 from ..http_facts import FORM_CONTENT_TYPES
 from ..json_schema import Draft4RequestValidator, Draft4ResponseValidator
+from ..lifecycle import ConnexionResponse
 from ..utils import all_json, boolean, is_json_mimetype, is_null, is_nullable
 
 _jsonschema_3_or_newer = pkg_resources.parse_version(

--- a/connexion/options.py
+++ b/connexion/options.py
@@ -7,6 +7,8 @@ try:
 except ImportError:
     swagger_ui_2_path = swagger_ui_3_path = None
 
+from connexion.decorators.uri_parsing import AbstractURIParser
+
 MODULE_PATH = pathlib.Path(__file__).absolute().parent
 NO_UI_MSG = """The swagger_ui directory could not be found.
     Please install connexion with extra install: pip install connexion[swagger-ui]

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -2,6 +2,7 @@ import abc
 import copy
 import pathlib
 from collections.abc import Mapping
+from typing import List
 from urllib.parse import urlsplit
 
 import jinja2

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands=
     python setup.py test
 
 [testenv:flake8]
-deps=flake8==3.6.0
+deps=flake8==3.9.2
 commands=python setup.py flake8
 
 [testenv:isort-check]


### PR DESCRIPTION
https://pypi.org/project/flake8

$ `./setup.py flake8`
```
running flake8
WARNING: flake8 setuptools integration is deprecated and
scheduled for removal in 4.x.  For more information, see 
```
https://gitlab.com/pycqa/flake8/issues/544

Fixes # .



Changes proposed in this pull request:

 -
 -
 -
