### PR TITLE
Tox.ini: Run mypy in ignore_outcome mode

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,8 +21,9 @@ jobs:
         pip install --upgrade pip
         pip install "tox<4" "tox-gh-actions<3" "setuptools<58" "coveralls<4"
     - name: Test with tox
-      run: mkdir .mypy_cache
-      run: tox
+      run: |
+        mkdir .mypy_cache
+        tox
     - name: Coveralls
       run: coveralls --service github
       env:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,9 +21,7 @@ jobs:
         pip install --upgrade pip
         pip install "tox<4" "tox-gh-actions<3" "setuptools<58" "coveralls<4"
     - name: Test with tox
-      run: |
-        mkdir -p .mypy_cache
-        tox
+      run: tox
     - name: Coveralls
       run: coveralls --service github
       env:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,6 +21,7 @@ jobs:
         pip install --upgrade pip
         pip install "tox<4" "tox-gh-actions<3" "setuptools<58" "coveralls<4"
     - name: Test with tox
+      run: mkdir .mypy_cache
       run: tox
     - name: Coveralls
       run: coveralls --service github

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -22,7 +22,7 @@ jobs:
         pip install "tox<4" "tox-gh-actions<3" "setuptools<58" "coveralls<4"
     - name: Test with tox
       run: |
-        mkdir .mypy_cache
+        mkdir -p .mypy_cache
         tox
     - name: Coveralls
       run: coveralls --service github

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -1,5 +1,6 @@
 import json
 from io import BytesIO
+from typing import List
 
 import pytest
 
@@ -43,31 +44,31 @@ def test_array_query_param(simple_app):
     headers = {'Content-type': 'application/json'}
     url = '/v1.0/test_array_csv_query_param'
     response = app_client.get(url, headers=headers)
-    array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [str]
+    array_response: List[str] = json.loads(response.data.decode('utf-8', 'replace'))
     assert array_response == ['squash', 'banana']
     url = '/v1.0/test_array_csv_query_param?items=one,two,three'
     response = app_client.get(url, headers=headers)
-    array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [str]
+    array_response: List[str] = json.loads(response.data.decode('utf-8', 'replace'))
     assert array_response == ['one', 'two', 'three']
     url = '/v1.0/test_array_pipes_query_param?items=1|2|3'
     response = app_client.get(url, headers=headers)
-    array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [int]
+    array_response: List[int] = json.loads(response.data.decode('utf-8', 'replace'))
     assert array_response == [1, 2, 3]
     url = '/v1.0/test_array_unsupported_query_param?items=1;2;3'
     response = app_client.get(url, headers=headers)
-    array_response = json.loads(response.data.decode('utf-8', 'replace'))  # [str] unsupported collectionFormat
+    array_response: List[str] = json.loads(response.data.decode('utf-8', 'replace'))  # unsupported collectionFormat
     assert array_response == ["1;2;3"]
     url = '/v1.0/test_array_csv_query_param?items=A&items=B&items=C&items=D,E,F'
     response = app_client.get(url, headers=headers)
-    array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [str] multi array with csv format
+    array_response: List[str] = json.loads(response.data.decode('utf-8', 'replace'))  # multi array with csv format
     assert array_response == ['D', 'E', 'F']
     url = '/v1.0/test_array_multi_query_param?items=A&items=B&items=C&items=D,E,F'
     response = app_client.get(url, headers=headers)
-    array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [str] multi array with csv format
+    array_response: List[str] = json.loads(response.data.decode('utf-8', 'replace'))  # multi array with csv format
     assert array_response == ['A', 'B', 'C', 'D', 'E', 'F']
     url = '/v1.0/test_array_pipes_query_param?items=4&items=5&items=6&items=7|8|9'
     response = app_client.get(url, headers=headers)
-    array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [int] multi array with pipes format
+    array_response: List[int] = json.loads(response.data.decode('utf-8', 'replace'))  # multi array with pipes format
     assert array_response == [7, 8, 9]
 
 
