### PR TITLE
Bump upperbound version for jsonschema to 5.0.0

### DIFF
--- a/connexion/json_schema.py
+++ b/connexion/json_schema.py
@@ -2,10 +2,11 @@
 Module containing all code related to json schema validation.
 """
 
+import typing as t
 from collections.abc import Mapping
 from copy import deepcopy
 
-from jsonschema import Draft4Validator, RefResolver, _utils
+from jsonschema import Draft4Validator, RefResolver
 from jsonschema.exceptions import RefResolutionError, ValidationError  # noqa
 from jsonschema.validators import extend
 from openapi_spec_validator.handlers import UrlHandler
@@ -54,22 +55,16 @@ def resolve_refs(spec, store=None, handlers=None):
     return res
 
 
-def validate_type(validator, types, instance, schema):
-    if instance is None and (schema.get('x-nullable') is True or schema.get('nullable')):
-        return
+def allow_nullable(validation_fn: t.Callable) -> t.Callable:
+    """Extend an existing validation function, so it allows nullable values to be null."""
 
-    types = _utils.ensure_list(types)
+    def nullable_validation_fn(validator, to_validate, instance, schema):
+        if instance is None and (schema.get('x-nullable') is True or schema.get('nullable')):
+            return
 
-    if not any(validator.is_type(instance, type) for type in types):
-        yield ValidationError(_utils.types_msg(instance, types))
+        yield from validation_fn(validator, to_validate, instance, schema)
 
-
-def validate_enum(validator, enums, instance, schema):
-    if instance is None and (schema.get('x-nullable') is True or schema.get('nullable')):
-        return
-
-    if instance not in enums:
-        yield ValidationError(f"{instance!r} is not one of {enums!r}")
+    return nullable_validation_fn
 
 
 def validate_required(validator, required, instance, schema):
@@ -100,14 +95,14 @@ def validate_writeOnly(validator, wo, instance, schema):
 
 
 Draft4RequestValidator = extend(Draft4Validator, {
-                                'type': validate_type,
-                                'enum': validate_enum,
+                                'type': allow_nullable(Draft4Validator.VALIDATORS['type']),
+                                'enum': allow_nullable(Draft4Validator.VALIDATORS['enum']),
                                 'required': validate_required,
                                 'readOnly': validate_readOnly})
 
 Draft4ResponseValidator = extend(Draft4Validator, {
-                                 'type': validate_type,
-                                 'enum': validate_enum,
+                                 'type': allow_nullable(Draft4Validator.VALIDATORS['type']),
+                                 'enum': allow_nullable(Draft4Validator.VALIDATORS['enum']),
                                  'required': validate_required,
                                  'writeOnly': validate_writeOnly,
                                  'x-writeOnly': validate_writeOnly})

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ version = read_version('connexion')
 
 install_requires = [
     'clickclick>=1.2,<21',
-    'jsonschema>=2.5.1,<4',
+    'jsonschema>=2.5.1,<5',
     'PyYAML>=5.1,<6',
     'requests>=2.9.1,<3',
     'inflection>=0.3.1,<0.6',


### PR DESCRIPTION
Fixes #1430

Changes proposed in this pull request:
 - Drop usage of private jsonschema modules to prevent breaking on non-major version changes.
 - Create validate_defaults function by passing in the instance_validator instead of using an attribute on the OpenApiValidator. This is necessary since the attribute is no longer maintained while the validator descends into the spec. I presume due to the usage of `attrs.resolve` by jsonschema.