### PR TITLE
Replace links of master in favor of main

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -48,8 +48,8 @@ You can find a `minimal OAuth example application`_ showing the use of
 ``x-tokenInfoUrl``, and `another OAuth example`_ showing the use of
 ``x-tokenInfoFunc`` in Connexion's "examples" folder.
 
-.. _minimal OAuth example application: https://github.com/zalando/connexion/tree/master/examples/swagger2/oauth2
-.. _another OAuth example: https://github.com/zalando/connexion/tree/master/examples/swagger2/oauth2_local_tokeninfo
+.. _minimal OAuth example application: https://github.com/zalando/connexion/tree/main/examples/swagger2/oauth2
+.. _another OAuth example: https://github.com/zalando/connexion/tree/main/examples/swagger2/oauth2_local_tokeninfo
 
 Basic Authentication
 --------------------
@@ -66,7 +66,7 @@ authentication.
 You can find a `minimal Basic Auth example application`_ in Connexion's "examples" folder.
 
 .. _oauth scope: https://oauth.net/2/scope/
-.. _minimal Basic Auth example application: https://github.com/zalando/connexion/tree/master/examples/openapi3/basicauth
+.. _minimal Basic Auth example application: https://github.com/zalando/connexion/tree/main/examples/openapi3/basicauth
 
 ApiKey Authentication
 ---------------------
@@ -138,7 +138,7 @@ parameters to the underlying `werkzeug`_ server.
 .. _rfc6750: https://tools.ietf.org/html/rfc6750
 .. _rfc6749: https://tools.ietf.org/html/rfc6749
 .. _rfc7662: https://tools.ietf.org/html/rfc7662
-.. _minimal API Key example application: https://github.com/zalando/connexion/blob/master/examples/openapi3/apikey
-.. _minimal JWT example application: https://github.com/zalando/connexion/tree/master/examples/openapi3/jwt
+.. _minimal API Key example application: https://github.com/zalando/connexion/blob/main/examples/openapi3/apikey
+.. _minimal JWT example application: https://github.com/zalando/connexion/tree/main/examples/openapi3/jwt
 .. _enabling authentication passthrough in modwsgi: https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIPassAuthorization.html
 .. _modwsgi documentation: https://modwsgi.readthedocs.io/en/develop/index.html


### PR DESCRIPTION
Replace links referring to the ``master`` branch in favor of ``main``

Fixes # .



Changes proposed in this pull request:

 -
 -
 -