@@ -76,25 +77,25 @@ def test_array_form_param(simple_app):
     headers = {'Content-type': 'application/x-www-form-urlencoded'}
     url = '/v1.0/test_array_csv_form_param'
     response = app_client.post(url, headers=headers)
-    array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [str]
+    array_response: List[str] = json.loads(response.data.decode('utf-8', 'replace'))
     assert array_response == ['squash', 'banana']
     url = '/v1.0/test_array_csv_form_param'
     response = app_client.post(url, headers=headers, data={"items": "one,two,three"})
-    array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [str]
+    array_response: List[str] = json.loads(response.data.decode('utf-8', 'replace'))
     assert array_response == ['one', 'two', 'three']
     url = '/v1.0/test_array_pipes_form_param'
     response = app_client.post(url, headers=headers, data={"items": "1|2|3"})
-    array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [int]
+    array_response: List[int] = json.loads(response.data.decode('utf-8', 'replace'))
     assert array_response == [1, 2, 3]
     url = '/v1.0/test_array_csv_form_param'
     data = 'items=A&items=B&items=C&items=D,E,F'
     response = app_client.post(url, headers=headers, data=data)
-    array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [str] multi array with csv format
+    array_response: List[str] = json.loads(response.data.decode('utf-8', 'replace'))  # multi array with csv format
     assert array_response == ['D', 'E', 'F']
     url = '/v1.0/test_array_pipes_form_param'
     data = 'items=4&items=5&items=6&items=7|8|9'
     response = app_client.post(url, headers=headers, data=data)
-    array_response = json.loads(response.data.decode('utf-8', 'replace'))  # type: [int] multi array with pipes format
+    array_response: List[int] = json.loads(response.data.decode('utf-8', 'replace'))  # multi array with pipes format
     assert array_response == [7, 8, 9]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -60,11 +60,5 @@ changedir={toxinidir}/tests
 commands=isort --thirdparty aiohttp,connexion --check-only --diff .
 
 [testenv:mypy]
-allowlist_externals=
-    ls
-    mkdir
 deps=mypy==0.910
-commands=
-    mkdir .mypy_cache
-    ls -la .m*
-    mypy --install-types --non-interactive . || true
+commands=mypy --install-types --non-interactive . || true

--- a/tox.ini
+++ b/tox.ini
@@ -62,4 +62,4 @@ commands=isort --thirdparty aiohttp,connexion --check-only --diff .
 [testenv:mypy]
 deps=mypy==0.910
 ignore_outcome=true
-commands=mypy --exclude '/(__init__|api|api.pets|app|hello|orm|resty)\.py$' --install-types --non-interactive .
+commands=mypy --exclude 'examples/' --install-types --non-interactive .

--- a/tox.ini
+++ b/tox.ini
@@ -60,5 +60,8 @@ changedir={toxinidir}/tests
 commands=isort --thirdparty aiohttp,connexion --check-only --diff .
 
 [testenv:mypy]
+allowlist_externals=touch
 deps=mypy==0.910
-commands=mypy --install-types --non-interactive . || true
+commands=
+    touch .mypy_cache
+    mypy --install-types --non-interactive . || true

--- a/tox.ini
+++ b/tox.ini
@@ -65,5 +65,6 @@ deps=
     types-PyYAML
     types-requests
     types-setuptools
+    types-ujson
 ignore_outcome=true
-commands=mypy --exclude 'examples/' .
+commands=mypy --exclude='examples/' connexion tests

--- a/tox.ini
+++ b/tox.ini
@@ -60,8 +60,11 @@ changedir={toxinidir}/tests
 commands=isort --thirdparty aiohttp,connexion --check-only --diff .
 
 [testenv:mypy]
-allowlist_externals=touch
+allowlist_externals=
+    ls
+    touch
 deps=mypy==0.910
 commands=
     touch .mypy_cache
+    ls -la .m*
     mypy --install-types --non-interactive . || true

--- a/tox.ini
+++ b/tox.ini
@@ -62,4 +62,4 @@ commands=isort --thirdparty aiohttp,connexion --check-only --diff .
 [testenv:mypy]
 deps=mypy==0.910
 ignore_outcome=true
