### PR TITLE
#1424: add keywords to the list of pythonic words

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -43,10 +43,7 @@ def snake_and_shadow(name):
     :return:
     """
     snake = inflection.underscore(name)
-    all_reserved = []
-    all_reserved.extend(list(builtins.__dict__.keys()))
-    all_reserved.extend(keyword.kwlist)
-    if snake in all_reserved:
+    if snake in builtins.__dict__ or keyword.iskeyword(snake):
         return f"{snake}_"
     return snake
 

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -3,6 +3,7 @@ This module defines a decorator to convert request parameters to arguments for t
 """
 
 import builtins
+import keyword
 import functools
 import inspect
 import logging
@@ -42,7 +43,10 @@ def snake_and_shadow(name):
     :return:
     """
     snake = inflection.underscore(name)
-    if snake in builtins.__dict__.keys():
+    all_reserved = []
+    all_reserved.extend(list(builtins.__dict__.keys()))
+    all_reserved.extend(keyword.kwlist)
+    if snake in all_reserved:
         return f"{snake}_"
     return snake
 

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -3,9 +3,9 @@ This module defines a decorator to convert request parameters to arguments for t
 """
 
 import builtins
-import keyword
 import functools
 import inspect
+import keyword
 import logging
 import re
 from typing import Any

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -462,7 +462,7 @@ def test_parameters_snake_case(snake_case_app):
     assert resp.status_code == 200
     resp = app_client.post('/v1.0/test-post-query-snake?someId=123', headers=headers, data=json.dumps({"a": "test"}))
     assert resp.status_code == 200
-    resp = app_client.post('/v1.0/test-post-query-shadow?id=123', headers=headers, data=json.dumps({"a": "test"}))
+    resp = app_client.post('/v1.0/test-post-query-shadow?id=123&class=header', headers=headers, data=json.dumps({"a": "test"}))
     assert resp.status_code == 200
     resp = app_client.get('/v1.0/test-get-path-snake/123')
     assert resp.status_code == 200

--- a/tests/fakeapi/snake_case.py
+++ b/tests/fakeapi/snake_case.py
@@ -34,6 +34,6 @@ def post_query_snake(some_id, some_other_id):
     return data
 
 
-def post_query_shadow(id_, next_):
-    data = {'id': id_, 'next': next_}
+def post_query_shadow(id_, class_, next_):
+    data = {'id': id_, 'class': class_, 'next': next_}
     return data

--- a/tests/fixtures/snake_case/openapi.yaml
+++ b/tests/fixtures/snake_case/openapi.yaml
@@ -179,6 +179,12 @@ paths:
           required: true
           schema:
             type: integer
+        - name: class
+          in: query
+          description: class parameter
+          required: true
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/tests/fixtures/snake_case/swagger.yaml
+++ b/tests/fixtures/snake_case/swagger.yaml
@@ -158,6 +158,11 @@ paths:
           description: id parameter
           required: true
           type: integer
+        - name: class
+          in: query
+          description: class parameter
+          required: true
+          type: string
         - name: next
           in: body
           description: next parameter


### PR DESCRIPTION
Fixes #1424 .



Changes proposed in this pull request:

 - Add Python's keywords to the list of reserved words for underscoring.