### PR TITLE
Reload Flask on API file changes

### DIFF
--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -23,6 +23,7 @@ logger = logging.getLogger('connexion.app')
 class FlaskApp(AbstractApp):
     def __init__(self, import_name, server='flask', **kwargs):
         super().__init__(import_name, FlaskApi, server=server, **kwargs)
+        self.extra_files = kwargs.get("extra_files", [])
 
     def create_app(self):
         app = flask.Flask(self.import_name, **self.server_args)
@@ -64,6 +65,8 @@ class FlaskApp(AbstractApp):
     def add_api(self, specification, **kwargs):
         api = super().add_api(specification, **kwargs)
         self.app.register_blueprint(api.blueprint)
+        if isinstance(specification, (str, pathlib.Path)):
+            self.extra_files.append(specification)
         return api
 
     def add_error_handler(self, error_code, function):
@@ -101,7 +104,8 @@ class FlaskApp(AbstractApp):
 
         logger.debug('Starting %s HTTP server..', self.server, extra=vars(self))
         if self.server == 'flask':
-            self.app.run(self.host, port=self.port, debug=self.debug, **options)
+            self.app.run(self.host, port=self.port, debug=self.debug,
+                         extra_files=self.extra_files, **options)
         elif self.server == 'tornado':
             try:
                 import tornado.httpserver

--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -73,7 +73,13 @@ class FlaskApp(AbstractApp):
         # type: (int, FunctionType) -> None
         self.app.register_error_handler(error_code, function)
 
-    def run(self, port=None, server=None, debug=None, host=None, **options):  # pragma: no cover
+    def run(self,
+            port=None,
+            server=None,
+            debug=None,
+            host=None,
+            extra_files=None,
+            **options):  # pragma: no cover
         """
         Runs the application on a local development server.
         :param host: the host interface to bind on.
@@ -84,6 +90,9 @@ class FlaskApp(AbstractApp):
         :type server: str | None
         :param debug: include debugging information
         :type debug: bool
+        :param extra_files: extra files that should be watched by the Flask/Werkzeug reloader.
+            By default, the swagger spec is watched by the reloader.
+        :type extra_files: Optional[Iterable[str | pathlib.Path]]
         :param options: options to be forwarded to the underlying server
         """
         # this functions is not covered in unit tests because we would effectively testing the mocks
@@ -101,6 +110,9 @@ class FlaskApp(AbstractApp):
 
         if debug is not None:
             self.debug = debug
+
+        if extra_files is not None:
+            self.extra_files.extend(extra_files)
 
         logger.debug('Starting %s HTTP server..', self.server, extra=vars(self))
         if self.server == 'flask':

--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -22,6 +22,12 @@ logger = logging.getLogger('connexion.app')
 
 class FlaskApp(AbstractApp):
     def __init__(self, import_name, server='flask', extra_files=None, **kwargs):
+        """
+        :param extra_files: additional files to be watched by the reloader, defaults to the swagger specs of added apis
+        :type extra_files: list[str | pathlib.Path], optional
+
+        See :class:`~connexion.AbstractApp` for additional parameters.
+        """
         super().__init__(import_name, FlaskApi, server=server, **kwargs)
         self.extra_files = extra_files or []
 
@@ -82,6 +88,7 @@ class FlaskApp(AbstractApp):
             **options):  # pragma: no cover
         """
         Runs the application on a local development server.
+
         :param host: the host interface to bind on.
         :type host: str
         :param port: port to listen to
@@ -91,7 +98,7 @@ class FlaskApp(AbstractApp):
         :param debug: include debugging information
         :type debug: bool
         :param extra_files: additional files to be watched by the reloader.
-        :type extra_files: Optional[Iterable[str | pathlib.Path]]
+        :type extra_files: Iterable[str | pathlib.Path]
         :param options: options to be forwarded to the underlying server
         """
         # this functions is not covered in unit tests because we would effectively testing the mocks

--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -90,8 +90,7 @@ class FlaskApp(AbstractApp):
         :type server: str | None
         :param debug: include debugging information
         :type debug: bool
-        :param extra_files: extra files that should be watched by the Flask/Werkzeug reloader.
-            By default, the swagger spec is watched by the reloader.
+        :param extra_files: additional files to be watched by the reloader.
         :type extra_files: Optional[Iterable[str | pathlib.Path]]
         :param options: options to be forwarded to the underlying server
         """

--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -21,9 +21,9 @@ logger = logging.getLogger('connexion.app')
 
 
 class FlaskApp(AbstractApp):
-    def __init__(self, import_name, server='flask', **kwargs):
+    def __init__(self, import_name, server='flask', extra_files=None, **kwargs):
         super().__init__(import_name, FlaskApi, server=server, **kwargs)
-        self.extra_files = kwargs.get("extra_files", [])
+        self.extra_files = extra_files or []
 
     def create_app(self):
         app = flask.Flask(self.import_name, **self.server_args)

--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -66,7 +66,7 @@ class FlaskApp(AbstractApp):
         api = super().add_api(specification, **kwargs)
         self.app.register_blueprint(api.blueprint)
         if isinstance(specification, (str, pathlib.Path)):
-            self.extra_files.append(specification)
+            self.extra_files.append(self.specification_dir / specification)
         return api
 
     def add_error_handler(self, error_code, function):


### PR DESCRIPTION
Flask can automatically reload in debug mode whenver specified files
change. By default that includes templates, however changes to the API
files (i.e. openapi.yml) should result in a reload as well.

This PR adds all added API files to be monitored automatically by Flask.

WIP since I have to figure out the used `tox` setup first.

Signed-off-by: Paul Spooren <mail@aparcar.org>