-commands=mypy --exclude '/(__init__|api|api.pets|app|hello)\.py$' --install-types --non-interactive .
+commands=mypy --exclude '/(__init__|api|api.pets|app|hello|resty)\.py$' --install-types --non-interactive .

--- a/tox.ini
+++ b/tox.ini
@@ -60,6 +60,10 @@ changedir={toxinidir}/tests
 commands=isort --thirdparty aiohttp,connexion --check-only --diff .
 
 [testenv:mypy]
-deps=mypy==0.910
+deps=
+    mypy==0.910
+    types-PyYAML
+    types-requests
+    types-setuptools
 ignore_outcome=true
-commands=mypy --exclude 'examples/' --install-types --non-interactive .
+commands=mypy --exclude 'examples/' .

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ envlist =
     isort-check-examples
     isort-check-tests
     flake8
+    mypy
 
 [gh-actions]
 python =
@@ -57,3 +58,7 @@ basepython=python3
 deps=isort==5.9.1
 changedir={toxinidir}/tests
 commands=isort --thirdparty aiohttp,connexion --check-only --diff .
+
+[testenv:mypy]
+deps=mypy==0.910
+commands=mypy --install-types --non-interactive . || true

--- a/tox.ini
+++ b/tox.ini
@@ -62,4 +62,4 @@ commands=isort --thirdparty aiohttp,connexion --check-only --diff .
 [testenv:mypy]
 deps=mypy==0.910
 ignore_outcome=true
