### PR TITLE
Feature/relative resolver

### DIFF
--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -102,7 +102,7 @@ class RestyResolver(Resolver):
         :param default_module_name: Default module name for operations
         :type default_module_name: str
         """
-        super().__init__(self)
+        super().__init__()
         self.default_module_name = default_module_name
         self.collection_endpoint_name = collection_endpoint_name
 
@@ -113,7 +113,7 @@ class RestyResolver(Resolver):
         :type operation: connexion.operations.AbstractOperation
         """
         if operation.operation_id:
-            return super().resolve_operation_id(self, operation)
+            return super().resolve_operation_id(operation)
 
         return self.resolve_operation_id_using_rest_semantics(operation)
 

--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -70,6 +70,28 @@ class Resolver:
             raise ResolverError(str(e), sys.exc_info())
 
 
+class RelativeResolver(Resolver):
+    """
+    Resolves endpoint functions relative to a given root path.
+    """
+    def __init__(self, root_path, function_resolver):
+        super().__init__(function_resolver=function_resolver)
+        self.root_path = root_path
+
+    def resolve_operation_id(self, operation):
+        """Resolves the operationId relative to the root path, unless
+        x-swagger-router-controller or x-openapi-router-controller is specified.
+
+        :param operation: The operation to resolve
+        :type operation: connexion.operations.AbstractOperation
+        """
+        operation_id = operation.operation_id
+        router_controller = operation.router_controller
+        if router_controller is None:
+            return f'{self.root_path}.{operation_id}'
+        return f'{router_controller}.{operation_id}'
+
+
 class RestyResolver(Resolver):
     """
     Resolves endpoint functions using REST semantics (unless overridden by specifying operationId)

--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -3,6 +3,7 @@ This module contains resolvers, functions that resolves the user defined view fu
 from the operations defined in the OpenAPI spec.
 """
 
+import inspect
 import logging
 import sys
 
@@ -74,9 +75,19 @@ class RelativeResolver(Resolver):
     """
     Resolves endpoint functions relative to a given root path.
     """
-    def __init__(self, root_path, function_resolver):
+    def __init__(self, root_path, function_resolver=utils.get_function_from_name):
+        """
+        :param root_path: The root path relative to which an operationId is resolved.
+            Can also be a module.
+        :type root_path: typing.Union[str, types.ModuleType]
+        :param function_resolver: Function that resolves functions using an operationId
+        :type function_resolver: types.FunctionType
+        """
         super().__init__(function_resolver=function_resolver)
-        self.root_path = root_path
+        if inspect.ismodule(root_path):
+            self.root_path = root_path.__name__
+        else:
+            self.root_path = root_path
 
     def resolve_operation_id(self, operation):
         """Resolves the operationId relative to the root path, unless

--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -73,12 +73,14 @@ class Resolver:
 
 class RelativeResolver(Resolver):
     """
-    Resolves endpoint functions relative to a given root path.
+    Resolves endpoint functions relative to a given root path or module.
     """
     def __init__(self, root_path, function_resolver=utils.get_function_from_name):
         """
         :param root_path: The root path relative to which an operationId is resolved.
-            Can also be a module.
+            Can also be a module. Has the same effect as setting
+            `x-swagger-router-controller` or `x-openapi-router-controller` equal to
+            `root_path` for every operation individually.
         :type root_path: typing.Union[str, types.ModuleType]
         :param function_resolver: Function that resolves functions using an operationId
         :type function_resolver: types.FunctionType

--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -102,7 +102,7 @@ class RestyResolver(Resolver):
         :param default_module_name: Default module name for operations
         :type default_module_name: str
         """
-        Resolver.__init__(self)
+        super().__init__(self)
         self.default_module_name = default_module_name
         self.collection_endpoint_name = collection_endpoint_name
 
@@ -113,7 +113,7 @@ class RestyResolver(Resolver):
         :type operation: connexion.operations.AbstractOperation
         """
         if operation.operation_id:
-            return Resolver.resolve_operation_id(self, operation)
+            return super().resolve_operation_id(self, operation)
 
         return self.resolve_operation_id_using_rest_semantics(operation)
 

--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -42,6 +42,18 @@ in your operation definition, making ``operationId`` relative:
           x-openapi-router-controller: myapp.api
           operationId: hello_world
 
+If all your operations are relative, you can use the ``RelativeResolver`` class
+instead of repeating the same ``x-swagger-router-controller`` or
+``x-openapi-router-controller`` in every operation:
+
+.. code-block:: python
+
+    from connexion.resolver import RelativeResolver
+      
+    app = connexion.FlaskApp(__name__)
+    app.add_api('swagger.yaml', resolver=RelativeResolver('api'))
+
+
 Keep in mind that Connexion follows how `HTTP methods work in Flask`_
 and therefore HEAD requests will be handled by the ``operationId`` specified
 under GET in the specification. If both methods are supported,

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -2,13 +2,18 @@ import connexion.apps
 import pytest
 from connexion.exceptions import ResolverError
 from connexion.operations import Swagger2Operation
