### PR TITLE
Remove reference to deleted vendor files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-recursive-include connexion/vendor/swagger-ui *
 include *.txt
 include *.rst


### PR DESCRIPTION
Fixes #1003 .

Just a small fix to remove the obsolete reference to vendor files in MANIFEST.in