-commands=mypy --exclude /examples/* --install-types --non-interactive .
+commands=mypy --exclude '/app\.py$' --install-types --non-interactive .

--- a/tox.ini
+++ b/tox.ini
@@ -62,9 +62,10 @@ commands=isort --thirdparty aiohttp,connexion --check-only --diff .
 [testenv:mypy]
 allowlist_externals=
     ls
+    sudo
     touch
 deps=mypy==0.910
 commands=
-    touch .mypy_cache
+    sudo touch .mypy_cache
     ls -la .m*
     mypy --install-types --non-interactive . || true

--- a/tox.ini
+++ b/tox.ini
@@ -62,10 +62,9 @@ commands=isort --thirdparty aiohttp,connexion --check-only --diff .
 [testenv:mypy]
 allowlist_externals=
     ls
-    sudo
-    touch
+    mkdir
 deps=mypy==0.910
 commands=
-    sudo touch .mypy_cache
+    mkdir .mypy_cache
     ls -la .m*
     mypy --install-types --non-interactive . || true

--- a/tox.ini
+++ b/tox.ini
@@ -61,4 +61,5 @@ commands=isort --thirdparty aiohttp,connexion --check-only --diff .
 
 [testenv:mypy]
 deps=mypy==0.910
-commands=mypy --exclude=/examples/ --install-types --non-interactive . || true
+ignore_outcome=true
+commands=mypy --exclude /examples/ --install-types --non-interactive .

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ python =
     3.6: py36-min,py36-pypi
     3.7: py37-min,py37-pypi
     3.8: py38-min,py38-pypi
-    3.9: py39-min,py39-pypi,flake8,isort-check,isort-check-examples,isort-check-tests
+    3.9: py39-min,py39-pypi,flake8,isort-check,isort-check-examples,isort-check-tests,mypy
 
 [testenv]
 setenv=PYTHONPATH = {toxinidir}:{toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -62,4 +62,4 @@ commands=isort --thirdparty aiohttp,connexion --check-only --diff .
 [testenv:mypy]
 deps=mypy==0.910
 ignore_outcome=true
-commands=mypy --exclude '/(__init__|api|app|hello)\.py$' --install-types --non-interactive .
+commands=mypy --exclude '/(__init__|api|api.pets|app|hello)\.py$' --install-types --non-interactive .

--- a/tox.ini
+++ b/tox.ini
@@ -62,4 +62,4 @@ commands=isort --thirdparty aiohttp,connexion --check-only --diff .
 [testenv:mypy]
 deps=mypy==0.910
 ignore_outcome=true
-commands=mypy --exclude '/(api|app|hello)\.py$' --install-types --non-interactive .
+commands=mypy --exclude '/(__init__|api|app|hello)\.py$' --install-types --non-interactive .

--- a/tox.ini
+++ b/tox.ini
@@ -62,4 +62,4 @@ commands=isort --thirdparty aiohttp,connexion --check-only --diff .
 [testenv:mypy]
 deps=mypy==0.910
 ignore_outcome=true
-commands=mypy --exclude '/(__init__|api|api.pets|app|hello|resty)\.py$' --install-types --non-interactive .
+commands=mypy --exclude '/(__init__|api|api.pets|app|hello|orm|resty)\.py$' --install-types --non-interactive .

--- a/tox.ini
+++ b/tox.ini
@@ -62,4 +62,4 @@ commands=isort --thirdparty aiohttp,connexion --check-only --diff .
 [testenv:mypy]
 deps=mypy==0.910
 ignore_outcome=true
-commands=mypy --exclude '/app\.py$' --install-types --non-interactive .
+commands=mypy --exclude '/(app|hello)\.py$' --install-types --non-interactive .

--- a/tox.ini
+++ b/tox.ini
@@ -62,4 +62,4 @@ commands=isort --thirdparty aiohttp,connexion --check-only --diff .
 [testenv:mypy]
 deps=mypy==0.910
 ignore_outcome=true
-commands=mypy --exclude /examples/ --install-types --non-interactive .
+commands=mypy --exclude /examples/* --install-types --non-interactive .

--- a/tox.ini
+++ b/tox.ini
@@ -62,4 +62,4 @@ commands=isort --thirdparty aiohttp,connexion --check-only --diff .
 [testenv:mypy]
 deps=mypy==0.910
 ignore_outcome=true
-commands=mypy --exclude '/(app|hello)\.py$' --install-types --non-interactive .
+commands=mypy --exclude '/(api|app|hello)\.py$' --install-types --non-interactive .

--- a/tox.ini
+++ b/tox.ini
@@ -61,4 +61,4 @@ commands=isort --thirdparty aiohttp,connexion --check-only --diff .
 
 [testenv:mypy]
 deps=mypy==0.910
-commands=mypy --install-types --non-interactive . || true
+commands=mypy --exclude=/examples/ --install-types --non-interactive . || true


### PR DESCRIPTION
Related to #2, #998, #1111
Proves #1392

`mypy --exclude '/(__init__|api|api.pets|app|hello|orm|resty)\.py$' --install-types --non-interactive .`

Changes proposed in this pull request:
 - Run [`mypy`](https://mypy.readthedocs.io) in [tox ignore_outcome](https://tox.readthedocs.io/en/latest/config.html#conf-ignore_outcome) mode to show progress on #1111
 - Making mypy work is a pain in the neck!!

```
tox: mypy
  mypy run-test-pre: PYTHONHASHSEED='866419681'
  mypy run-test: commands[0] | mypy --exclude '/(__init__|api|api.pets|app|hello|orm|resty)\.py$' \
       --install-types --non-interactive .
  tests/api/test_parameters.py:62: error: syntax error in type comment "[str] multi array with csv format"
  tests/api/test_parameters.py:66: error: syntax error in type comment "[str] multi array with csv format"
  tests/api/test_parameters.py:70: error: syntax error in type comment "[int] multi array with pipes format"
  tests/api/test_parameters.py:92: error: syntax error in type comment "[str] multi array with csv format"
  tests/api/test_parameters.py:97: error: syntax error in type comment "[int] multi array with pipes format"
  Found 5 errors in 1 file (errors prevented further checking)
  WARNING: command failed but result from testenv is ignored
  cmd: InvocationError for command /home/runner/work/connexion/connexion/.tox/mypy/bin/mypy \
       --exclude '/(__init__|api|api.pets|app|hello|orm|resty)\.py$' --install-types --non-interactive . \
       (exited with code 2)
```
