### PR TITLE
don't rely on  jsonschema._utils in json_schema.py

### DIFF
--- a/connexion/json_schema.py
+++ b/connexion/json_schema.py
@@ -5,7 +5,7 @@ Module containing all code related to json schema validation.
 from collections.abc import Mapping
 from copy import deepcopy
 
-from jsonschema import Draft4Validator, RefResolver, _utils
+from jsonschema import Draft4Validator, RefResolver
 from jsonschema.exceptions import RefResolutionError, ValidationError  # noqa
 from jsonschema.validators import extend
 from openapi_spec_validator.handlers import UrlHandler
@@ -58,10 +58,11 @@ def validate_type(validator, types, instance, schema):
     if instance is None and (schema.get('x-nullable') is True or schema.get('nullable')):
         return
 
-    types = _utils.ensure_list(types)
+    if isinstance(types, str):
+        types = (types,)
 
     if not any(validator.is_type(instance, type) for type in types):
-        yield ValidationError(_utils.types_msg(instance, types))
+        yield ValidationError(f"{instance!r} is not one of {types!r}")
 
 
 def validate_enum(validator, enums, instance, schema):


### PR DESCRIPTION
In the `json_schema.validate_type` function `jsonschemas_utils.types_msg`is used, wich leads to an
`AttributeError` if the instance to check has no valid type.
In general it is not a good idea to rely on other libs utils especially if they start with `_`.
So I also replaced the call of `_utils.ensure_list` with it's adjusted implementation.