### PR TITLE
Use both class docstring and init docstring for autoapi

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ autoapi_options = ['members',
                    'show-module-summary',
                    'special-members',
                    'imported-members']
+autoapi_python_class_content = 'both'
 autoapi_dirs = [
     '../connexion'
 ]


### PR DESCRIPTION
The generated API reference documentation only used the class docstring, this PR changes this such that both the class docstring and the `__init__` docstring are used [1]. For example, the `FlaskApp` and `AbstractApp` only contain documentation in the init methods.

[1] https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html#confval-autoapi_python_class_content

Before: https://connexion.readthedocs.io/en/stable/autoapi/connexion/apps/flask_app/index.html#connexion.apps.flask_app.FlaskApp
After: https://connexion--1451.org.readthedocs.build/en/1451/autoapi/connexion/apps/flask_app/index.html#connexion.apps.flask_app.FlaskApp