-from connexion.resolver import Resolver, RestyResolver
+from connexion.resolver import RelativeResolver, Resolver, RestyResolver
 
 PARAMETER_DEFINITIONS = {'myparam': {'in': 'path', 'type': 'integer'}}
 
 
 def test_standard_get_function():
     function = Resolver().resolve_function_from_operation_id('connexion.FlaskApp.common_error_handler')
+    assert function == connexion.FlaskApp.common_error_handler
+
+
+def test_relative_get_function():
+    function = RelativeResolver('connexion').resolve_function_from_operation_id('connexion.FlaskApp.common_error_handler')
     assert function == connexion.FlaskApp.common_error_handler
 
 
@@ -23,6 +28,8 @@ def test_missing_operation_id():
     with pytest.raises(ResolverError):
         Resolver().resolve_function_from_operation_id(None)
     with pytest.raises(ResolverError):
+        RelativeResolver('connexion').resolve_function_from_operation_id(None)
+    with pytest.raises(ResolverError):
         RestyResolver('connexion').resolve_function_from_operation_id(None)
 
 
@@ -31,6 +38,8 @@ def test_bad_operation_id():
     # be handled upstream.
     with pytest.raises(ResolverError):
         Resolver().resolve_function_from_operation_id('ohai.I.do.not.exist')
+    with pytest.raises(ResolverError):
+        RelativeResolver('connexion').resolve_function_from_operation_id('ohai.I.do.not.exist')
     with pytest.raises(ResolverError):
         RestyResolver('connexion').resolve_function_from_operation_id('ohai.I.do.not.exist')
 
@@ -51,6 +60,62 @@ def test_standard_resolve_x_router_controller():
                                   definitions={},
                                   parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=Resolver())
+    assert operation.operation_id == 'fakeapi.hello.post_greeting'
+
+
+def test_relative_resolve_x_router_controller():
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation={
+                                      'x-swagger-router-controller': 'fakeapi.hello',
+                                      'operationId': 'post_greeting',
+                                  },
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=RelativeResolver('root_path'))
+    assert operation.operation_id == 'fakeapi.hello.post_greeting'
+
+
+def test_relative_resolve_operation_id():
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation={
+                                      'operationId': 'hello.post_greeting',
+                                  },
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=RelativeResolver('fakeapi'))
+    assert operation.operation_id == 'fakeapi.hello.post_greeting'
+
+
+def test_relative_resolve_operation_id_with_module():
+    import fakeapi
+    operation = Swagger2Operation(api=None,
+                                  method='GET',
+                                  path='endpoint',
+                                  path_parameters=[],
+                                  operation={
+                                      'operationId': 'hello.post_greeting',
+                                  },
+                                  app_produces=['application/json'],
+                                  app_consumes=['application/json'],
+                                  app_security=[],
+                                  security_definitions={},
+                                  definitions={},
+                                  parameter_definitions=PARAMETER_DEFINITIONS,
+                                  resolver=RelativeResolver(fakeapi))
     assert operation.operation_id == 'fakeapi.hello.post_greeting'
 
 

--- a/tests/test_resolver3.py
+++ b/tests/test_resolver3.py
@@ -1,5 +1,5 @@
 from connexion.operations import OpenAPIOperation
-from connexion.resolver import Resolver, RestyResolver
+from connexion.resolver import RelativeResolver, Resolver, RestyResolver
 
 COMPONENTS = {'parameters': {'myparam': {'in': 'path', 'schema': {'type': 'integer'}}}}
 
@@ -17,6 +17,56 @@ def test_standard_resolve_x_router_controller():
         app_security=[],
         components=COMPONENTS,
         resolver=Resolver()
+    )
+    assert operation.operation_id == 'fakeapi.hello.post_greeting'
+
+
+def test_relative_resolve_x_router_controller():
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='endpoint',
+        path_parameters=[],
+        operation={
+            'x-openapi-router-controller': 'fakeapi.hello',
+            'operationId': 'post_greeting',
+        },
+        app_security=[],
+        components=COMPONENTS,
+        resolver=RelativeResolver('root_path')
+    )
+    assert operation.operation_id == 'fakeapi.hello.post_greeting'
+
+
+def test_relative_resolve_operation_id():
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='endpoint',
+        path_parameters=[],
+        operation={
+            'operationId': 'hello.post_greeting',
+        },
+        app_security=[],
+        components=COMPONENTS,
+        resolver=RelativeResolver('fakeapi')
+    )
+    assert operation.operation_id == 'fakeapi.hello.post_greeting'
+
+
+def test_relative_resolve_operation_id_with_module():
+    import fakeapi
+    operation = OpenAPIOperation(
+        api=None,
+        method='GET',
+        path='endpoint',
+        path_parameters=[],
+        operation={
+            'operationId': 'hello.post_greeting',
+        },
+        app_security=[],
+        components=COMPONENTS,
+        resolver=RelativeResolver(fakeapi)
     )
     assert operation.operation_id == 'fakeapi.hello.post_greeting'
 


### PR DESCRIPTION
Fixes #938 .

Changes proposed in this pull request:

 - Add `RelativeResolver` class to resolve add `operationId`s relative to the same module/path without having to specify the same `x-swagger-router-controller` or `x-openapi-router-controller` for every operation individually

